### PR TITLE
Bug/vulnerabilities

### DIFF
--- a/solr-commons/pom.xml
+++ b/solr-commons/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <artifactId>solr-solrj</artifactId>
             <groupId>org.apache.solr</groupId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jsp-api</artifactId>
@@ -130,7 +130,7 @@
         <dependency>
                <artifactId>solr-solrj</artifactId>
                <groupId>org.apache.solr</groupId>
-               <version>4.5.0</version>
+               <version>4.6.0</version>
                <type>jar</type>
                <scope>compile</scope>
         </dependency>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -125,6 +125,10 @@
                     <artifactId>jsp-api</artifactId>
                     <groupId>javax.servlet.jsp</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -129,6 +129,14 @@
                     <groupId>commons-fileupload</groupId>
                     <artifactId>commons-fileupload</artifactId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>org.restlet</artifactId>
+                    <groupId>org.restlet.jee</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.restlet.ext.servlet</artifactId>
+                    <groupId>org.restlet.jee</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jsp-api</artifactId>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.2.1</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>jdom</groupId>
@@ -146,13 +146,13 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
         </dependency>
         <!-- Solr dependencies for indexing and searching -->
         <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
-            <version>4.5.0</version>
+            <version>4.6.0</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jsp-api</artifactId>
@@ -171,7 +171,7 @@
                 <dependency>
                <artifactId>solr-solrj</artifactId>
                <groupId>org.apache.solr</groupId>
-               <version>4.5.0</version>
+               <version>4.6.0</version>
                <type>jar</type>
                <scope>compile</scope>
         </dependency>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -159,6 +159,14 @@
                     <groupId>javax.servlet.jsp</groupId>
                 </exclusion>
                 <exclusion>
+                    <artifactId>org.restlet</artifactId>
+                    <groupId>org.restlet.jee</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>org.restlet.ext.servlet</artifactId>
+                    <groupId>org.restlet.jee</groupId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.lucene</groupId>
                     <artifactId>lucene-core</artifactId>
                 </exclusion>


### PR DESCRIPTION
Thanks for @mprins for reporting! Fixed a couple of vulnerabilities. 

Batik and Oracle could not be updated/removed: Batik is used in FOP, which does not have a newer version of the dependency. And oracle is oracle.
