### PR TITLE
Feat/search dynamic searchentries

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Search.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search.js
@@ -493,20 +493,20 @@ Ext.define ("viewer.components.Search",{
         this.viewerController.mapComponent.getMap().removeMarker("searchmarker");
         this.form.getChildByElement("removePin"+ this.name).setVisible(false);
     },
-    handleSearchResult : function(config){
+    handleSearchResult : function(result){
 
-        config.x = (config.location.maxx + config.location.minx) / 2;
-        config.y = (config.location.maxy + config.location.miny) / 2;
-        this.viewerController.mapComponent.getMap().zoomToExtent(config.location);
+        result.x = (result.location.maxx + result.location.minx) / 2;
+        result.y = (result.location.maxy + result.location.miny) / 2;
+        this.viewerController.mapComponent.getMap().zoomToExtent(result.location);
         this.viewerController.mapComponent.getMap().removeMarker("searchmarker");
-        this.viewerController.mapComponent.getMap().setMarker("searchmarker",config.x,config.y,"marker");
+        this.viewerController.mapComponent.getMap().setMarker("searchmarker",result.x,result.y,"marker");
         
-        var type = this.getCurrentSearchType();
+        var type = this.getCurrentSearchType(result);
         if(type === "solr"){
             
             var searchconfig = this.getCurrentSearchconfig();
             if(searchconfig ){
-                var solrConfig = searchconfig.solrConfig[config.searchConfig];
+                var solrConfig = searchconfig.solrConfig[result.searchConfig];
                 var switchOnLayers = solrConfig.switchOnLayers;
                 if(switchOnLayers){
                     var selectedContentChanged = false;
@@ -576,9 +576,11 @@ Ext.define ("viewer.components.Search",{
             this.searchConfigChanged(this.searchconfigs[0].id);
         }
     },
-    getCurrentSearchType: function() {
+    getCurrentSearchType: function(clickedResult) {
         var config = this.getCurrentSearchconfig();
-        if (config) {
+        if(clickedResult && clickedResult.searchType){
+            return clickedResult.searchType;
+        }else if (config) {
             return config.type;
         } else {
             return null;

--- a/viewer/src/main/webapp/viewer-html/components/Search.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search.js
@@ -332,15 +332,18 @@ Ext.define ("viewer.components.Search",{
         this.searchResult = new Array();
         for(var i = 0 ; i < this.dynamicSearchEntries.length; i++){
             var entry = this.dynamicSearchEntries[i];
-            var result = entry.callback(searchText, this.searchRequestId);
-            if(result.success){
-                var results = result.results;
+            var returnValue = entry.callback(searchText, this.searchRequestId);
+            if(returnValue.success){
+                var results = returnValue.results;
                 for(var j = 0 ; j < results.length ; j++){
-                    results[j].searchType = "Dynamic";
-                    this.searchResult.push(results[j]);
+                    var result = results[j];
+                    if(result){
+                        result.searchType = "Dynamic";
+                        this.searchResult.push(result);
+                    }
                 }
             }else{
-                this.viewerController.logger.warning("Search component yielded error: " + result.errorMessage);
+                this.viewerController.logger.warning("Search component yielded error: " + returnValue.errorMessage);
             }
         }
         if (this.getCurrentSearchType() === "simplelist") {


### PR DESCRIPTION
With this PR, we implement the feature which enables other component to implement their own way of searching (possibly through their own dataset).
For this to work, a component has to register itself to the search component and provide a callback (in which the searching is done). How a component can register itself, and how the reply should look like can be found in the gist:
https://gist.github.com/mtoonen/491fadaf0efb5318a4d5
