### PR TITLE
Bug/223 batchwise indexing solr

### DIFF
--- a/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
+++ b/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
@@ -25,6 +25,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.persistence.EntityManager;
 import nl.b3p.viewer.config.services.AttributeDescriptor;
 import nl.b3p.viewer.config.services.SimpleFeatureType;
@@ -56,6 +58,7 @@ public class SolrUpdateJob implements Job {
     private static final Log log = LogFactory.getLog(SolrUpdateJob.class);
     private SolrServer server;
     public static int MAX_FEATURES = 5000;
+    public static int BATCH_SIZE = 50;
 
     @Override
     public void execute(JobExecutionContext jec) throws JobExecutionException {
@@ -124,30 +127,62 @@ public class SolrUpdateJob implements Job {
             status.setCurrentAction("Features ophalen");
 
             status.setProgress(10);
+            
+            List<AttributeDescriptor> indexAttributesConfig = config.getIndexAttributes();
+            List<AttributeDescriptor> resultAttributesConfig = config.getResultAttributes();
+            
             SimpleFeatureType sft = config.getSimpleFeatureType();
             fs = sft.openGeoToolsFeatureSource();
 
             Query q = new Query();
-            if (sft.getFeatureSource() instanceof WFSFeatureSource) {
-                q.setMaxFeatures(MAX_FEATURES);
-            }
-            
             if(filter != null){
                 q.setFilter(filter);
             }
             
-            FeatureCollection fc = fs.getFeatures(q);
-            List<AttributeDescriptor> indexAttributesConfig = config.getIndexAttributes();
-            List<AttributeDescriptor> resultAttributesConfig = config.getResultAttributes();
+            if (sft.getFeatureSource() instanceof WFSFeatureSource) {
+                q.setMaxFeatures(MAX_FEATURES);
+                FeatureCollection fc = fs.getFeatures(q);
+                FeatureIterator<SimpleFeature> iterator = fc.features();
+                processFeatures(iterator, indexAttributesConfig, resultAttributesConfig, config.getId(),solrServer, status);
+            }else{
+                
+                FeatureCollection fc = fs.getFeatures(q);
+                int total = fc.size();
+                int numIterations = (int)Math.ceil((double)total/BATCH_SIZE);
+                for (int i = 0; i < numIterations; i++) {
+                    int start = i * BATCH_SIZE;
+                    q.setStartIndex(start);
+                    int max = Math.min(total,i* BATCH_SIZE + BATCH_SIZE);
+                    q.setMaxFeatures(max);
+                    
+                    fc = fs.getFeatures(q);
+                    processFeatures(fc.features(), indexAttributesConfig, resultAttributesConfig, config.getId(),solrServer, status);
+                }
+            }
+            
+            Date now = new Date();
+            config.setLastUpdated(now);
+            em.persist(config);
+            status.setProgress(100);
+            status.setFinished(true);
+        } catch (Exception ex) {
+            log.error("Cannot add configuration to index", ex);
+            status.setCurrentAction("Mislukt.");
+        } finally {
+            if (fs != null && fs.getDataStore() != null) {
+                fs.getDataStore().dispose();
+            }
+        }
+    }
+    
 
+    private static void processFeatures( FeatureIterator<SimpleFeature> iterator,List<AttributeDescriptor> indexAttributesConfig,
+            List<AttributeDescriptor> resultAttributesConfig, Long id, SolrServer solrServer, WaitPageStatus status ) {
+        try {
+            
             List<SolrInputDocument> docs = new ArrayList();
-
-            FeatureIterator<SimpleFeature> iterator = fc.features();
-            double size = fc.size();
-            double percentagesForAdding = 50;
-            double intervalPerDoc = percentagesForAdding / size;
-            Double total = (double) status.getProgress();
             try {
+                
                 while (iterator.hasNext()) {
                     SimpleFeature feature = iterator.next();
                     SolrInputDocument doc = new SolrInputDocument();
@@ -159,11 +194,11 @@ public class SolrUpdateJob implements Job {
                         if (col != null) {
                             doc.addField("columns", attributeName);
                             doc.addField(field, col);
-                        }else{
+                        } else {
                             hasAllRequiredFields = false;
                         }
                     }
-                    if(!hasAllRequiredFields){
+                    if (!hasAllRequiredFields) {
                         continue;
                     }
                     for (AttributeDescriptor attributeDescriptor : resultAttributesConfig) {
@@ -179,56 +214,31 @@ public class SolrUpdateJob implements Job {
                     Geometry g = (Geometry) obj;
                     if (g != null) {
                         Envelope env = featureToEnvelope(g);
-
+                        
                         doc.addField("minx", env.getMinX());
                         doc.addField("miny", env.getMinY());
                         doc.addField("maxx", env.getMaxX());
                         doc.addField("maxy", env.getMaxY());
                     }
-
+                    
                     doc.addField("id", feature.getID());
-                    doc.addField("searchConfig", config.getId());
+                    doc.addField("searchConfig", id);
                     docs.add(doc);
-                    total += intervalPerDoc;
-                    status.setProgress(total.intValue());
+                 //   total += intervalPerDoc;
+                   // status.setProgress(total.intValue());
                 }
             } finally {
                 iterator.close();
             }
-            status.setProgress(60);
-            status.setCurrentAction("Features toevoegen aan solr index");
 
-            if(docs.size() > MAX_FEATURES){
-                double percentagesForCommitting = 30;
-                int numIterations = (int)Math.ceil(size/ MAX_FEATURES);
-                double percentagePerIteration = percentagesForCommitting / numIterations;
-                total = (double) status.getProgress();
-                for (int i = 0; i < numIterations; i++) {
-                    int begin = i * MAX_FEATURES;
-                    int end = Math.min((i+1) * MAX_FEATURES, docs.size());
-                    List<SolrInputDocument> sublist = docs.subList(begin, end);
-                    
-                    solrServer.add(sublist);
-                    solrServer.commit();
-                    total += percentagePerIteration;
-                    status.setProgress(total.intValue());
-                }
-            }else{
-                solrServer.add(docs);
-                solrServer.commit();
-            }
-            Date now = new Date();
-            config.setLastUpdated(now);
-            em.persist(config);
-            status.setProgress(100);
-            status.setFinished(true);
-        } catch (Exception ex) {
+            status.setCurrentAction("Features toevoegen aan solr index");
+            
+            solrServer.add(docs);
+            solrServer.commit();
+        }   catch (SolrServerException ex) {
             log.error("Cannot add configuration to index", ex);
-            status.setCurrentAction("Mislukt.");
-        } finally {
-            if (fs != null && fs.getDataStore() != null) {
-                fs.getDataStore().dispose();
-            }
+        } catch (IOException ex) {
+            log.error("Cannot add configuration to index", ex);
         }
     }
 

--- a/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
+++ b/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
@@ -25,8 +25,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.persistence.EntityManager;
 import nl.b3p.viewer.config.services.AttributeDescriptor;
 import nl.b3p.viewer.config.services.SimpleFeatureType;

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editsolrsource.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editsolrsource.jsp
@@ -96,10 +96,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </c:when>
                 <c:otherwise>
                     <script type="text/javascript">
-                    var frameParent = getParent();
-                    if(frameParent && frameParent.reloadGrid) {
-                        frameParent.reloadGrid();
-                    }
+                    Ext.onReady(function() {
+                        var frameParent = getParent();
+
+                        if(frameParent && frameParent.reloadGrid) {
+                            frameParent.reloadGrid();
+                        }
+                    });
                     </script>
                     <stripes:submit name="newSearchConfig" value="Nieuwe zoekbron"/>
 


### PR DESCRIPTION
Fixes #223 
With this change, when indexing documents, it is done by batches: both loading the documents from its source, as the sending of it to solr.
Prevents an out of memory when indexing large datasets.
