### PR TITLE
Search: Clickable autosuggest

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/search/SolrSearchClient.java
+++ b/viewer/src/main/java/nl/b3p/viewer/search/SolrSearchClient.java
@@ -22,11 +22,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.persistence.EntityManager;
 import nl.b3p.viewer.config.services.SolrConf;
 import nl.b3p.viewer.solr.SolrInitializer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -43,6 +43,7 @@ import org.stripesstuff.stripersist.Stripersist;
  * @author Meine Toonen
  */
 public class SolrSearchClient extends SearchClient {
+    private static final Log log = LogFactory.getLog(SolrSearchClient.class);  
 
     private JSONObject config;
     private List<Long> visibleLayers;
@@ -84,9 +85,9 @@ public class SolrSearchClient extends SearchClient {
            
 
         } catch (SolrServerException ex) {
-            Logger.getLogger(SolrSearchClient.class.getName()).log(Level.SEVERE, null, ex);
+            log.error(ex);
         } catch (JSONException ex) {
-            Logger.getLogger(SolrSearchClient.class.getName()).log(Level.SEVERE, null, ex);
+            log.error(ex);
         } 
         
         return result;
@@ -116,7 +117,7 @@ public class SolrSearchClient extends SearchClient {
             SolrDocumentList list = rsp.getResults();
 
             for (SolrDocument solrDocument : list) {
-                JSONObject doc = solrDocumentToAutosuggest(solrDocument);
+                JSONObject doc = solrDocumentToResult(solrDocument);
                 if(doc != null){
                     respDocs.put(doc);
                 }
@@ -124,7 +125,7 @@ public class SolrSearchClient extends SearchClient {
             response.put("docs", respDocs);
             return respDocs;
         } catch (SolrServerException ex) {
-            Logger.getLogger(SolrSearchClient.class.getName()).log(Level.SEVERE, null, ex);
+            log.error(ex);
         }
         return respDocs;
     }
@@ -168,33 +169,6 @@ public class SolrSearchClient extends SearchClient {
       
     }
     
-    
-    private JSONObject solrDocumentToAutosuggest(SolrDocument doc){
-        JSONObject result = null;
-        try {
-            Collection<Object> resultValues = doc.getFieldValues("values");
-            if (resultValues != null) {
-                result = new JSONObject();
-                String resultLabel = "";
-                List<String> labels = new ArrayList(resultValues);
-                for (String label : labels) {
-                    if (!resultLabel.isEmpty()) {
-                        resultLabel += ", ";
-                    }
-                    resultLabel += label;
-                }
-                result.put("label", resultLabel);
-              
-                result.put("searchConfig", doc.getFieldValue("searchConfig"));
-                String naam = getConfigurationNaam((Integer)doc.getFieldValue("searchConfig"));
-                result.put("type", naam);
-            }
-        } catch (JSONException ex) {
-            Logger.getLogger(SolrSearchClient.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        return result;
-    }
-    
     private JSONObject solrDocumentToResult(SolrDocument doc){
         JSONObject result = null;
         try {
@@ -222,7 +196,7 @@ public class SolrSearchClient extends SearchClient {
                 result.put("type", naam);
             }
         } catch (JSONException ex) {
-            Logger.getLogger(SolrSearchClient.class.getName()).log(Level.SEVERE, null, ex);
+            log.error(ex);
         }
         return result;
     }

--- a/viewer/src/main/webapp/viewer-html/components/Search.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search.js
@@ -205,18 +205,18 @@ Ext.define ("viewer.components.Search",{
                     listConfig:{
                         listeners:{
                             itemclick:function(list, node){
-                                var data = node.data !== undefined ? node.data : node.raw;
-                                var label = data.label;
-                                me.searchField.setValue(label);
-                                me.search();
+                                this.searchHighlightedSuggestion(node);
                             },
-                        scope:me
+                            scope:me
                         }
                     },
                     listeners: {
                         specialkey: function(field, e){
                             if (e.getKey() === e.ENTER) {
-                                me.search();
+                                var item = field.picker.pickerField.listKeyNav.boundList.highlightedItem;
+                                if(!item){
+                                    me.search();
+                                }
                             }
                         },
                         beforeQuery : function(request){
@@ -235,12 +235,13 @@ Ext.define ("viewer.components.Search",{
                     store:this.autosuggestStore
                 });
                 Ext.view.BoundListKeyNav.override({
-                    selectHighlighted: function(e) {
+                    selectHighlighted: function() {
                         var item = this.boundList.highlightedItem;
-                        if (item) {
-                            this.callOverridden(e); // If an item is selected, the user did that. So use that for searching. Otherwise search with the user typed string
+                        //If an item is selected, the user did that. So go directly to that result. Otherwise search with the user typed string
+                        if (item) { 
+                            var node = this.boundList.getRecord(item);
+                            me.searchHighlightedSuggestion(node);
                         }
-                        me.search();
                     }
                 });
                 
@@ -300,6 +301,11 @@ Ext.define ("viewer.components.Search",{
             
         });
         return itemList;
+    },
+    searchHighlightedSuggestion: function(node){
+        var data = node.raw !== undefined ? node.raw : node.data;
+        this.searchField.setValue(data.label);
+        this.handleSearchResult(data);
     },
     hideWindow : function(){
         this.searchField.collapse();


### PR DESCRIPTION
Made the SolrSearchClient return full-fletched results for autosuggesting, to enable the user to directly go to the autosuggested result. The front end now also supports clicking/pressing enter on the dropdown list with autosuggest results.
