### PR TITLE
leeg de build cache als appveyor.yml of pom.xml is aangepast

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ install:
   - mvn install -U -Dmaven.test.skip=true -B -V -fae -q -T2 
   
 cache:
-  - C:\bin\apache-maven-%MVN_VERSION%
-  - C:\Users\appveyor\.m2\repository
+  - C:\bin\apache-maven-3.2.5 -> appveyor.yml
+  - C:\Users\appveyor\.m2\repository -> pom.xml
 
 build: off
 


### PR DESCRIPTION
- leeg de appveyor maven repository als pom.xml is aangepast, onderaan http://www.appveyor.com/docs/build-cache staat iets over conditioneel legen van de cache
- Het lijkt erop dat de env var %MVN_VERSION% niet (meer) bestaat als de cache wordt gebouwd

er is een [api call voor legen van de cache](http://www.appveyor.com/docs/api/projects-builds#delete-project-build-cache), maar dat lijkt me gedoe...
