### PR TITLE
Feat/keep mashups when publishing

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
@@ -55,6 +55,9 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
     private String owner;
     @Validate
     private boolean authenticatedRequired;
+
+    @Validate
+    private boolean mashupMustPointToPublishedVersion = false;
     
     @Validate
     private String mashupName;
@@ -143,7 +146,14 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
     public void setMashupName(String mashupName) {
         this.mashupName = mashupName;
     }
-    
+
+    public boolean isMashupMustPointToPublishedVersion() {
+        return mashupMustPointToPublishedVersion;
+    }
+
+    public void setMashupMustPointToPublishedVersion(boolean mashupMustPointToPublishedVersion) {
+        this.mashupMustPointToPublishedVersion = mashupMustPointToPublishedVersion;
+    }
     //</editor-fold>
     
     @DefaultHandler
@@ -395,7 +405,6 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
             String uniqueVersion = findUniqueVersion(name, "B_"+now );
             oldPublished.setVersion(uniqueVersion);
             em.persist(oldPublished);
-            boolean mashupMustPointToPublishedVersion = true;
             if(mashupMustPointToPublishedVersion){
                 List<Application> mashups = em.createQuery(
                     "from Application where root = :level and id <> :oldId")

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
@@ -403,6 +403,7 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
                 for (Application mashup : mashups) {
                     mashup.setRoot(application.getRoot());//nog iets doen met veranderde layerids uit cofniguratie
                     SelectedContentCache.setApplicationCacheDirty(mashup,true, false);
+                    mashup.transferMashup(oldPublished);
                     em.persist(mashup);
                 }
             }

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/application/applicationSettings.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/application/applicationSettings.jsp
@@ -131,7 +131,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             <input type="button" class="extlikebutton" value="Maak mashup" onclick="return confirmMashup();"/>
                         </div>
                         <div style="float: left;">
-                            <stripes:submit name="publish" value="Publiceren"/>
+                            <input type="button" class="extlikebutton" value="Publiceren" onclick="return confirmPublish();"/>
                             <stripes:submit name="save" value="Opslaan"/>
                             <stripes:submit name="cancel" value="Annuleren"/>
                             <input type="hidden" name="copy" value="1" disabled="true"/>
@@ -190,7 +190,21 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 });  
             }
             
-            
+            function confirmPublish() {
+                Ext.MessageBox.show({
+                    title: 'Neem mashups over van huidige gepubliceerde',
+                    msg: 'Als de huidige gepubliceerde versie mashups bevat, moeten de mashups dan wijzen naar de nieuwe gepubliceerde versie?',
+                    buttons: Ext.MessageBox.YESNOCANCEL,
+                    fn: function(btn, text){
+                        if(btn === 'yes' || btn === 'no'){
+                            var mashupMustPointToPublishedVersion = btn === 'yes';
+                            var frm = document.forms[0];
+                            frm.action = "?publish=t&mashupMustPointToPublishedVersion=" + mashupMustPointToPublishedVersion;
+                            frm.submit();
+                        }
+                    }
+                });
+            }
 
             Ext.onReady(function() {
                 Ext.tip.QuickTipManager.init();


### PR DESCRIPTION
The user is now able to choose whether or not the mashups of a previously published application should become the mashup of a newly published application.
