### PR TITLE
make the TOC follow up on ON_LAYER_VISIBILITY_CHANGED

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/TOC.js
+++ b/viewer/src/main/webapp/viewer-html/components/TOC.js
@@ -635,7 +635,9 @@ Ext.define ("viewer.components.TOC",{
         var layer = object.layer;
         var vis = object.visible;
         var nodeId = "layer-" + layer.appLayerId;
-        var node = this.panel.getRootNode().findChild("nodeId",nodeId,true);
+        var node = this.panel.getRootNode().findChildBy(function(node){
+            return (node.data.layerObj.nodeId === nodeId);
+        }, this, true);
         if (node){
             if (this.config.layersChecked || (node.hasChildNodes() && this.config.groupCheck)){
                  node.set('checked', vis);


### PR DESCRIPTION
Make the TOC follow up the ON_LAYER_VISIBILITY_CHANGED event again regarding checkboxes. 
Programmatic ON_LAYER_VISIBILITY_CHANGED events fired through other controls like LayerSwitcher and Snapping were not reflected in the state of the checkboxes of the TOC control.
