### PR TITLE
remove extra (3rd party) path from component.registry in context.xml

### DIFF
--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Context antiJARLocking="true" disableURLRewriting="true" path="/viewer">
-  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components,/opt/flamingo_data/flamingo_3rdparty/ro-tercera-component"/>
+  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components"/>
   <!-- For Tomcat: define datasource in server.xml, for example:
 
     <Server ...>


### PR DESCRIPTION
pretty sure this path `/opt/flamingo_data/flamingo_3rdparty/ro-tercera-component` only exists in very few installations and was inadvertently introduced in 993b994c248c06bf624d83991745a971b8bc2f40
