### PR TITLE
Prevent geometry editing by specified user groups on layers with editable geometry

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayerActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayerActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2015 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,6 +56,8 @@ public class LayerActionBean implements ActionBean {
     @Validate
     private List<String> groupsWrite = new ArrayList<String>();
     @Validate
+    private List<String> groupsPreventGeomEdit = new ArrayList<String>();
+    @Validate
     private Map<String, String> details = new HashMap<String, String>();
     @Validate
     private SimpleFeatureType simpleFeatureType;
@@ -110,6 +112,14 @@ public class LayerActionBean implements ActionBean {
 
     public void setGroupsWrite(List<String> groupsWrite) {
         this.groupsWrite = groupsWrite;
+    }
+
+    public List<String> getGroupsPreventGeomEdit() {
+        return groupsPreventGeomEdit;
+    }
+
+    public void setGroupsPreventGeomEdit(List<String> groupsPreventGeomEdit) {
+        this.groupsPreventGeomEdit = groupsPreventGeomEdit;
     }
 
     public SortedSet<String> getApplicationsUsedIn() {
@@ -170,6 +180,7 @@ public class LayerActionBean implements ActionBean {
 
             groupsRead.addAll(layer.getReaders());
             groupsWrite.addAll(layer.getWriters());
+            groupsPreventGeomEdit.addAll(layer.getPreventGeomEditors());
 
             if (layer.getFeatureType() != null) {
                 simpleFeatureType = layer.getFeatureType();
@@ -238,6 +249,11 @@ public class LayerActionBean implements ActionBean {
         layer.getWriters().clear();
         for (String groupName : groupsWrite) {
             layer.getWriters().add(groupName);
+        }
+
+        layer.getPreventGeomEditors().clear();
+        for (String groupName : groupsPreventGeomEdit) {
+            layer.getPreventGeomEditors().add(groupName);
         }
 
         layer.setFeatureType(simpleFeatureType);

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/layer.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/layer.jsp
@@ -1,5 +1,5 @@
 <%--
-Copyright (C) 2011-2013 B3Partners B.V.
+Copyright (C) 2011-2015 B3Partners B.V.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -94,14 +94,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     </tr>
                     <tr>
                         <td valign="top">
-                            <h1>Groepen:</h1>
-                            L &nbsp; B <br>
-
-                            <c:forEach var="group" items="${actionBean.allGroups}">
-                                <stripes:checkbox name="groupsRead" value="${group.name}"/>
-                                <stripes:checkbox name="groupsWrite" value="${group.name}"/> ${group.name}<br />
-                            </c:forEach>
-
+                            <h1>Groepen:</h1>                           
+                            <table summary="Groepen">
+                                <thead>
+                                    <tr>
+                                        <th scope="col" title="Lezen">L</th>
+                                        <th scope="col" title="Bewerken">B</th>
+                                        <th scope="col" title="Geometrie NIET Bewerken">G!B</th>
+                                        <th scope="col" style="text-align:left">groep</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <c:forEach var="group" items="${actionBean.allGroups}">     
+                                        <tr>
+                                            <td><stripes:checkbox name="groupsRead" value="${group.name}"/></td>
+                                            <td><stripes:checkbox name="groupsWrite" value="${group.name}"/></td>
+                                            <td><stripes:checkbox name="groupsPreventGeomEdit" value="${group.name}"/></td>
+                                            <th scope="row" style="text-align:left">${group.name}</th>
+                                        </tr>
+                                    </c:forEach>
+                                </tbody>
+                            </table>
                         </td>
                     </tr>
                     <c:if test="${not empty actionBean.applicationsUsedIn}">

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
@@ -294,7 +294,30 @@ public class Authorizations {
             throw new Exception(unauthMsg(request,true) + " layer #" + l.getId());
         }
     }
-    
+
+    /**
+     * See if a user can edit geometry attribute of a layer in addition to
+     * regular writing. Calling this will also call
+     * {@link #isLayerWriteAuthorized(nl.b3p.viewer.config.services.Layer, javax.servlet.http.HttpServletRequest)}
+     *
+     * @param l
+     * @param request
+     * @return {@code true} if the user is allowed to edit the geometry
+     * attribute of the layer (the user is not in any of the groups that prevent
+     * editing geometry).
+     */
+    public static boolean isLayerGeomWriteAuthorized(Layer l, HttpServletRequest request) {
+        if (isLayerWriteAuthorized(l, request)) {
+            Set<String> preventEditGeomGroup = l.getPreventGeomEditors();
+            for (String group : preventEditGeomGroup) {
+                if (request.isUserInRole(group)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     private static final String REQUEST_APP_CACHE = Authorizations.class.getName() + ".REQUEST_APP_CACHE";
     
     public static ApplicationCache getApplicationCacheFromRequest(Application app, HttpServletRequest request) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/Layer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/Layer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2015 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,6 +16,7 @@
  */
 package nl.b3p.viewer.config.services;
 
+import java.io.Serializable;
 import java.util.*;
 import javax.persistence.*;
 import nl.b3p.viewer.config.ClobElement;
@@ -36,7 +37,7 @@ import org.stripesstuff.stripersist.Stripersist;
  */
 @Entity
 @org.hibernate.annotations.Entity(dynamicUpdate = true)
-public class Layer implements Cloneable {
+public class Layer implements Cloneable, Serializable {
     private static final Log log = LogFactory.getLog(Layer.class);
 
     public static final String EXTRA_KEY_METADATA_URL = "metadata.url";
@@ -133,6 +134,10 @@ public class Layer implements Cloneable {
     @ElementCollection
     @Column(name="role_name")
     private Set<String> writers = new HashSet<String>();
+
+    @ElementCollection
+    @Column(name = "role_name")
+    private Set<String> preventGeomEditors = new HashSet<String>();
 
     @ManyToMany(cascade=CascadeType.PERSIST) // Actually @OneToMany, workaround for HHH-1268
     @JoinTable(inverseJoinColumns=@JoinColumn(name="child", unique=true))
@@ -554,6 +559,14 @@ public class Layer implements Cloneable {
 
     public void setWriters(Set<String> writers) {
         this.writers = writers;
+    }
+
+    public Set<String> getPreventGeomEditors() {
+        return preventGeomEditors;
+    }
+
+    public void setPreventGeomEditors(Set<String> preventGeomEditors) {
+        this.preventGeomEditors = preventGeomEditors;
     }
 
     public List<Layer> getChildren() {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -94,6 +94,8 @@ public class DatabaseSynchronizer implements Servlet {
         updates.put("6", Collections.singletonList("alter_layer_children_child_unique.sql"));
 
         updates.put("7", Collections.singletonList("add_application_to_bookmark.sql"));
+
+        updates.put("8", Collections.singletonList("add_layer_prevent_geom_editors.sql"));
     }
     /**
      * Function is called in init() of servlet.

--- a/viewer-config-persistence/src/main/resources/scripts/oracle-add_layer_prevent_geom_editors.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/oracle-add_layer_prevent_geom_editors.sql
@@ -1,0 +1,9 @@
+create table layer_prevent_geom_editors (
+    layer number(19,0) not null,
+    role_name varchar2(255 char)
+);
+
+alter table layer_prevent_geom_editors
+    add constraint FKF2CC57D82AB24981
+    foreign key (layer)
+    references layer;

--- a/viewer-config-persistence/src/main/resources/scripts/postgresql-add_layer_prevent_geom_editors.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/postgresql-add_layer_prevent_geom_editors.sql
@@ -1,0 +1,9 @@
+create table layer_prevent_geom_editors (
+    layer int8 not null,
+    role_name varchar(255)
+);
+
+alter table layer_prevent_geom_editors
+    add constraint FKF2CC57D82AB24981
+    foreign key (layer)
+    references layer;

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/EditFeatureActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/EditFeatureActionBean.java
@@ -211,6 +211,10 @@ public class EditFeatureActionBean  implements ActionBean {
                     error = "Layer not found";
                     break;
                 }
+                if (!Authorizations.isLayerGeomWriteAuthorized(layer, context.getRequest())) {
+                    error = "U heeft geen rechten om de geometrie van deze kaartlaag te bewerken";
+                    break;
+                }
 
                 if(layer.getFeatureType() == null) {
                     error ="No feature type";

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/MergeFeaturesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/MergeFeaturesActionBean.java
@@ -111,7 +111,7 @@ public class MergeFeaturesActionBean implements ActionBean {
     @Before(stages = LifecycleStage.EventHandling)
     public void checkAuthorization() {
         if (application == null || appLayer == null
-                || !Authorizations.isAppLayerWriteAuthorized(application, appLayer, context.getRequest())) {
+                || !Authorizations.isLayerGeomWriteAuthorized(layer, context.getRequest())) {
             unauthorized = true;
         }
     }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
@@ -115,7 +115,7 @@ public class SplitFeatureActionBean implements ActionBean {
     @Before(stages = LifecycleStage.EventHandling)
     public void checkAuthorization() {
         if (application == null || appLayer == null
-                || !Authorizations.isAppLayerWriteAuthorized(application, appLayer, context.getRequest())) {
+                || !Authorizations.isLayerGeomWriteAuthorized(layer, context.getRequest())) {
             unauthorized = true;
         }
     }

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -441,6 +441,7 @@ Ext.define("viewer.components.Edit", {
                         });
                     }
                     this.inputContainer.add(input);
+                    Ext.getCmp(this.name + "editButton").setDisabled(false);
                 }
             }
         } else {
@@ -575,8 +576,9 @@ Ext.define("viewer.components.Edit", {
         });
     },
     remove: function () {
-        if (!this.config.allowDelete) {
+        if (!this.config.allowDelete || !this.geometryEditable) {
             Ext.Msg.alert('Mislukt', "Verwijderen is niet toegestaan.");
+            return;
         }
 
         var feature = this.inputContainer.getValues();
@@ -803,6 +805,13 @@ Ext.define("viewer.components.Edit", {
         var map = {};
         var index = 0;
         for (var i = 0; i < attributes.length; i++) {
+            if (attributes[i].name === appLayer.geometryAttribute) {
+                // if the editing of the geometry attribute is disabled at
+                // the layer level skip a level in the conversion map
+                if (!this.geometryEditable) {
+                    index++;
+                }
+            }
             if (attributes[i].editable) {
                 map["c" + index] = attributes[i].name;
                 index++;


### PR DESCRIPTION
This makes it possible to have an editable layer that can be fully editable for one or more groups and have one or more groups that cannot edit the geometry attribute (but can edit the other editable attributes) of the layer.

Not being able to edit the geometry also prevents deleting, splitting or merging the feature.
