### PR TITLE
Add extension points for handling extraData (eg. workflow) to Split and Merge

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Merge.js
+++ b/viewer/src/main/webapp/viewer-html/components/Merge.js
@@ -147,6 +147,15 @@ Ext.define("viewer.components.Merge", {
         this.resetForm();
         this.popup.hide();
     },
+    /**
+     * Can be overridden to add some extra data before sending the split
+     * request to the server. The extradata is handled by a custom split backend.
+     * @return {String} a string with extra data
+     */
+    getExtraData: function () {
+        //eg. return "workflow_status=nieuw";
+        return null;
+    },
     save: function () {
         var options = {
             fidA: this.fidA,
@@ -156,6 +165,10 @@ Ext.define("viewer.components.Merge", {
             appLayer: this.layerSelector.getSelectedAppLayer().id,
             application: this.config.viewerController.app.id
         };
+        var extraData = this.getExtraData();
+        if (extraData !== null) {
+            options.extraData = extraData;
+        }
         this.merge(options, this.saveSucces, this.failed);
     },
     merge: function (options, successFunction, failureFunction) {

--- a/viewer/src/main/webapp/viewer-html/components/Split.js
+++ b/viewer/src/main/webapp/viewer-html/components/Split.js
@@ -511,6 +511,10 @@ Ext.define("viewer.components.Split", {
             appLayer: this.layerSelector.getSelectedAppLayer().id,
             application: this.config.viewerController.app.id
         };
+        var extraData = this.getExtraData();
+        if (extraData !== null) {
+            options.extraData = extraData;
+        }
         this.split(options, this.saveSucces, this.saveFailed);
 
     },
@@ -564,12 +568,13 @@ Ext.define("viewer.components.Split", {
         Ext.get(this.getContentDiv()).unmask();
     },
     /**
-     * Can be overridden to add some extra feature attributes before saving the
-     * feature.
-     * @return the changed feature
+     * Can be overridden to add some extra data before sending the split 
+     * request to the server. The extradata is handled by a custom split backend.
+     * @return {String} a string with extra data
      */
-    changeFeatureBeforeSave: function (feature) {
-        return feature;
+    getExtraData: function () {
+        //eg. return "workflow_status=nieuw";
+        return null;
     },
     /**
      * Can be overridden to disable editing in the component/js


### PR DESCRIPTION
Implementers would need to extend and override the `getExtraData()` function in the control and the  `handleExtraData(List<SimpleFeature> features)` method in the ActionBeans to handle a String parameter `extraData`. 

Some example code, for the control:

``` javascript
/**
 * add a workflow_status to be sent to the backend
 * @override
 */
getExtraData: function () {
    return 'workflow_status=' + this.status.getId();
}
```

and for the ActionBean:

``` java
/**
 * force the workflow status attribute on the feature. This will handle the
 * case where the {@code extraData} attribute is a key/value pair with the
 * workflow, eg {@code workflow_status=status}.
 *
 * @param features A list of features to be modified
 * @return the list of modified features that are about to be committed to the datastore
 */
@Override
protected List<SimpleFeature> handleExtraData(List<SimpleFeature> features) {
    final String[] extraData = this.getExtraData().split("=");
    for (SimpleFeature f : features) {
        log.debug(String.format("Setting value : %s for attribute: %s on feature %s", 
                                     extraData[1], extraData[0], f.getID()));
        f.setAttribute(extraData[0], extraData[1]);
    }
    return features;
}
```

assuming `workflow_status` is a valid attribute name for the feature

One would probably also want to use a custom urlbinding to prevent conflicts.
