### PR TITLE
Add a deactivateControls function to the ViewerController

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
@@ -345,7 +345,33 @@ Ext.define("viewer.viewercontroller.MapComponent",{
         }
         return activeTools;
     },     
-    
+    /**
+     * Deactivate contols by calling cancel(), will also deactivate subclasses
+     * of the specified classes.
+     * 
+     * eg. when called with [viewer.components.Merge] and
+     * viewer.components.IbisMerge", { extend: "viewer.components.Merge"... 
+     * both Merge and IbisMerge will be cancelled.
+     *
+     * This will raise an error if a class listed in the argument does not have a cancel() function.
+     *
+     * @param {Array} cancellable An array of classnames that have a cancel function to be called
+     */
+    deactivateControls: function (cancellable) {
+        var cmps = this.viewerController.getComponents();
+        for (var i = 0; i < cmps.length; i++) {
+            for (var n = 0; n < cancellable.length; n++) {
+                if (cmps[i].self.getName() === cancellable[n] ||
+                        cmps[i].superclass.self.getName() === cancellable[n]) {
+                    if (typeof cmps[i].cancel === "function") {
+                        cmps[i].cancel();
+                    } else {
+                        Ext.Error.raise({msg: "cancel() Not implemented for component: " + cmps[i].self.getName()});
+                    }
+                }
+            }
+        }
+    },
     /**
      * Get the width of this component
      * @return width in pixels.

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
@@ -346,33 +346,6 @@ Ext.define("viewer.viewercontroller.MapComponent",{
         return activeTools;
     },     
     /**
-     * Deactivate contols by calling cancel(), will also deactivate subclasses
-     * of the specified classes.
-     * 
-     * eg. when called with [viewer.components.Merge] and
-     * viewer.components.IbisMerge", { extend: "viewer.components.Merge"... 
-     * both Merge and IbisMerge will be cancelled.
-     *
-     * This will raise an error if a class listed in the argument does not have a cancel() function.
-     *
-     * @param {Array} cancellable An array of classnames that have a cancel function to be called
-     */
-    deactivateControls: function (cancellable) {
-        var cmps = this.viewerController.getComponents();
-        for (var i = 0; i < cmps.length; i++) {
-            for (var n = 0; n < cancellable.length; n++) {
-                if (cmps[i].self.getName() === cancellable[n] ||
-                        cmps[i].superclass.self.getName() === cancellable[n]) {
-                    if (typeof cmps[i].cancel === "function") {
-                        cmps[i].cancel();
-                    } else {
-                        Ext.Error.raise({msg: "cancel() Not implemented for component: " + cmps[i].self.getName()});
-                    }
-                }
-            }
-        }
-    },
-    /**
      * Get the width of this component
      * @return width in pixels.
      */

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1325,7 +1325,7 @@ Ext.define("viewer.viewercontroller.ViewerController", {
     },
     /**
      * Get all the registered components.
-     * @return {Array} A array of the registered components.
+     * @return {Array} An array of the registered components.
      */
     getComponents: function (){
         var results=[];

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1367,6 +1367,33 @@ Ext.define("viewer.viewercontroller.ViewerController", {
         }
     },
     /**
+     * Deactivate contols by calling cancel(), will also deactivate subclasses
+     * of the specified classes.
+     *
+     * eg. when called with [viewer.components.Merge] and
+     * viewer.components.IbisMerge", { extend: "viewer.components.Merge"...
+     * both Merge and IbisMerge will be cancelled.
+     *
+     * This will raise an error if a class listed in the argument does not have a cancel() function.
+     *
+     * @param {Array} cancellable An array of classnames that have a cancel function to be called
+     */
+    deactivateControls: function (cancellable) {
+        var cmps = this.getComponents();
+        for (var i = 0; i < cmps.length; i++) {
+            for (var n = 0; n < cancellable.length; n++) {
+                if (cmps[i].self.getName() === cancellable[n] ||
+                        cmps[i].superclass.self.getName() === cancellable[n]) {
+                    if (typeof cmps[i].cancel === "function") {
+                        cmps[i].cancel();
+                    } else {
+                        Ext.Error.raise({msg: "cancel() Not implemented for component: " + cmps[i].self.getName()});
+                    }
+                }
+            }
+        }
+    },
+    /**
      * Get the attributes of the appLayer
      */
     getAttributesFromAppLayer: function (appLayer, featureTypeId, addJoinedAttributes){

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -37,7 +37,8 @@ Ext.define("viewer.components.Edit", {
         tooltip: "",
         layers: null,
         label: "",
-        allowDelete: false
+        allowDelete: false,
+        cancelOtherControls: ["viewer.components.Merge", "viewer.components.Split"]
     },
     constructor: function (conf) {
         viewer.components.Edit.superclass.constructor.call(this, conf);
@@ -114,6 +115,7 @@ Ext.define("viewer.components.Edit", {
         }
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
+        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     loadWindow: function () {
@@ -648,7 +650,10 @@ Ext.define("viewer.components.Edit", {
         Ext.getCmp(this.name + "geomLabel").setText("");
         this.inputContainer.removeAll();
         this.config.viewerController.mapComponent.getMap().removeMarker("edit");
-        this.vectorLayer.removeAllFeatures();
+        if (this.vectorLayer) {
+            // vector layer may be null when cancel() is called
+            this.vectorLayer.removeAllFeatures();
+        }
     },
     getExtComponents: function () {
         return [this.maincontainer.getId()];

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -115,7 +115,7 @@ Ext.define("viewer.components.Edit", {
         }
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
-        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
+        this.config.viewerController.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     loadWindow: function () {

--- a/viewer/src/main/webapp/viewer-html/components/Merge.js
+++ b/viewer/src/main/webapp/viewer-html/components/Merge.js
@@ -112,7 +112,7 @@ Ext.define("viewer.components.Merge", {
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
         this.config.viewerController.mapComponent.deactivateTools();
-        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
+        this.config.viewerController.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     toMergeFeatureAdded: function (vecLayer, feature) {

--- a/viewer/src/main/webapp/viewer-html/components/Merge.js
+++ b/viewer/src/main/webapp/viewer-html/components/Merge.js
@@ -32,7 +32,8 @@ Ext.define("viewer.components.Merge", {
         strategy: null,
         actionbeanUrl: "/viewer/action/feature/merge",
         layers: null,
-        mergeGapDist: null
+        mergeGapDist: null,
+        cancelOtherControls: ["viewer.components.Edit", "viewer.components.Split"]
     },
     constructor: function (conf) {
         viewer.components.Merge.superclass.constructor.call(this, conf);
@@ -111,6 +112,7 @@ Ext.define("viewer.components.Merge", {
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
         this.config.viewerController.mapComponent.deactivateTools();
+        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     toMergeFeatureAdded: function (vecLayer, feature) {
@@ -229,7 +231,10 @@ Ext.define("viewer.components.Merge", {
         this.layerSelector.combobox.select(null);
         Ext.getCmp(this.name + "geomLabel").setText("");
         this.config.viewerController.mapComponent.getMap().removeMarker("edit");
-        this.vectorLayer.removeAllFeatures();
+        if (this.vectorLayer) {
+            // vector layer may be null when cancel() is called
+            this.vectorLayer.removeAllFeatures();
+        }
     },
     loadWindow: function () {
         var me = this;

--- a/viewer/src/main/webapp/viewer-html/components/Split.js
+++ b/viewer/src/main/webapp/viewer-html/components/Split.js
@@ -173,7 +173,7 @@ Ext.define("viewer.components.Split", {
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
         this.config.viewerController.mapComponent.deactivateTools();
-        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
+        this.config.viewerController.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     loadWindow: function () {

--- a/viewer/src/main/webapp/viewer-html/components/Split.js
+++ b/viewer/src/main/webapp/viewer-html/components/Split.js
@@ -45,7 +45,8 @@ Ext.define("viewer.components.Split", {
         title: "",
         iconUrl: "",
         layers: null,
-        label: ""
+        label: "",
+        cancelOtherControls: ["viewer.components.Edit", "viewer.components.Merge"]
     },
     constructor: function (conf) {
         viewer.components.Split.superclass.constructor.call(this, conf);
@@ -172,6 +173,7 @@ Ext.define("viewer.components.Split", {
         this.layerSelector.initLayers();
         this.popup.popupWin.setTitle(this.config.title);
         this.config.viewerController.mapComponent.deactivateTools();
+        this.config.viewerController.mapComponent.deactivateControls(this.config.cancelOtherControls);
         this.popup.show();
     },
     loadWindow: function () {
@@ -603,8 +605,13 @@ Ext.define("viewer.components.Split", {
         Ext.getCmp(this.name + "geomLabel").setText("");
         this.inputContainer.removeAll();
         this.config.viewerController.mapComponent.getMap().removeMarker("edit");
-        this.vectorLayer.removeAllFeatures();
-        this.drawLayer.removeAllFeatures();
+        // vector layers may be null when cancel() is called
+        if (this.vectorLayer) {
+            this.vectorLayer.removeAllFeatures();
+        }
+        if (this.vectorLayer) {
+            this.drawLayer.removeAllFeatures();
+        }
     },
     getExtComponents: function () {
         return [this.maincontainer.getId()];


### PR DESCRIPTION
To be able to close other (conflicting) controls (by classname) when activating a control. Will also take care of subclassed controls eg. 

``` javascript
Ext.define(viewer.components.IbisMerge", 
    { extend: "viewer.components.Merge", ....
```

and an argument of `['viewer.components.Merge']` will cancel both the Merge and the subclassed IbisMerge controls

close #398
