### PR TITLE
use a system chosen, ephemeral port to bind to for SearchClientTest

### DIFF
--- a/viewer/src/test/java/nl/b3p/viewer/HttpTestSupport.java
+++ b/viewer/src/test/java/nl/b3p/viewer/HttpTestSupport.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 /**
  *
  * @author Roy Braam
+ * @author mprins
  */
 public class HttpTestSupport{
     
@@ -20,7 +21,7 @@ public class HttpTestSupport{
     
     public HttpTestSupport(){
         try{
-            httpServer = HttpServer.create(new InetSocketAddress(8888),0);
+            httpServer = HttpServer.create(new InetSocketAddress(0), 0);
         }catch(IOException ioe){
             ioe.printStackTrace();
         }

--- a/viewer/src/test/java/nl/b3p/viewer/search/SearchClientTest.java
+++ b/viewer/src/test/java/nl/b3p/viewer/search/SearchClientTest.java
@@ -11,16 +11,14 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import nl.b3p.viewer.HttpTestSupport;
 import org.json.JSONArray;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
  *
  * @author Roy Braam
+ * @author mprins
  */
 public class SearchClientTest extends HttpTestSupport{
     private OpenLSSearchClient ols;
@@ -37,23 +35,12 @@ public class SearchClientTest extends HttpTestSupport{
         };
         httpServer.createContext("/geocoder/Geocoder",handler);
     }
-    
-    @BeforeClass
-    public static void setUpClass() {
-        
-    }
-    
-    @AfterClass
-    public static void tearDownClass() {
-    }
-    
+   
     @Before
     public void setUp() {
-        ols = new OpenLSSearchClient("http://localhost:8888/geocoder/Geocoder?zoekterm=");        
-    }
-    
-    @After
-    public void tearDown() {
+        ols = new OpenLSSearchClient("http://localhost:"
+                + httpServer.getAddress().getPort()
+                + "/geocoder/Geocoder?zoekterm=");
     }
     
     @Test


### PR DESCRIPTION
nl.b3p.viewer.search.SearchClientTest fails on AppVeyor with the following stack trace:

```
nl.b3p.viewer.search.SearchClientTest
java.net.BindException: Address already in use: bind 
    at sun.nio.ch.Net.bind0(Native Method)
    at sun.nio.ch.Net.bind(Net.java:444)
    at sun.nio.ch.Net.bind(Net.java:436)
...
```

it tries to start a server on port 8888 which seems to be unavailable at some times.
