### PR TITLE
Changeover the closure compiler maven plugin

### DIFF
--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -262,9 +262,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.sandwormz</groupId>
-                <artifactId>maven.closure.plugin</artifactId>
-                <version>0.0.2-SNAPSHOT</version>
+                <groupId>nl.geodienstencentrum.maven</groupId>
+                <artifactId>closure-compiler-maven-plugin</artifactId>
+                <version>1.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -264,7 +264,7 @@
             <plugin>
                 <groupId>nl.geodienstencentrum.maven</groupId>
                 <artifactId>closure-compiler-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
from a Sandwormz -snapshot version to [nl.geodienstencentrum.maven:closure-compiler-maven-plugin:1.0.1](https://geodienstencentrum.github.io/closure-compiler-maven-plugin) release

close #402 
