### PR TITLE
fix the overview map to always have the same dimensions

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -266,7 +266,7 @@ public class PrintActionBean implements ActionBean {
         JSONArray reqs = new JSONArray();
         
         JSONObject image = new JSONObject();
-        image.put("protocol", CombineImageActionBean.IMAGE);
+        image.put("protocol", CombineImageActionBean.WMS);
         image.put("url", overview.get("overviewUrl"));
         image.put("extent", overview.get("extent"));
         reqs.put(image);

--- a/viewer/src/main/webapp/WEB-INF/xsl/print/calc.xsl
+++ b/viewer/src/main/webapp/WEB-INF/xsl/print/calc.xsl
@@ -307,6 +307,10 @@
                     <xsl:value-of select="overviewUrl"/>
                     <xsl:text>&amp;geom=</xsl:text>
                     <xsl:value-of select="$bbox-corrected"/>
+                    <xsl:text>&amp;width=</xsl:text>
+                    <xsl:value-of select="translate($width,'px', '')"/>
+                    <xsl:text>&amp;height=</xsl:text>
+                    <xsl:value-of select="translate($height,'px', '')"/>
                 </xsl:variable>
                 <fo:external-graphic src="url({$overviewSrc})" content-height="scale-to-fit" content-width="scale-to-fit" scaling="uniform" width="{$width}" height="{$height}"/>
             </fo:block>


### PR DESCRIPTION
and not depend on the size of the viewport.

_NOTE_: this change may have effect on existing templates, especially if you used cm. to set the overview size.
