### PR TITLE
Fix for mismatch between Flamingo attribute types and ExtJS Field types

### DIFF
--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/AttributeDescriptor.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/AttributeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2015 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -64,6 +64,35 @@ public class AttributeDescriptor {
     private String alias;
 
     private String type;
+    
+    /**
+     * Returns the ExtJS
+     * {@link https://docs.sencha.com/extjs/5.1/5.1.0-apidocs/#!/api/Ext.data.field.Field field}
+     * type for this attribute.
+     *
+     * @return a string representing the field type (one of
+     * auto,string,int,number,boolean,date)
+     */
+    public String getExtJSType() {
+        // default to "auto" field type
+        String ext_type = "auto";
+
+        if (this.type.equals(TYPE_STRING)) {
+            ext_type = "string";
+        } else if (this.type.equals(TYPE_INTEGER)) {
+            ext_type = "int";
+        } else if (this.type.equals(TYPE_DOUBLE)) {
+            ext_type = "number";
+        } else if (this.type.equals(TYPE_BOOLEAN)) {
+            ext_type = "boolean";
+        } else if (this.type.equals(TYPE_DATE)) {
+            ext_type = "date";
+        } else if (this.type.equals(TYPE_TIMESTAMP)) {
+            ext_type = "date";
+        }
+
+        return ext_type;
+    }
 
     //<editor-fold defaultstate="collapsed" desc="getters en setters">
     public Long getId() {


### PR DESCRIPTION
nl.b3p.viewer.config.services.AttributeDescriptor has the following "data types"

``` java
    public static final String TYPE_STRING = "string";
    public static final String TYPE_DOUBLE = "double";
    public static final String TYPE_INTEGER = "integer";
    public static final String TYPE_BOOLEAN = "boolean";
...
    public static final String TYPE_DATE = "date";
    public static final String TYPE_TIMESTAMP = "timestamp";
...
// geometry types excluded
```

ExtJS however only has

``` javascript
Ext.data.field.Field \\ auto (Default, implies no conversion)
Ext.data.field.String \\ string
Ext.data.field.Integer \\ int
Ext.data.field.Number \\ number
Ext.data.field.Boolean \\ boolean
Ext.data.field.Date \\ date

```

see: https://docs.sencha.com/extjs/5.1/5.1.0-apidocs/#!/api/Ext.data.field.Field

this leads to errors when using code like the following to create  `Store` metadata and convert a feature collection to a store for display in a grid

``` java
  /**
     *
     * @param sfc collections of features
     * @param json output/appendend to json structure
     * @param featureTypeAttributes flamingo attribute descriptors for the
     * features
     * @param outputPropNames fieldnames to put in output
     * @throws JSONException is any
     */
    private void featuresToJson(SimpleFeatureCollection sfc, JSONObject json, List<AttributeDescriptor> featureTypeAttributes, List<String> outputPropNames) throws JSONException {
        // metadata for data fields
        JSONArray fields = new JSONArray();
        // columns for grid
        JSONArray columns = new JSONArray();
        // data payload
        JSONArray datas = new JSONArray();

        SimpleFeatureIterator sfIter = sfc.features();

        boolean getMetadataFromFirstFeature = true;
        while (sfIter.hasNext()) {
            SimpleFeature feature = sfIter.next();
            JSONObject fData = new JSONObject();

            for (AttributeDescriptor attr : featureTypeAttributes) {
                String name = attr.getName();
                if (getMetadataFromFirstFeature) {
                    if (outputPropNames.contains(name)) {
                        // only load metadata into json this for first feature
                        fields.put(new JSONObject().put("name", name)
/* this will cause an error when a double type is encountered*/
                            .put("type", attr.getType()));
                        columns.put(new JSONObject().put("text", (attr.getAlias() != null ? attr.getAlias() : name))
                           .put("dataIndex", name));
                    }
                }
                fData.put(attr.getName(), feature.getAttribute(attr.getName()));
            }
            datas.put(fData);
            getMetadataFromFirstFeature = false;
        }

        json.getJSONObject(JSON_METADATA).put("fields", fields);
        json.getJSONObject(JSON_METADATA).put("columns", columns);
        json.put("data", datas);
        json.put("total", datas.length());

        sfIter.close();
    }
```
