### PR TITLE
nl.geozet:openls-databinding is in Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
             <dependency>
                 <groupId>nl.geozet</groupId>
                 <artifactId>openls-databinding</artifactId>
-                <version>0.3</version>
+                <version>0.4</version>
             </dependency>
             <!-- lucene for csw advanced searching -->
             <dependency>
@@ -405,17 +405,9 @@
     </dependencyManagement>
     <repositories>
         <repository>
-            <id>releases</id>
+            <id>B3Partners</id>
             <name>Releases hosted by B3Partners</name>
-            <url>http://repo.b3p.nl/nexus/content/repositories/releases/</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>3rdparty</id>
-            <name>3rd party components hosted by B3Partners</name>
-            <url>http://repo.b3p.nl/nexus/content/repositories/thirdparty/</url>
+            <url>http://repo.b3p.nl/nexus/content/groups/public/</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -424,17 +416,6 @@
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
             <url>http://download.osgeo.org/webdav/geotools/</url>
-        </repository>
-        <repository>
-            <id>github</id>
-            <name>geozet releases repository</name>
-            <url>https://github.com/geozet/geozet-maven-repo/raw/master/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
         </repository>
     </repositories>
     <pluginRepositories />


### PR DESCRIPTION
As of now the openls-databinding artifact can be found in Maven Central so we no longer need the github repository, also just need to point to the 'public' of B3Partners not the separate sub-repo's
