### PR TITLE
Add an option to enable/disable the new button

### DIFF
--- a/viewer-admin/src/main/webapp/resources/html/help.html
+++ b/viewer-admin/src/main/webapp/resources/html/help.html
@@ -6122,6 +6122,18 @@ program. If not, see <http://www.gnu.org/licenses/>
                     <tr>
                         <td>
                             <p>
+                                Nieuw toestaan
+                            </p>
+                        </td>
+                        <td>
+                            <p>
+                                De beheerder kan hiermee de knop "Nieuw" in het editor scherm inschakelen.
+                            </p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>
+                            <p>
                                 Filter
                             </p>
                         </td>

--- a/viewer/src/main/webapp/viewer-html/components/Edit-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit-config.js
@@ -44,6 +44,13 @@ Ext.define("viewer.components.CustomConfiguration", {
             },
             {
                 xtype: 'checkbox',
+                fieldLabel: 'Nieuw toestaan',
+                name: 'allowNew',
+                value: this.configObject.allowNew !== undefined ? this.configObject.allowNew : true,
+                labelWidth: this.labelWidth
+            },
+            {
+                xtype: 'checkbox',
                 fieldLabel: 'Link toevoegen in Feature Info',
                 name: 'showEditLinkInFeatureInfo',
                 value: this.configObject.showEditLinkInFeatureInfo !== undefined ? this.configObject.showEditLinkInFeatureInfo : false,

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -44,6 +44,7 @@ Ext.define("viewer.components.Edit", {
         label: "",
         allowDelete: false,
         allowCopy: false,
+        allowNew: true,
         cancelOtherControls: ["viewer.components.Merge", "viewer.components.Split"],
         formLayout: 'anchor',
         showEditLinkInFeatureInfo: true
@@ -271,6 +272,9 @@ Ext.define("viewer.components.Edit", {
         if (!this.config.allowCopy) {
             Ext.getCmp(this.name + "copyButton").destroy();
         }
+        if (!this.config.allowNew) {
+            Ext.getCmp(this.name + "newButton").destroy();
+        }
 
         this.inputContainer = Ext.getCmp(this.name + 'InputPanel');
     },
@@ -423,7 +427,9 @@ Ext.define("viewer.components.Edit", {
                 if (this.newGeomType == null) {
                     tekst = "Geometrie mag alleen bewerkt worden";
                 } else {
-                    Ext.getCmp(this.name + "newButton").setDisabled(false);
+                    if (!this.config.allowNew) {
+                        Ext.getCmp(this.name + "newButton").setDisabled(false);
+                    }
                     tekst = 'Bewerk een ' + this.tekstGeom + " op de kaart";
                     if (this.config.allowDelete) {
                         tekst = 'Bewerk of verwijder een ' + this.tekstGeom + " uit de kaart";
@@ -454,7 +460,9 @@ Ext.define("viewer.components.Edit", {
         } else {
             gl.setText("Geometrietype onbekend. Bewerken niet mogelijk.");
             Ext.getCmp(this.name + "editButton").setDisabled(true);
-            Ext.getCmp(this.name + "newButton").setDisabled(true);
+            if (!this.config.allowNew) {
+                Ext.getCmp(this.name + "newButton").setDisabled(true);
+            }         
             if (this.config.allowDelete) {
                 Ext.getCmp(this.name + "deleteButton").setDisabled(true);
             }
@@ -813,7 +821,9 @@ Ext.define("viewer.components.Edit", {
     },
     resetForm: function () {
         Ext.getCmp(this.name + "editButton").setDisabled(true);
-        Ext.getCmp(this.name + "newButton").setDisabled(true);
+        if (!this.config.allowNew) {
+            Ext.getCmp(this.name + "newButton").setDisabled(true);
+        }
         if (this.config.allowDelete) {
             Ext.getCmp(this.name + "deleteButton").setDisabled(true);
         }


### PR DESCRIPTION
This makes it possible to tun off the "nieuw" button on the editing panel. To prevent problems in backward-compatible behaviour it is "on" by default
