### PR TITLE
pass errorhandler function to ajax request and pass scope to error handler

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/ajax/FeatureInfo.js
+++ b/viewer/src/main/webapp/viewer-html/common/ajax/FeatureInfo.js
@@ -60,8 +60,8 @@ Ext.define("viewer.FeatureInfo", {
                 successFunction(response);
             },
             failure: function(result) {
-                if(failureFunction != undefined) {
-                    failureFunction("Ajax request failed with status " + result.status + " " + result.statusText + ": " + result.responseText);
+                if (failureFunction !== undefined) {
+                    failureFunction("Ajax request failed with status " + result.status + " " + result.statusText + ": " + result.responseText, scope);
                 }
             }
         });

--- a/viewer/src/main/webapp/viewer-html/components/Maptip.js
+++ b/viewer/src/main/webapp/viewer-html/components/Maptip.js
@@ -205,7 +205,7 @@ Ext.define ("viewer.components.Maptip",{
             }
 
             me.onMapData(null, options);
-        }, this.onFailure);
+        }, this.onFailure, me);
     },
     /**
      * Handles when the mapping framework returns with data
@@ -498,10 +498,19 @@ Ext.define ("viewer.components.Maptip",{
         cDiv.appendChild(featureDiv);
         this.popup.show();
     },
-    onFailure: function(e){
-        this.config.viewerController.logger.error(e);
-        if(this.config.spinnerWhileIdentify){
-            this.viewerController.mapComponent.getMap().removeMarker("edit");
+    /**
+     * Handle failure of ajax requests.
+     * @param {String} e The error message
+     * @param {Window|viewer.components.Maptip} scope Either this or another object;
+     *         commonly 'this' is the global scope ('Window') which is why we make it possible to pass in.
+     */
+    onFailure: function (e, scope) {
+        var me = this;
+        if (!me.config) {
+            me = scope;
+        }
+        if (me.config.spinnerWhileIdentify) {
+            me.viewerController.mapComponent.getMap().removeMarker("edit");
         }
     },
     /**

--- a/viewer/src/main/webapp/viewer-html/components/RequestManager.js
+++ b/viewer/src/main/webapp/viewer-html/components/RequestManager.js
@@ -27,8 +27,11 @@ Ext.define ("viewer.components.RequestManager",{
         this.featureInfo = featureInfo;
         this.config.viewerController = viewerController;
     },
-    request: function(id, options, radius, layers, callback, failure) {
+    request: function (id, options, radius, layers, callback, failure, scope) {
         var me = this;
+        if (!scope) {
+            scope = me;
+        }
         if (this.previousRequests[id] === undefined) {
             this.previousRequests[id] = new Object();
             this.previousRequests[id].requests = new Array();
@@ -43,7 +46,7 @@ Ext.define ("viewer.components.RequestManager",{
             var request = this.featureInfo.layersFeatureInfo(options.coord.x, options.coord.y, radius, [layers[i]], extraParams,function(data){
                 me.responseReceived(data[0].requestId);
                 callback(data);
-            }, this.onFailure,me);
+            }, failure, scope);
             
             if(request){
                 this.previousRequests[id].requests.push(request);


### PR DESCRIPTION
This PR allows passing scope so that the errorhandler function is useful (otherwise the default scope of Window is used) 

As described in https://github.com/flamingo-geocms/flamingo/issues/487#issuecomment-167516763 the errorhandler was not being passed to the Ajax request which would leave the spinner on screen in case of a timeout or error.

close #487 
