### PR TITLE
Manage maven plugins from the parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <name>flamingo-mc</name>
     <url>http://github.com/flamingo-mc</url>
     <prerequisites>
-        <maven>3.0.5</maven>
+        <maven>3.2.5</maven>
     </prerequisites>
     <scm>
         <connection>scm:git:git@github.com:flamingo-mc/flamingo.git</connection>
@@ -30,16 +30,25 @@
     </distributionManagement>
     <properties>
         <flamingo.version>4.6.1-SNAPSHOT</flamingo.version>
+        <project.build.sourceVersion>1.7</project.build.sourceVersion>
+        <project.build.targetVersion>1.7</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <geotools.version>14.1</geotools.version>
         <powermock.version>1.5.5</powermock.version>
+        <hsqldb.version>2.3.3</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
+        <postgresql.version>9.4.1207</postgresql.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>true</test.skip.integrationtests>
     </properties>
     <dependencyManagement>
+        <!--
+            To check for plugin updates use the following command:
+            mvn -U org.codehaus.mojo:versions-maven-plugin:2.2:display-dependency-updates
+            and check the output for anay available updates
+        -->
         <dependencies>
             <!-- viewer-->
             <dependency>
@@ -51,31 +60,26 @@
                 <groupId>jdom</groupId>
                 <artifactId>jdom</artifactId>
                 <version>1.0</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>com.vividsolutions</groupId>
                 <artifactId>jts</artifactId>
                 <version>1.13</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-main</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-render</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
                 <version>20090211</version>
-                <type>jar</type>
             </dependency>
             <!-- Stripes -->
             <dependency>
@@ -93,35 +97,41 @@
                 <groupId>org.flamingo-mc</groupId>
                 <artifactId>viewer-config-persistence</artifactId>
                 <version>${flamingo.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.flamingo-mc</groupId>
                 <artifactId>solr-commons</artifactId>
                 <version>${flamingo.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>fop</artifactId>
                 <version>1.0</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.1</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
-                <version>1.2.16</version>
+                <version>1.2.17</version>
             </dependency>
             <dependency>
                 <groupId>org.twitter4j</groupId>
                 <artifactId>twitter4j-core</artifactId>
                 <version>3.0.5</version>
+            </dependency>
+            <dependency>
+                <groupId>jaxen</groupId>
+                <artifactId>jaxen</artifactId>
+                <version>1.1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+                <version>2.7.1</version>
             </dependency>
 
             <!-- nl b3p csw-->
@@ -129,7 +139,6 @@
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
                 <version>2.0</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -175,7 +184,6 @@
                 <artifactId>solr-solrj</artifactId>
                 <groupId>org.apache.solr</groupId>
                 <version>4.6.0</version>
-                <type>jar</type>
                 <scope>compile</scope>
             </dependency>
 
@@ -183,7 +191,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.11</version>
+                <version>4.12</version>
             </dependency>
             <dependency>
                 <groupId>commons-logging</groupId>
@@ -194,7 +202,6 @@
                 <groupId>com.googlecode.json-simple</groupId>
                 <artifactId>json-simple</artifactId>
                 <version>1.1</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
@@ -223,22 +230,20 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-shapefile</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-epsg-wkt</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
 
-         <!-- Solr dependencies for indexing and searching -->
+            <!-- Solr dependencies for indexing and searching -->
             <dependency>
                 <groupId>org.apache.solr</groupId>
                 <artifactId>solr-core</artifactId>
                 <version>4.6.0</version>
                 <exclusions>
-                     <exclusion>
+                    <exclusion>
                         <artifactId>jsp-api</artifactId>
                         <groupId>javax.servlet.jsp</groupId>
                     </exclusion>
@@ -281,7 +286,6 @@
                 <version>3.6.8.Final</version>
             </dependency>
 
-
             <!-- viewer-config-persistence -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -302,13 +306,11 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-wms</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-wfs-ng</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.geotools.jdbc</groupId>
@@ -332,7 +334,6 @@
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-metadata</artifactId>
                 <version>${geotools.version}</version>
-                <type>jar</type>
             </dependency>
 
             <!-- viewer-admin-->
@@ -359,7 +360,6 @@
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
                 <version>3.9</version>
-                <type>jar</type>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
@@ -388,39 +388,39 @@
                 <artifactId>fluent-hc</artifactId>
                 <version>4.3.6</version>
             </dependency>
-              <dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.3.3</version>
-              </dependency>
-              <dependency>
-                  <groupId>org.apache.httpcomponents</groupId>
-                  <artifactId>httpmime</artifactId>
-                  <version>4.3.6</version>
-              </dependency>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpmime</artifactId>
+                <version>4.3.6</version>
+            </dependency>
 
-              <dependency>
-                  <groupId>org.eclipse.emf</groupId>
-                  <artifactId>org.eclipse.emf.common</artifactId>
-                  <version>2.10.1</version>
-              </dependency>
-              <dependency>
-                  <groupId>xalan</groupId>
-                  <artifactId>xalan</artifactId>
-                  <version>2.7.0</version>
-              </dependency>
+            <dependency>
+                <groupId>org.eclipse.emf</groupId>
+                <artifactId>org.eclipse.emf.common</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <dependency>
+                <groupId>xalan</groupId>
+                <artifactId>xalan</artifactId>
+                <version>2.7.0</version>
+            </dependency>
 
-              <dependency>
-                  <groupId>org.hsqldb</groupId>
-                  <artifactId>hsqldb</artifactId>
-                  <version>2.3.3</version>
-              </dependency>
+            <dependency>
+                <groupId>org.hsqldb</groupId>
+                <artifactId>hsqldb</artifactId>
+                <version>${hsqldb.version}</version>
+            </dependency>
               
-              <dependency>
-                  <groupId>org.skyscreamer</groupId>
-                  <artifactId>jsonassert</artifactId>
-                  <version>1.2.3</version>
-              </dependency>
+            <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>1.3.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <repositories>
@@ -440,19 +440,128 @@
     </repositories>
     <pluginRepositories />
     <build>
+        <pluginManagement>
+            <plugins>
+                <!--
+                    To check for plugin updates use the following command:
+                    mvn -U org.codehaus.mojo:versions-maven-plugin:2.2:display-plugin-updates
+                    and check the output for anay available updates
+                -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.10.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.10.3</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.7</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.5</version>
+                    <configuration>
+                        <source>${project.build.sourceVersion}</source>
+                        <target>${project.build.targetVersion}</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>hibernate3-maven-plugin</artifactId>
+                    <version>3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-war-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.10</version>
+                </plugin>
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <version>2.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>truezip-maven-plugin</artifactId>
+                    <version>1.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>nl.geodienstencentrum.maven</groupId>
+                    <artifactId>closure-compiler-maven-plugin</artifactId>
+                    <version>2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.tomcat.maven</groupId>
+                    <artifactId>tomcat7-maven-plugin</artifactId>
+                    <version>2.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <pushChanges>true</pushChanges>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*IntegrationTest.java</exclude>
@@ -460,9 +569,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <includes>
                         <include>**/*IntegrationTest.java</include>

--- a/solr-commons/pom.xml
+++ b/solr-commons/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <groupId>org.flamingo-mc</groupId>
     <artifactId>solr-commons</artifactId>
     <packaging>jar</packaging>
@@ -10,14 +9,8 @@
         <groupId>org.flamingo-mc</groupId>
         <artifactId>flamingo-mc</artifactId>
         <version>4.6.1-SNAPSHOT</version>
-    </parent>  
-
+    </parent>
     <name>solr-commons</name>
-    <url>http://maven.apache.org</url>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -116,7 +116,6 @@
                <artifactId>solr-solrj</artifactId>
                <groupId>org.apache.solr</groupId>
         </dependency>
-        
         <dependency>
             <groupId>org.flamingo-mc</groupId>
             <artifactId>viewer-config-persistence</artifactId>
@@ -130,10 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>
@@ -142,7 +138,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <webResources>
@@ -159,7 +154,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -184,7 +178,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -210,8 +203,6 @@
                     </gitDescribe>
                 </configuration>
             </plugin>
-
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -222,7 +213,6 @@
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -18,7 +18,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>hibernate3-maven-plugin</artifactId>
-                <version>3.0</version>
                 <executions>
                     <execution>
                         <id>schema-export</id>
@@ -63,31 +62,26 @@
                 </executions>
                 <dependencies>
                     <dependency>
-                        <!-- hsqldb wordt allen voor unit tests gebruikt, maar als deze
+                        <!-- hsqldb wordt alleen voor unit tests gebruikt, maar als deze
                         als test scope dep wordt opgevoerd treedt er een CNFE op tijdens de build. -->
-
                         <groupId>org.hsqldb</groupId>
                         <artifactId>hsqldb</artifactId>
-                        <version>2.3.3</version>
+                        <version>${hsqldb.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <goals>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -149,7 +149,6 @@
         <dependency>
             <groupId>org.apache.poi</groupId>
             <artifactId>poi</artifactId>
-            <type>jar</type>
         </dependency>
 
         <dependency>
@@ -165,38 +164,19 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
-            <version>1.1.6</version>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
-            <version>2.7.1</version>
         </dependency>
     </dependencies>
-
-    <!-- plugin repo for complosure -->
-    <pluginRepositories>
-        <pluginRepository>
-            <id>sonatype-oss-public</id>
-            <url>https://oss.sonatype.org/content/groups/public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>
@@ -205,7 +185,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.1.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                     <webResources>
@@ -224,7 +203,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>truezip-maven-plugin</artifactId>
-                <version>1.2</version>
                 <executions>
                     <execution>
                         <id>remove-a-file</id>
@@ -246,7 +224,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.1</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>
@@ -271,7 +248,6 @@
             <plugin>
                 <groupId>nl.geodienstencentrum.maven</groupId>
                 <artifactId>closure-compiler-maven-plugin</artifactId>
-                <version>1.0.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -403,7 +379,6 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.1.5</version>
                 <executions>
                     <execution>
                         <goals>
@@ -450,7 +425,7 @@
                 <dependency>
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
-                    <version>9.4.1207</version>
+                    <version>${postgresql.version}</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -459,7 +434,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
-                        <version>1.0.0</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -486,7 +460,6 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
-                        <version>2.2</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/context.xml</contextFile>
@@ -521,7 +494,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>9.4.1207</version>
+                                <version>${postgresql.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/viewer/src/main/webapp/viewer-html/common/ClearTrigger.js
+++ b/viewer/src/main/webapp/viewer-html/common/ClearTrigger.js
@@ -27,19 +27,19 @@ Ext.define('Ext.ux.form.trigger.Clear', {
     },
 
     /**
-     * @cfg {Boolean} Hides the clear trigger when the field is empty (has no value)
+     * @property {Boolean} Hides the clear trigger when the field is empty (has no value)
      *      (default: true).
      */
     hideWhenEmpty: true,
 
     /**
-     * @cfg {Boolean} Hides the clear trigger until the mouse hovers over the field
+     * @property {Boolean} Hides the clear trigger until the mouse hovers over the field
      *      (default: false).
      */
     hideWhenMouseOut: false,
 
     /**
-     * @cfg {Boolean} Clears the textfield/combobox when the escape (ESC) key is pressed
+     * @property {Boolean} Clears the textfield/combobox when the escape (ESC) key is pressed
      */
     clearOnEscape: false,
 

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/MapComponent.js
@@ -3,7 +3,7 @@
 /**
  * MapComponent
  * @class 
- * @constructor
+ * 
  * @param viewerObject Het viewerObject
  * @author <a href="mailto:meinetoonen@b3partners.nl">Meine Toonen</a>
  * @author <a href="mailto:roybraam@b3partners.nl">Roy Braam</a>
@@ -25,8 +25,9 @@ Ext.define("viewer.viewercontroller.MapComponent",{
      * Construct a map component
      * @param viewerController the viewerController
      * @param domId id of the dom where this map component must be added
-     * @param config a config object
-     * @param config.resolutions a array of resolutions for the map     
+     * @param {Object} config a config object having:
+     *        config.resolutions a array of resolutions for the map
+     * @constructor
      */    
     constructor :function (viewerController,domId,config){
         //init values
@@ -44,28 +45,28 @@ Ext.define("viewer.viewercontroller.MapComponent",{
     },
        
     /**
-    *Creates a Map object for this framework
-    *@param id the id of the map
-    *@param options extra options for the map
-    *@param options.startExtent the starting extent (viewer.viewercontroller.controller.Extent) of the map 
-    *@param options.maxExtent the max extent (viewer.viewercontroller.controller.Extent) of the map
-    *Must be implemented by subclass
+    * Creates a Map object for this framework. Must be implemented by subclass.
+    * @param id the id of the map
+    * @param {Object} options extra options for the map, having:
+    *       options.startExtent the starting extent (viewer.viewercontroller.controller.Extent) of the map
+    *       options.maxExtent the max extent (viewer.viewercontroller.controller.Extent) of the map
+    *
     */
     createMap : function(id, options){
         Ext.Error.raise({msg: "MapComponent.createMap(...) not implemented! Must be implemented in sub-class"});
     },
-    /**
+    /*
     *Create functions. SubClass needs to implement these so the user can
     *create Framework specific objects.
-    **/
+    */
 
     /**
-    *Creates a layer for this framework
+    *Creates a layer for this framework, Must be implemented by subclass
     *@param name the showable name of the layer
     *@param url the url to the serviceProvider
     *@param ogcParams the params that are used in the OGC-WMS request
     *@param options extra options for this wms layer
-    *Must be implemented by subclass
+    *
     */
     createWMSLayer : function(name, url, ogcParams,options){
         Ext.Error.raise({msg: "MapComponent.createWMSLayer() Not implemented! Must be implemented in sub-class"});
@@ -74,13 +75,13 @@ Ext.define("viewer.viewercontroller.MapComponent",{
     * @description Creates a OSGEO TMS layer.
     * @param name the showable name of the layer
     * @param url the url to the tms service
-    * @param options extra options for this tiling layer
-    * @param options.tileHeight the tile height
-    * @param options.tileWidth the tile width
-    * @param options.serviceEnvelop the envelope of the service
-    * @param options.resolutions the resolutions of this service
-    * @param options.protocol tiling protocol
-    * @returns Returns the TilingLayer
+    * @param {Object} options extra options for this tiling layer, having:
+    *         options.tileHeight the tile height,
+    *         options.tileWidth the tile width,
+    *         options.serviceEnvelop the envelope of the service,
+    *         options.resolutions the resolutions of this service,
+    *         options.protocol tiling protocol
+    * @returns  the TilingLayer
     */
     createTilingLayer : function (id,name,url, options){
         Ext.Error.raise({msg: "MapComponent.createTMSLayer() Not implemented! Must be implemented in sub-class"});
@@ -124,24 +125,24 @@ Ext.define("viewer.viewercontroller.MapComponent",{
     *Creates a drawable vectorlayer
     *Must be implemented by subclass
     * A vectorlayer is a layer on which features can be drawn by the user (a EditMap in Flamingo, a VectorLayer in OpenLayers)
-    * @param name The name of this laye
+    * @param name The name of this layer
     */
     createVectorLayer : function (name){
         Ext.Error.raise({msg: "MapComponent.createVectorLayer() Not implemented! Must be implemented in sub-class"});
     },
     /**
-    *Must be implemented by the sub-class
-    *Create a tool
-    *@param conf: the options used for initializing the Tool
-    *@param conf.id the id
-    *@param conf.type the type tool @see viewer.viewercontroller.controller.Tool#statics
-    *@param conf.tooltip the tooltip for this tool
-    *@param conf.iconUrl_up overwrite (or set if not available for the tool type) the icon url for the up state of the control
-    *@param conf.iconUrl_over  overwrite (or set if not available for the tool type) the icon url for the over state of the control
-    *@param conf.iconUrl_sel overwrite (or set if not available for the tool type) the icon url for the selected state of the control
-    *@param conf.iconUrl_dis overwrite (or set if not available for the tool type) the icon url for the disabled state of the control
-    *@return object of type: viewer.viewercontroller.controller.Tool
-    **/
+    *Must be implemented by the sub-class, Create a tool.
+    *
+    * @param {Object} conf: the options used for initializing the Tool, having:
+    *        conf.id the id
+    *        conf.type the type tool @see viewer.viewercontroller.controller.Tool#statics
+    *        conf.tooltip the tooltip for this tool
+    *        conf.iconUrl_up overwrite (or set if not available for the tool type) the icon url for the up state of the control
+    *        conf.iconUrl_over  overwrite (or set if not available for the tool type) the icon url for the over state of the control
+    *        conf.iconUrl_sel overwrite (or set if not available for the tool type) the icon url for the selected state of the control
+    *        conf.iconUrl_dis overwrite (or set if not available for the tool type) the icon url for the disabled state of the control
+    * @return object of type: viewer.viewercontroller.controller.Tool
+    */
     createTool: function (conf){
         Ext.Error.raise({msg: "MapComponent.createTool(...) not implemented! Must be implemented in sub-class"});
     },

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Component.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Component.js
@@ -20,17 +20,18 @@
  */
 Ext.define("viewer.viewercontroller.controller.Component",{
     extend: "Ext.util.Observable",
-    config :{
+    config: {
+        /** @property the id of this component */
         id: null,
+        /** @property a reference to the implementing object. */
         frameworkObject: null,
+        /** @property the type of the object (see #statics) */
         type: -1,
         viewerController:null
     },
     /**
-     * @param config
-     * @param config.id the id of this component
-     * @param config.frameworkObject a reference to the implementing object
-     * @param config.type the type of the object (see statics)
+     * @param {Object} config A config object having, config.id, config.frameworkObject and config.type.
+     * @see #config
      */
     constructor: function (config){
         this.initConfig(config);

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Event.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Event.js
@@ -21,38 +21,38 @@ Ext.define("viewer.viewercontroller.controller.Event",{
         /** @field 
          * @param map the map object
          * @param options the options returned
-         * @param options.nr number of layers that are identified
-         * @param options.total number of total layers that needs to be done.
+         * @property options.nr number of layers that are identified
+         * @property options.total number of total layers that needs to be done.
          **/
         ON_GET_FEATURE_INFO_PROGRESS          : "ON_GET_FEATURE_INFO_PROGRESS",       
         /**
          * @field
          * Occures when the map wants a maptip.
          * @param map the map where this event occured
-         * @param options.x x in pixels on the screen
-         * @param options.y y in pixels on the screen
-         * @param options.coord.x the x coord in world coords
-         * @param options.coord.y the y coord in world coords
+         * @property options.x x in pixels on the screen
+         * @property options.y y in pixels on the screen
+         * @property options.coord.x the x coord in world coords
+         * @property options.coord.y the y coord in world coords
          */
         ON_GET_FEATURE_INFO                   : "ON_GET_FEATURE_INFO",
         /** @field 
          * Occures when a maptip returns data
          * @param layer the layer where this event occured
          * @param options a object with options         
-         * @param options.data[i].features the data as a object array
-         * @param options.data[i].request.appLayer the id of the appLayer
-         * @param options.data[i].request.serviceLayer the service name for the layer 
-         * @param options.x the x pixel (screen location)
-         * @param options.y the y pixel (screen location)
-         * @param options.coord.x the x world coord 
-         * @param options.coord.y the y world coord
-         * @param options.extent (not always available) the place where this maptip for is done.
-         * @param options.extent.minx (not always available) the minx world coord (world location)
-         * @param options.extent.miny (not always available) the miny world coord (world location)
-         * @param options.extent.maxx (not always available) the maxx world coord (world location)
-         * @param options.extent.maxy (not always available) the maxy world coord (world location)
-         * @param options.nr nr of layer that is done
-         * @param options.total total identifies that needs to be done         
+         * @property options.data[i].features the data as a object array
+         * @property options.data[i].request.appLayer the id of the appLayer
+         * @property options.data[i].request.serviceLayer the service name for the layer
+         * @property options.x the x pixel (screen location)
+         * @property options.y the y pixel (screen location)
+         * @property options.coord.x the x world coord
+         * @property options.coord.y the y world coord
+         * @property options.extent (not always available) the place where this maptip for is done.
+         * @property options.extent.minx (not always available) the minx world coord (world location)
+         * @property options.extent.miny (not always available) the miny world coord (world location)
+         * @property options.extent.maxx (not always available) the maxx world coord (world location)
+         * @property options.extent.maxy (not always available) the maxy world coord (world location)
+         * @property options.nr nr of layer that is done
+         * @property options.total total identifies that needs to be done
          * 
          * Example: <appLayer>,
          *           {
@@ -81,15 +81,15 @@ Ext.define("viewer.viewercontroller.controller.Event",{
         /** @field 
          * Occures when the extent is changed
          * @param map the map on which this occures
-         * @param options a options object
-         * @param options.extent the new extent
+         * @param options an options object
+         * @property options.extent the new extent
          */
         ON_CHANGE_EXTENT                      : "ON_CHANGE_EXTENT",
         /** @field 
          * Occures when the extent is finished changing
          * @param map the map on which this occures
-         * @param options a options object
-         * @param options.extent the new extent
+         * @param options an options object
+         * @property options.extent the new extent
          */
         ON_FINISHED_CHANGE_EXTENT             : "ON_FINISHED_CHANGE_EXTENT",
         /**
@@ -104,14 +104,14 @@ Ext.define("viewer.viewercontroller.controller.Event",{
         /** @field 
          * Occures when a layer is added to this map
          * @param map the map object
-         * @param options.layer the layer that is added.
+         * @property options.layer the layer that is added.
          **/
         ON_LAYER_ADDED                        : "ON_LAYER_ADDED",
         /**
          * @field
          * Occures when a layer is removed from the map.
          * @param map the map object 
-         * @param options.layer the layer that is removed.
+         * @property options.layer the layer that is removed.
          */
         ON_LAYER_REMOVED                        : "ON_LAYER_REMOVED",
         /**
@@ -141,26 +141,26 @@ Ext.define("viewer.viewercontroller.controller.Event",{
          * @field
          * Occures when the map wants a maptip.
          * @param map the map where this event occured
-         * @param options.x x in pixels on the screen
-         * @param options.y y in pixels on the screen
-         * @param options.coord.x the x coord in world coords
-         * @param options.coord.y the y coord in world coords
+         * @property options.x x in pixels on the screen
+         * @property options.y y in pixels on the screen
+         * @property options.coord.x the x coord in world coords
+         * @property options.coord.y the y coord in world coords
          */
         ON_MAPTIP                             : "ON_MAPTIP",        
         /** @field 
          * Occures when a maptip returns data
          * @param layer the layer where this event occured
-         * @param options a object with options
-         * @param options.data the data as a multi array
-         * @param options.x the x pixel (screen location)
-         * @param options.y the y pixel (screen location)
-         * @param options.coord.x the x world coord 
-         * @param options.coord.y the y world coord
-         * @param options.extent (not always available) the place where this maptip for is done.
-         * @param options.extent.minx (not always available) the minx world coord (world location)
-         * @param options.extent.miny (not always available) the miny world coord (world location)
-         * @param options.extent.maxx (not always available) the maxx world coord (world location)
-         * @param options.extent.maxy (not always available) the maxy world coord (world location)
+         * @param options an object with options
+         * @property options.data the data as a multi array
+         * @property options.x the x pixel (screen location)
+         * @property options.y the y pixel (screen location)
+         * @property options.coord.x the x world coord
+         * @property options.coord.y the y world coord
+         * @property options.extent (not always available) the place where this maptip for is done.
+         * @property options.extent.minx (not always available) the minx world coord (world location)
+         * @property options.extent.miny (not always available) the miny world coord (world location)
+         * @property options.extent.maxx (not always available) the maxx world coord (world location)
+         * @property options.extent.maxy (not always available) the maxy world coord (world location)
          **/
         ON_MAPTIP_DATA                        : "ON_MAPTIP_DATA",
         
@@ -187,8 +187,8 @@ Ext.define("viewer.viewercontroller.controller.Event",{
         /** @field
          * Thrown when the visibiliy of the layer is changed
          * @param map the map
-         * @param object.layer the layer that is changed
-         * @param object.visible the new value*/
+         * @property object.layer the layer that is changed
+         * @property object.visible the new value*/
         ON_LAYER_VISIBILITY_CHANGED           : "ON_LAYER_VISIBILITY_CHANGED",
         
         /**
@@ -213,8 +213,8 @@ Ext.define("viewer.viewercontroller.controller.Event",{
         ON_ACTIVE_FEATURE_CHANGED             :  "ON_ACTIVE_FEATURE_CHANGED",
         /** @field 
          * Fired when a feature is completed or added to the vector layer. 
-         * @param object.layer The vectorlayer on which the event occured
-         * @param object.feature The feature which was added/completed
+         * @property object.layer The vectorlayer on which the event occured
+         * @property object.feature The feature which was added/completed
          **/
         ON_FEATURE_ADDED                      : "ON_FEATURE_ADDED",
         

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Map.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/Map.js
@@ -22,10 +22,10 @@ Ext.define("viewer.viewercontroller.controller.Map",{
      * @constructor
      * Create a Map Object
      * @param config configuration object
-     * @param config.id the id of this map
-     * @param config.viewerController the viewer controller (viewer.viewercontroller.ViewerController)
-     * @param config.mapComponent the mapping component (viewer.viewercontroller.MapComponent)
-     * @param config.options options for the map @see viewer.viewercontroller.MapComponent#createMap
+     * @property config.id the id of this map
+     * @property config.viewerController the viewer controller (viewer.viewercontroller.ViewerController)
+     * @property config.mapComponent the mapping component (viewer.viewercontroller.MapComponent)
+     * @property config.options options for the map @see viewer.viewercontroller.MapComponent#createMap
      */
     constructor: function(config){
         viewer.viewercontroller.controller.Map.superclass.constructor.call(this, config);

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/ToolMapClick.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/ToolMapClick.js
@@ -29,15 +29,15 @@ Ext.define ("viewer.viewercontroller.controller.ToolMapClick",{
     /**
      *@constructor
      *@see viewer.viewercontroller.controller.Tool#constructor
-     *Extra options:
-     *@param conf.name the name     
-     *@param conf.handler the handling object. 2 values needed:
-     *@param conf.handler.fn the function that is called when clicked on the map with this tool. 
+     *@param {Object} conf Extra options:
+     *@property conf.name the name
+     *@property conf.handler the handling object. 2 values needed:
+     *@property conf.handler.fn the function that is called when clicked on the map with this tool.
      * The given function is called with 2 arguments:
      * tool: this tool
      * result: a result object with .coord object that has a .x and .y  as world coords.
      * Optional the result object can also have a x or y as screen pixels.
-     *@param conf.handler.scope the scope of the function
+     *@property conf.handler.scope the scope of the function
      */    
     constructor: function (conf){              
         viewer.viewercontroller.controller.ToolMapClick.superclass.constructor.call(this, conf);

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersLayer.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersLayer.js
@@ -164,8 +164,8 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersLayer",{
     },    
 
     /**
-     * Sets the visibility of the layer
-     * @visible true or false
+     * Sets the visibility of the layer.
+     * @param visible true or false
      */
     setVisible : function (visible){
         this.visible=visible;

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
@@ -668,8 +668,7 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
     },
     addComponent: function(component){
         if(Ext.isEmpty(component)){
-            this.viewerController.logger.warning("Empty component added to OpenLayersMapComponent. \n\
-                Properly not yet implemented");
+            this.viewerController.logger.warning("Empty component added to OpenLayersMapComponent. \nProbably not yet implemented");
         }else{
             //add the component to the map
             this.getMap().getFrameworkMap().addControl(component.getFrameworkObject());

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersSnappingController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersSnappingController.js
@@ -25,7 +25,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     /**
      * editable/drawable OpenLayers Vector layer.
      * @private
-     * @TODO refactor to array as each edit & draw control have their own layer
+     * TODO refactor to array as each edit & draw control have their own layer
      */
     frameworkLayer: null,
     /** snapping control.*/
@@ -58,7 +58,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     /**
      * @constructor
      * @param {Object} config
-     * @returns {viewer.viewercontroller.openlayers.OpenLayersSnappingLayer|OpenLayersSnappingControllerAnonym$0.constructor}
+     * @returns {viewer.viewercontroller.openlayers.OpenLayersSnappingController}
      */
     constructor: function (config) {
         viewer.viewercontroller.openlayers.OpenLayersSnappingController.superclass.constructor.call(this, config);
@@ -93,7 +93,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
      * Attach the snapping control to the Openlayers layers of the added
      * editing or drawing layer or other layer.
      * @param {type} map
-     * @param {type} options
+     * @param {Object} options
      */
     layerAdded: function (map, options) {
         if (options.layer &&
@@ -105,7 +105,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     },
     /**
      * add the snapping target.
-     * @param {type} appLayer
+     * @param {Object} appLayer
      */
     addAppLayer: function (appLayer) {
         var me = this;
@@ -125,7 +125,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
      * fetch/load geometries.
      * @param {type} geomAttribute
      * @param {type} featureService
-     * @param {type} appLayer
+     * @param {Object} appLayer
      * @returns {void}
      */
     loadAttributes: function (geomAttribute, featureService, appLayer) {
@@ -154,7 +154,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     },
     /**
      * remove the snapping target.
-     * @param {type} appLayer
+     * @param {Object} appLayer
      */
     removeLayer: function (appLayer) {
         this.deactivate();
@@ -246,7 +246,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     },
     /**
      *
-     * @param {type} appLayer
+     * @param {Object} appLayer
      * @returns {String} local layer name
      * @see getAppLayer
      */
@@ -255,8 +255,8 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersSnappingController", {
     },
     /**
      *
-     * @param {type} name local name
-     * @returns {OpenLayersSnappingControllerAnonym$0@pro;config@pro;viewerController@call;getAppLayerById}
+     * @param {String} name local name
+     * @returns {Object}
      *
      * @see getlayerName
      */

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/Utils.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/Utils.js
@@ -46,12 +46,11 @@ OpenLayers.Control.MouseWheelZoom = OpenLayers.Class(OpenLayers.Control, {
             }
         });
     },
-    /**      *
+    /**      
      * Method: wheelChange
      * Copied from: @see OpenLayers.Control.Navigation#wheelChange
-     * Parameters:
-     * evt - {Event}
-     * deltaZ - {Integer}
+     * @param {Event} evt
+     * @param {Integer} deltaZ
      */
     wheelChange: function(evt, deltaZ) {
         var currentZoom = this.map.getZoom();
@@ -77,9 +76,8 @@ OpenLayers.Control.MouseWheelZoom = OpenLayers.Class(OpenLayers.Control, {
      * Copied from: @see OpenLayers.Control.Navigation#wheelUp
      * User spun scroll wheel up
      *
-     * Parameters:
-     * evt - {Event}
-     * delta - {Integer}
+     * @param {Event} evt
+     * @param {Integer} delta
      */
     wheelUp: function(evt, delta) {
         this.wheelChange(evt, delta || 1);
@@ -90,9 +88,8 @@ OpenLayers.Control.MouseWheelZoom = OpenLayers.Class(OpenLayers.Control, {
      * Copied from: @see OpenLayers.Control.Navigation#wheelDown
      * User spun scroll wheel down
      *
-     * Parameters:
-     * evt - {Event}
-     * delta - {Integer}
+     * @param {Event} evt
+     * @param {Integer} delta
      */
     wheelDown: function(evt, delta) {
         this.wheelChange(evt, delta || -1);
@@ -307,11 +304,7 @@ OpenLayers.Control.LoadingPanel = OpenLayers.Class(OpenLayers.Control, {
 
 /**
  * Create a Click controller
- * @param options
- * @param options.handlerOptions options passed to the OpenLayers.Handler.Click
- * @param options.click the function that is called on a single click (optional)
- * @param options.dblclick the function that is called on a dubble click (optional)
- */
+*/
 OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control,{
     defaultHandlerOptions: {
         'single': true,
@@ -319,6 +312,14 @@ OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control,{
         'stopSingle': false,
         'stopDouble': false
     },
+    /**
+     *
+     * @param {Object} options having:
+     *        options.handlerOptions: options passed to the OpenLayers.Handler.Click,
+     *        options.click the function that is called on a single click (optional),
+     *        options.dblclick the function that is called on a dubble click (optional)
+     * @returns {OpenLayers.Control.Click}
+     */
     initialize: function(options) {
         this.handlerOptions = OpenLayers.Util.extend(
             {}, this.defaultHandlerOptions

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/components/OpenLayersMaptip.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/components/OpenLayersMaptip.js
@@ -22,6 +22,12 @@
 Ext.define ("viewer.viewercontroller.openlayers.components.OpenLayersMaptip",{
     extend: "viewer.viewercontroller.openlayers.OpenLayersComponent",    
     map: null,
+    /**
+     * @constructor
+     * @param {Object} conf
+     * @param {type} map
+     * @returns {viewer.viewercontroller.openlayers.components.OpenLayersMaptip}
+     */
     constructor: function(conf,map){
         viewer.viewercontroller.openlayers.components.OpenLayersMaptip.superclass.constructor.call(this,conf);
         this.map=map;
@@ -46,16 +52,16 @@ Ext.define ("viewer.viewercontroller.openlayers.components.OpenLayersMaptip",{
         return this.frameworkObject;
     },
     onPause: function(object){         
+        var lonLat = this.map.getFrameworkMap().getLonLatFromViewPortPx(object.xy);
         /**
          * @field
-         * Occures when the map wants a maptip.
-         * @param map the map where this event occured
-         * @param options.x x in pixels on the screen
-         * @param options.y y in pixels on the screen
-         * @param options.coord.x the x coord in world coords
-         * @param options.coord.y the y coord in world coords
+         * Occurs when the map wants a maptip.
+         * @property map the map where this event occured
+         * @property options.x x in pixels on the screen
+         * @property options.y y in pixels on the screen
+         * @property options.coord.x the x coord in world coords
+         * @property options.coord.y the y coord in world coords
          */
-        var lonLat= this.map.getFrameworkMap().getLonLatFromViewPortPx(object.xy);
         var options={
             x: object.xy.x,
             y: object.xy.y,

--- a/viewer/src/main/webapp/viewer-html/components/Component.js
+++ b/viewer/src/main/webapp/viewer-html/components/Component.js
@@ -42,10 +42,11 @@ Ext.define("viewer.components.Component",{
     haveSprite: false,
     /**
     * @constructs
-    * @param config.name {String} the unique name of the object
-    * @param config.div {DomElement} the div where the component must be placed
-    * @param config.viewerController {ViewerController} a reference to the ViewerController
-    * @param config.isPopup {Boolean} Indicates whether or not to render this component to a popup
+    * @param {Object} config configuration object
+    * @property config.name {String} the unique name of the object
+    * @property config.div {DomElement} the div where the component must be placed
+    * @property config.viewerController {ViewerController} a reference to the ViewerController
+    * @property config.isPopup {Boolean} Indicates whether or not to render this component to a popup
     */
     constructor: function(config){
         var me = this;
@@ -104,12 +105,14 @@ Ext.define("viewer.components.Component",{
     },
 
     /**
-     * Renders a button in the div (holder)
+     * Renders a button in the div (holder).
      * if a titlebarIcon is set, its used to generate in the button. Otherwise the title or name.
-     * @param options.handler the handler function called when the button is clicked.
-     * @param options.text the text in the button
-     * @param options.icon the url to a  icon for this button.
-     * @param options.tooltip the tooltip for this button.
+     *
+     * @param {Object} options config options for the button
+     * @property options.handler the handler function called when the button is clicked.
+     * @property options.text the text in the button
+     * @property options.icon the url to a  icon for this button.
+     * @property options.tooltip the tooltip for this button.
      */
     renderButton: function(options) {
         var me = this,


### PR DESCRIPTION
Manage all maven plugins and as many properties as possible from the parent pom and not all over the project. Since we are now on Java 7, update some plugins and other build stuff. 
- [x] manage maven plugins in the parent pom
- [x] update plugin versions
- [x] require maven version 3.2.5 as a minimum
- [x] factor out some shared properties
- [x] fix up jsdoc warnings and errors as the new compiler is more strict with those
