### PR TITLE
Provide a tomcat instance on travis-ci for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,22 @@ language: java
 
 sudo: false
 
+addons:
+  postgresql: "9.4"
+
+before_install:
+  - psql -U postgres -a -c "CREATE ROLE flamingo4 LOGIN PASSWORD 'flamingo4' SUPERUSER CREATEDB;"
+  - psql -U postgres -a -c 'create database flamingo4;'
+  - psql -U postgres -a -c 'ALTER DATABASE flamingo4 OWNER TO flamingo4;'
+
 install:
   # install without testing
   - mvn install -U -DskipTests -B -V -fae -q
 
 script:
   # execute unit and integration tests
-  - mvn -e test verify -B
+  - mvn -e test -B
+  - mvn -e verify -B -Ptravis-ci
   # on java 8 run a javadoc build to check for errors
   - if [ "$TRAVIS_JDK_VERSION" == oraclejdk8 ]; then
          mvn javadoc:javadoc;

--- a/pom.xml
+++ b/pom.xml
@@ -449,29 +449,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*IntegrationTest.java</exclude>
                     </excludes>
-                    <!-- work around voor java 7. see:
-                    http://stackoverflow.com/questions/10869127/maven-build-causes-verifyerror-with-java-1-7
-                    -XX:-UseSplitVerifier
-                    <argLine>${surefire.argline}</argLine>
-                    -->
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <includes>
                         <include>**/*IntegrationTest.java</include>
                     </includes>
                     <testFailureIgnore>true</testFailureIgnore>
-                    <systemPropertyVariables></systemPropertyVariables>
-                    <!-- argLine>-XX:-UseSplitVerifier</argLine -->
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <flamingo.version>4.6.1-SNAPSHOT</flamingo.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <geotools.version>14.1</geotools.version>
         <powermock.version>1.5.5</powermock.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
@@ -444,6 +445,43 @@
                 <configuration>
                     <pushChanges>true</pushChanges>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                    <!-- work around voor java 7. see:
+                    http://stackoverflow.com/questions/10869127/maven-build-causes-verifyerror-with-java-1-7
+                    -XX:-UseSplitVerifier
+                    <argLine>${surefire.argline}</argLine>
+                    -->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IntegrationTest.java</include>
+                    </includes>
+                    <testFailureIgnore>true</testFailureIgnore>
+                    <systemPropertyVariables></systemPropertyVariables>
+                    <!-- argLine>-XX:-UseSplitVerifier</argLine -->
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -134,11 +134,18 @@ public class DatabaseSynchronizer implements Servlet {
     }
 
     /**
+     * Determine the update number. The updates list has an "init"
+     * {@link UpdateElement} + a number of numbered patch
+     * {@link UpdateElement}'s, this method returns the key of the last patch.
      *
-     * @return the highest metadata number
+     * @return the highest/update metadata number
      */
-    public static int getUpdateNumber() {
-        return updates.keySet().size() - 1;
+    public static String getUpdateNumber() {
+        String update = "";
+        for (Entry<String, UpdateElement> e : updates.entrySet()) {
+            update = e.getKey();
+        }
+        return update;
     }
 
     /**

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -132,6 +132,15 @@ public class DatabaseSynchronizer implements Servlet {
 
         // NB when adding an update also update the metadata version in the testdata.sql file around line 326
     }
+
+    /**
+     *
+     * @return the highest metadata number
+     */
+    public static int getUpdateNumber() {
+        return updates.keySet().size() - 1;
+    }
+
     /**
      * Function is called in init() of servlet.
      * Starts the updating process.

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -172,14 +172,6 @@
             <artifactId>xercesImpl</artifactId>
             <version>2.7.1</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.flamingo-mc</groupId>
-            <artifactId>viewer-config-persistence</artifactId>
-            <type>test-jar</type>
-            <scope>test</scope>
-            <version>${project.version}</version>
-        </dependency>
     </dependencies>
 
     <!-- plugin repo for complosure -->
@@ -449,12 +441,48 @@
                 -Dtest.persistence.unit=viewer-config-oracle
                 voor hsqldb
                 -Dtest.persistence.unit=viewer-config-hsqldb
-                de schema's voor postgresql en oracle worden niet automatisch aangemaakt.
+                de schema's de test worden niet automatisch aangemaakt.
                 -->
                 <test.persistence.unit>viewer-config-postgresql</test.persistence.unit>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>9.4.1207</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.0.0</version>
+                        <executions>
+                            <execution>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <files>
+                                        <file>src/test/resources/postgres.properties</file>
+                                    </files>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <testFailureIgnore>false</testFailureIgnore>
+                            <systemPropertyVariables>
+                                <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
+                            </systemPropertyVariables>
+                            <useFile>false</useFile>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
@@ -463,8 +491,7 @@
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/context.xml</contextFile>
                             <systemProperties>
-                                <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
-                            <systemProperties>
+                            </systemProperties>
                         </configuration>
                         <executions>
                             <execution>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -172,6 +172,14 @@
             <artifactId>xercesImpl</artifactId>
             <version>2.7.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.flamingo-mc</groupId>
+            <artifactId>viewer-config-persistence</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <!-- plugin repo for complosure -->
@@ -431,5 +439,67 @@
             </plugin>
         </plugins>
     </build>
-
+    <profiles>
+        <profile>
+            <id>travis-ci</id>
+            <properties>
+                <!-- om unit tests met postgres te draaien gebruik je
+                -Dtest.persistence.unit=viewer-config-postgresql
+                voor oracle:
+                -Dtest.persistence.unit=viewer-config-oracle
+                voor hsqldb
+                -Dtest.persistence.unit=viewer-config-hsqldb
+                de schema's voor postgresql en oracle worden niet automatisch aangemaakt.
+                -->
+                <test.persistence.unit>viewer-config-postgresql</test.persistence.unit>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.tomcat.maven</groupId>
+                        <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>2.2</version>
+                        <configuration>
+                            <port>9090</port>
+                            <contextFile>src/test/tomcatconf/context.xml</contextFile>
+                            <systemProperties>
+                                <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
+                            <systemProperties>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>tomcat-startup</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <fork>true</fork>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tomcat-shutdown</id>
+                                <goals>
+                                    <goal>shutdown</goal>
+                                </goals>
+                                <phase>post-integration-test</phase>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.mail</groupId>
+                                <artifactId>mail</artifactId>
+                                <version>1.4.7</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.postgresql</groupId>
+                                <artifactId>postgresql</artifactId>
+                                <version>9.4.1207</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/viewer/src/test/java/nl/b3p/viewer/ViewerIntegrationTest.java
+++ b/viewer/src/test/java/nl/b3p/viewer/ViewerIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2015 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import javax.persistence.EntityManager;
+import nl.b3p.viewer.config.metadata.Metadata;
+import nl.b3p.viewer.util.databaseupdate.DatabaseSynchronizer;
+import nl.b3p.viewer.util.TestUtil;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author Mark Prins <mark@b3partners.nl>
+ */
+public class ViewerIntegrationTest extends TestUtil {
+
+    /**
+     * the server root url. {@value}
+     */
+    public static final String BASE_TEST_URL = "http://localhost:9090/";
+
+    /**
+     * our test client.
+     */
+    private static CloseableHttpClient client;
+    /**
+     * our test response.
+     */
+    private HttpResponse response;
+
+    @BeforeClass
+    public static void setUpClass() {
+        client = HttpClientBuilder.create().build();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        client.close();
+    }
+
+    /**
+     * Test if the Flaming viewer application has started.
+     *
+     * @throws UnsupportedEncodingException if any
+     * @throws IOException if any
+     */
+    @Test
+    public void request() throws UnsupportedEncodingException, IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL + "/viewer/index.jsp"));
+
+        final String body = new String(EntityUtils.toByteArray(response.getEntity()), "UTF-8");
+        assertNotNull("Response body should not be null.", body);
+
+        // when looking at a pristine database it will report an application error
+        // assertThat("Response status is 500/Error.", response.getStatusLine().getStatusCode(),
+        //        equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+    }
+
+    /**
+     * test if the database has the right metadata version.
+     */
+    @Test
+    public void testMetadataVersion() {
+        // get 'database_version' from table metadata and check that is has the value of '15'
+        int expected = DatabaseSynchronizer.getUpdateNumber();
+        List<Metadata> metadata = entityManager.createQuery("From Metadata where configKey = :v").setParameter("v", Metadata.DATABASE_VERSION_KEY).getResultList();
+        assertFalse("There should be at least one metadata record.", metadata.isEmpty());
+
+        int actual = Integer.parseInt(metadata.get(0).getConfigValue());
+        assertEquals("The database version should be the same.", expected, actual);
+    }
+}

--- a/viewer/src/test/resources/log4j.xml
+++ b/viewer/src/test/resources/log4j.xml
@@ -4,7 +4,7 @@
     <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
         <param name="Threshold" value="debug" />
         <layout class="org.apache.log4j.PatternLayout">
-            <param name="ConversionPattern" value="%5p %d{HH:mm:ss} (%C#%M:%L) - %m%n" />
+            <param name="ConversionPattern" value="VIEWER-TEST: %5p %d{HH:mm:ss} (%C#%M:%L) - %m%n" />
         </layout>
     </appender>
     <root>

--- a/viewer/src/test/resources/postgres.properties
+++ b/viewer/src/test/resources/postgres.properties
@@ -1,0 +1,4 @@
+postgres.username=flamingo4
+postgres.password=flamingo4
+postgres.driverClassName=org.postgresql.Driver
+postgres.url=jdbc:postgresql://localhost:5432/flamingo4

--- a/viewer/src/test/tomcatconf/context.xml
+++ b/viewer/src/test/tomcatconf/context.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context path="/viewer">
+    <Parameter
+        name="componentregistry.path"
+        override="false"
+        value="/viewer-html/components"
+    />
+    
+    <Resource
+        name="jdbc/geo_viewer"
+        auth="Container"
+        type="javax.sql.DataSource"
+        username="flamingo4"
+        password="flamingo4"
+        driverClassName="org.postgresql.Driver"
+        url="jdbc:postgresql://localhost:5433/flamingo4"
+        maxActive="40"
+        validationQuery="select 1"
+        timeBetweenEvictionRunsMillis="30000"
+        minEvictableIdleTimeMillis="5000"
+    />
+
+    <Resource name="mail/session"
+              auth="Container"
+              type="javax.mail.Session"
+              mail.smtp.host="localhost"
+              mail.smtp.from="no-reply@b3partners.nl"
+    />
+
+    <Realm className="org.apache.catalina.realm.CombinedRealm">
+        <Realm allRolesMode="authOnly"
+               className="org.apache.catalina.realm.DataSourceRealm"
+               dataSourceName="jdbc/geo_viewer"
+               digest="SHA-1"
+               roleNameCol="group_"
+               userCredCol="password"
+               userNameCol="username"
+               userRoleTable="user_groups"
+               userTable="user_"
+        />
+        <!-- Use JNDIRealm for authenticating against a LDAP server (such as
+             Active Directory):
+             http://tomcat.apache.org/tomcat-6.0-doc/config/realm.html
+             http://tomcat.apache.org/tomcat-6.0-doc/realm-howto.html#JNDIRealm
+        -->
+        <!--Realm className="org.apache.catalina.realm.JNDIRealm"
+            allRolesMode="authOnly"
+            connectionURL="ldap://ldap:389"
+            connectionName="cn=ServiceUser,ou=Services,o=MyOrg"
+            connectionPassword=""
+            userBase="o=MyOrg"
+            userSubtree="true"
+            userSearch="cn={0}"
+            commonRole="ExtendedUser"
+        /-->
+    </Realm>
+</Context>

--- a/viewer/src/test/tomcatconf/context.xml
+++ b/viewer/src/test/tomcatconf/context.xml
@@ -6,14 +6,16 @@
         value="/viewer-html/components"
     />
     
+    <!-- properties below are expanded at runtime and are available
+    in ../resources/postgres.properties -->
     <Resource
         name="jdbc/geo_viewer"
         auth="Container"
         type="javax.sql.DataSource"
-        username="flamingo4"
-        password="flamingo4"
-        driverClassName="org.postgresql.Driver"
-        url="jdbc:postgresql://localhost:5433/flamingo4"
+        username="${postgres.username}"
+        password="${postgres.password}"
+        driverClassName="${postgres.driverClassName}"
+        url="${postgres.url}"
         maxActive="40"
         validationQuery="select 1"
         timeBetweenEvictionRunsMillis="30000"
@@ -38,20 +40,5 @@
                userRoleTable="user_groups"
                userTable="user_"
         />
-        <!-- Use JNDIRealm for authenticating against a LDAP server (such as
-             Active Directory):
-             http://tomcat.apache.org/tomcat-6.0-doc/config/realm.html
-             http://tomcat.apache.org/tomcat-6.0-doc/realm-howto.html#JNDIRealm
-        -->
-        <!--Realm className="org.apache.catalina.realm.JNDIRealm"
-            allRolesMode="authOnly"
-            connectionURL="ldap://ldap:389"
-            connectionName="cn=ServiceUser,ou=Services,o=MyOrg"
-            connectionPassword=""
-            userBase="o=MyOrg"
-            userSubtree="true"
-            userSearch="cn={0}"
-            commonRole="ExtendedUser"
-        /-->
     </Realm>
 </Context>


### PR DESCRIPTION
This PR introduces a maven profile called "travis-ci" in the viewer artifact that will start a tomcat instance in `pre-integration-test` phase and stop it in `post-integration-test` phase; this leaves the `integration-test` phase to run integration tests.
One integration test was added with two testcases, one to check if flamingo is running (by requesting http://localhost:9090/viewer/) and one testcase to check the flamingo database version. A property file (postgres.properties) is available to modify the database connection params.

The travis configuration has been modified to set up a postgres (9.4) instance with an empty database (flamingo4) with a role (flamingo4/flamingo4).

These changes also make it possible to spin up a local viewer in tomcat on port 9090 using `mvn package tomcat7:run -Ptravis-ci` You may need to change the database params in `viewer/src/test/resources/postgres.properties` to match your environment.
- [x] creates an empty database and user
- [x] spin up a tomcat instance with a viewer webapp loaded
- [x] simple testcase to check if the url is up
- [x] add integration test for database contents

see also #504 
