### PR TITLE
Prevent failure on javadoc errors during release when using java 8 runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ install:
 script:
   # execute unit and integration tests
   - mvn -e test verify -B
+  # on java 8 run a javadoc build to check for errors
+  - if [ "$TRAVIS_JDK_VERSION" == oraclejdk8 ]; then
+         mvn javadoc:javadoc;
+    fi
 
 jdk:
   - openjdk7

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ApplicationSettingsActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -437,7 +437,10 @@ public class ApplicationSettingsActionBean extends ApplicationActionBean {
       /**
      * Checks if a Application with given name already exists and if needed
      * returns name with sequence number in brackets added to make it unique.
+     *
      * @param name Name to make unique
+     * @param version version to check
+     *
      * @return A unique name for a FeatureSource
      */
     public static String findUniqueVersion(String name, String version) {

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/BookmarkActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/BookmarkActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,7 +45,7 @@ import org.stripesstuff.stripersist.Stripersist;
 
 /**
  *
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * @author Meine Toonen meinetoonen@b3partners.nl
  */
 public class BookmarkActionBean implements ActionBean{
 

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayarSourceActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayarSourceActionBean.java
@@ -224,11 +224,12 @@ public class LayarSourceActionBean implements ActionBean {
     }
     /**
      * Get the attribute names for the given FeatureType that are not of type Geometry
-     * @return A JSON object formated as:
+     * @return A JSON object formated as: <pre>
      *  Object {
-     *      attributes [<attributeName>,<attributeName>]
+     *      attributes ['attributeName','attributeName',...],
      *      error
      *  }
+     * </pre>
      */
     public Resolution getAttributes () throws JSONException{
         final JSONObject json = new JSONObject();

--- a/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStore.java
+++ b/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStore.java
@@ -40,9 +40,10 @@ import org.opengis.feature.type.Name;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 /**
- * DataStore for ArcGIS Server REST API for MapServer or FeatureServer (read-only) services. 
+ * DataStore for ArcGIS Server REST API for MapServer or FeatureServer
+ * (read-only) services.
  * <p>
- * Because of the nature of the REST API, paging is not suited for stateless 
+ * Because of the nature of the REST API, paging is not suited for stateless
  * code such as web pages. When you request a FeatureReader with a Query with
  * paging parameters set using {@link org.geotools.data.Query#setStartIndex} and
  * {@link org.geotools.data.Query#setMaxFeatures}, the data store must always
@@ -50,34 +51,39 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
  * features in the page using the object ids. If the feature collection is very
  * large this can take a long time.
  * <p>
- * It is possible to request the object ids matching the Query using {@link ArcGISFeatureReader#getObjectIds()}
- * and use this List later on to request features with {@link ArcGISFeatureReader#getFeaturesByObjectIds(java.util.List)}.
- * The list with object ids can be cached where appropriate and be used to request a 
+ * It is possible to request the object ids matching the Query using
+ * {@link ArcGISFeatureReader#getObjectIds()} and use this List later on to
+ * request features with
+ * {@link ArcGISFeatureReader#getFeaturesByObjectIds(java.util.List)}. The list
+ * with object ids can be cached where appropriate and be used to request a
  * sublist for paging.
  * <p>
- * Unfortunately the object ids cannot be used as a row id in a query to pass on 
- * the start index and max features. While sometimes the object ids start at 1 
+ * Unfortunately the object ids cannot be used as a row id in a query to pass on
+ * the start index and max features. While sometimes the object ids start at 1
  * and increment for each subsequent feature, this is not guaranteed.
  * <p>
  * Although ArcGIS server sends ETag headers in response to requests, there is
  * not really a performance improvement using conditional HTTP requests - with
- * very large feature collections the performance is abysmal no matter what. 
- * Because of this the HTTP cache (using {@link <a href=http://httpcache4j.codehaus.org/">HttpCache4j</a>})
- * is disabled by default so the HttpCache4j libraries are not required. To enable
- * HTTP caching you must patch HttpCache4j to support non-conformant ETag headers
- * sent by ESRI (see {@link CachingHTTPClient}), rename CachingHTTPClient.java.disabled
- * and uncomment the relevant lines in this class and {@link ArcGISDataStoreFactory}. 
- * Then pass a HTTPCache instance to the constructor or using the HTTP_CACHE
- * Param for the factory. 
+ * very large feature collections the performance is abysmal no matter what.
+ * Because of this the HTTP cache (using
+ * <a href="http://httpcache4j.codehaus.org/">HttpCache4j</a>) is disabled by
+ * default * so the HttpCache4j libraries are not required. To enable HTTP caching you
+ * must patch HttpCache4j to support non-conformant ETag headers sent by ESRI
+ * (see CachingHTTPClient, renamed to CachingHTTPClient.java.disabled) and
+ * uncomment the relevant lines in this class and
+ * {@link ArcGISDataStoreFactory}. Then pass a HTTPCache instance to the
+ * constructor or using the HTTP_CACHE Param for the factory.
  * <p>
- * When reading features ArcGIS server may produce invalid JSON when it apparently 
- * has an invalid coordinate and sends "*****************" instead. Like non-well
- * formed XML we do not accept this so ArcGISFeatureReader.next() may throw an exception 
- * (consistently, the ESRI WFS server also produces invalid posLists this way).
+ * When reading features ArcGIS server may produce invalid JSON when it
+ * apparently has an invalid coordinate and sends "*****************" instead.
+ * Like non-well formed XML we do not accept this so ArcGISFeatureReader.next()
+ * may throw an exception (consistently, the ESRI WFS server also produces
+ * invalid posLists this way).
  * <p>
- * The standard ESRI spatial querying restrictions apply: only one spatial operator
- * with the default geometry and a literal geometry operand is supported and can 
- * only be combined with other attribute queries in a Boolean AND.
+ * The standard ESRI spatial querying restrictions apply: only one spatial
+ * operator with the default geometry and a literal geometry operand is
+ * supported and can only be combined with other attribute queries in a Boolean
+ * AND.
  *
  * @author Matthijs Laan
  */

--- a/viewer-commons/src/main/java/nl/b3p/mail/Mailer.java
+++ b/viewer-commons/src/main/java/nl/b3p/mail/Mailer.java
@@ -65,7 +65,7 @@ public class Mailer {
      * @param mailContent The content of the message
      * @param attachment The attachment to be sent
      * @param filename Give that attachment a naem.
-     * @throws Exception 
+     * @throws Exception if any
      */
     public static void sendMail(String fromName, String fromEmail, String email, String subject, String mailContent, File attachment, String filename) throws Exception {
     

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/RemoveEmptyMapValuesUtil.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/RemoveEmptyMapValuesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,9 +33,12 @@ public class RemoveEmptyMapValuesUtil {
      * MAP. Hibernate fails to remove map entries with a null value when calling
      * clear() on a map on Oracle. This leads to duplicate key violations when
      * updating layer details.
-     * 
-     * @PreUpdate/@PrePersist nor @EntityListeners do not work consistenly with 
-     * cascaded objects in Hibernate, so call this manually!
+     *
+     * {@code @PreUpdate}/{@code @PrePersist} nor {@code @EntityListeners} do
+     * not work consistenly with cascaded objects in Hibernate, so call this
+     * manually!
+     *
+     * @param map the map to clean up
      */
     public static void removeEmptyMapValues(Map map) {
         List keysToRemove = new ArrayList();

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Application.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -368,8 +368,19 @@ public class Application {
     }
     
     /**
-     * Create a JSON representation for use in browser to start this application
-     * @return
+     * Create a JSON representation for use in browser to start this
+     * application.
+     *
+     * @param request servlet request to check authorisation
+     * @param validXmlTags {@code true} if valid xml names should be produced
+     * @param onlyServicesAndLayers {@code true} if only services and layers
+     * should be returned
+     * @param includeAppLayerAttributes {@code true} if applayer attributes
+     * should be included
+     * @param includeRelations {@code true} if relations should be included
+     * @param em the entity manager to use
+     * @return a json representation of this object
+     * @throws JSONException if transforming to json fails
      */
     public String toJSON(HttpServletRequest request, boolean validXmlTags, boolean onlyServicesAndLayers, boolean includeAppLayerAttributes, boolean includeRelations, EntityManager em) throws JSONException {
         JSONObject o = null;
@@ -572,6 +583,7 @@ public class Application {
      * In this method an Map is created in the same way as deepCopy creates. This Map is used for converting the layerIds in the
      * component configuration.
      * @param old The Application to which the layerIds should be matched.
+     * @param em the entity manager to use
      */
     public void transferMashup (Application old, EntityManager em){
         originalToCopy = new HashMap();

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ApplicationLayer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ApplicationLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -165,10 +165,14 @@ public class ApplicationLayer {
     //</editor-fold>
     
     /**
-     * Get all the attributes from this applicationLayer that are from the given 
-     * SimpleFeatureType (or the SimpleFeatureType == null, for configured attributes
-     * that don't have a SimpleFeatureType set yet)
-     * Optional the joined SimpleFeatureType attributes that are joined can be added (includeJoined=true)
+     * Get all the attributes from this applicationLayer that are from the given
+     * SimpleFeatureType (or the SimpleFeatureType == null, for configured
+     * attributes that don't have a SimpleFeatureType set yet). Optional the
+     * joined SimpleFeatureType attributes that are joined can be added
+     * (includeJoined=true)
+     *
+     * @param sft the type to get the attributes
+     * @return list of configured attributes
      */
     public List<ConfiguredAttribute> getAttributes(SimpleFeatureType sft){
         return getAttributes(sft, false, new ArrayList<ConfiguredAttribute>());

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredAttribute.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -277,7 +277,9 @@ public class ConfiguredAttribute {
         return copy;
     }
     /**
-     * Returns full name. That is the id of the featuretype + ":" + attributeName
+     * Returns full name.
+     *
+     * @return the id of the featuretype + ":" + attributeName
      */
     public String getFullName() {
         String uniqueName= "";

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredComponent.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -146,7 +146,9 @@ public class ConfiguredComponent implements Comparable<ConfiguredComponent> {
     
     /**
      * Retrieve the metadata from the component registry for the class of this
-     * component
+     * component.
+     *
+     * @return the configured ViewerComponent for this component
      */
     public ViewerComponent getViewerComponent() {
         return ComponentRegistry.getInstance().getViewerComponent(className);

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Level.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Level.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -225,7 +225,9 @@ public class Level implements Comparable{
     /**
      * Find the applications this level is used in. Because of mashups a level
      * can be used in more than one application.
-     * @return 
+     *
+     * @param em the entity manager to use
+     * @return the applications this level is part of
      */
     public Set<Application> findApplications(EntityManager em) {
         Level l = this;

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/StartLayer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/StartLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,14 +17,13 @@
 package nl.b3p.viewer.config.app;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import org.apache.commons.beanutils.BeanUtils;
 
 /**
  *
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * @author Meine Toonen meinetoonen@b3partners.nl
  */
 @Entity
 public class StartLayer {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/StartLevel.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/StartLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,7 +24,7 @@ import org.apache.commons.beanutils.BeanUtils;
 
 /**
  *
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * @author Meine Toonen meinetoonen@b3partners.nl
  */
 @Entity
 public class StartLevel {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,14 +38,14 @@ import org.stripesstuff.stripersist.Stripersist;
  * <b>Geo services registry:</b>
  * <ul>
  * <li>Categories: currently disabled, not accessible via user interface</li>
- * <li>Layers of GeoServices: with inheritence, read/write authorizations</i>
+ * <li>Layers of GeoServices: with inheritence, read/write authorizations</li>
  * </ul>
  * <p>
  * <b>Application:</b>
  * <ul>
  * <li>Levels: with inheritence, read authorization only</li>
  * <li>ApplicationLayers of Levels: inherits from Level <i>and</i> the referenced Layer, read/write authorizations</li>
- * <li>ConfiguredComponents</i>
+ * <li>ConfiguredComponents</li>
  * </ul>
  * <p>
  * Authorizations are based on role names which are Group names.
@@ -299,10 +299,11 @@ public class Authorizations {
     /**
      * See if a user can edit geometry attribute of a layer in addition to
      * regular writing. Calling this will also call
-     * {@link #isLayerWriteAuthorized(nl.b3p.viewer.config.services.Layer, javax.servlet.http.HttpServletRequest)}
+     * {@link #isAppLayerWriteAuthorized(nl.b3p.viewer.config.app.Application, nl.b3p.viewer.config.app.ApplicationLayer, javax.servlet.http.HttpServletRequest, javax.persistence.EntityManager)}
      *
-     * @param l
-     * @param request
+     * @param l the layer
+     * @param request the servlet request that has the user credential
+     * @param em the entity manager to use
      * @return {@code true} if the user is allowed to edit the geometry
      * attribute of the layer (the user is not in any of the groups that prevent
      * editing geometry).
@@ -465,6 +466,10 @@ public class Authorizations {
      * returned, everyone is authorized for reading and writing. Note: even if 
      * not null, the "readers" and "writers" properties of the returned 
      * ReadWriteAuthorizations may be equal to EVERYONE.
+     *
+     * @param l the layer to check
+     * @param em the entity manager to use
+     * @return the authorizations
      */
     public static ReadWrite getLayerAuthorizations(Layer l, EntityManager em) {
         synchronized(LOCK) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/AttributeDescriptor.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/AttributeDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2015 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,7 +67,7 @@ public class AttributeDescriptor {
     
     /**
      * Returns the ExtJS
-     * {@link https://docs.sencha.com/extjs/5.1/5.1.0-apidocs/#!/api/Ext.data.field.Field field}
+     * <a href="https://docs.sencha.com/extjs/5.1/5.1.0-apidocs/#!/api/Ext.data.field.Field">field</a>
      * type for this attribute.
      *
      * @return a string representing the field type (one of

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -295,6 +295,9 @@ public abstract class GeoService {
      * 
      * The cache is not updated on changes, so will only represent the database
      * state when loadLayerTree() was last called.
+     *
+     * @param em the entity manager to use
+     * @return the list of layers of this service
      */
     public List<Layer> loadLayerTree(EntityManager em) {
         if(layers != null) {
@@ -485,6 +488,9 @@ public abstract class GeoService {
     /**
      * Gets a single layer without loading all layers. If multiple layers exist
      * with the same name, a random non-virtual layer is returned.
+     *
+     * @param layerName the name of the layer to find
+     * @return the named layer
      */
     public Layer getSingleLayer(final String layerName) {
         try {
@@ -505,7 +511,9 @@ public abstract class GeoService {
      * Returns the layer with the given name in this server. The first layer in
      * a depth-first tree traversal with the name is returned. If a child has
      * the same name as its parent, the child is returned.
+     *
      * @param layerName the layer name to search for
+     * @param em the entity manager to use
      * @return the Layer or null if not found
      */
     public Layer getLayer(final String layerName, EntityManager em) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/JDBCFeatureSource.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/JDBCFeatureSource.java
@@ -83,8 +83,10 @@ public class JDBCFeatureSource extends UpdatableFeatureSource{
     }
     
     /**
-     * Creates list of featuretypes for this FeatureSource
-     * @return list of featuretypes.
+     * Creates list of featuretypes for this FeatureSource.
+     *
+     * @return list of featuretypes
+     * @throws java.lang.Exception if any
      */
     public List<SimpleFeatureType> createFeatureTypes() throws Exception{
         return createFeatureTypes(new WaitPageStatus());

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/Layer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/Layer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2015 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -306,6 +306,8 @@ public class Layer implements Cloneable, Serializable {
      * Copy user modified properties of given layer onto this instance. Used for
      * updating the topLayer. Not called for other layers, those instances are
      * updated with update().
+     *
+     * @param other the source of properties to copy
      */
     protected void copyUserModifiedProperties(Layer other) {
         setTitleAlias(other.getTitleAlias());
@@ -339,8 +341,9 @@ public class Layer implements Cloneable, Serializable {
 
     /**
      * Checks if the layer is bufferable.
-     * if service type of this layer is ArcIms or ArcGis or if the layer has a featuretype
-     * return true, otherwise return false
+     * 
+     * @return {@code true} if service type of this layer is ArcIms or ArcGis or
+     * if the layer has a featuretype, {@code false} otherwise
      */
     public boolean isBufferable(){
         return getService().getProtocol().equals(ArcIMSService.PROTOCOL) ||
@@ -354,7 +357,10 @@ public class Layer implements Cloneable, Serializable {
     /**
      * Do a depth-first traversal while the visitor returns true. Uses the call
      * stack to save layers yet to visit.
-     * @return true if visitor accepted all layers
+     *
+     * @param visitor the Layer.Visitor
+     * @param em the entity manager to use
+     * @return {@code true} if visitor accepted all layers
      */
     public boolean accept(Layer.Visitor visitor, EntityManager em) {
         for(Layer child: getCachedChildren(em)) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/StyleLibrary.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/StyleLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -134,6 +134,10 @@ public class StyleLibrary {
     /** 
      * Parse SLD XML and create the JSON object as described for the 
      * namedLayerUserStylesJson property.
+     *
+     * @param sldBody SLD to parse
+     * @return a json representation of the sld
+     * @throws java.lang.Exception is any
      */
     public static JSONObject parseSLDNamedLayerUserStyles(InputSource sldBody) throws Exception {
         JSONObject j = new JSONObject();

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/UpdatableFeatureSource.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/UpdatableFeatureSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 B3Partners B.V.
+ * Copyright (C) 2013-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -30,8 +30,12 @@ import org.apache.commons.logging.LogFactory;
  */
 public abstract class UpdatableFeatureSource extends FeatureSource{    
     private static final Log log = LogFactory.getLog(UpdatableFeatureSource.class);
+
     /**
-     * Update this featuresource
+     * Update this featuresource.
+     *
+     * @return the result of the update
+     * @throws java.lang.Exception if any
      */
     public FeatureSourceUpdateResult update() throws Exception{
         final FeatureSourceUpdateResult result = new FeatureSourceUpdateResult(this);         
@@ -79,7 +83,12 @@ public abstract class UpdatableFeatureSource extends FeatureSource{
     }
     
     /**
-     * return a list of featuretypes that are currently present in the FeatureSource
+     * return a list of featuretypes that are currently present in the
+     * FeatureSource.
+     *
+     * @param wps status page to monitor featuretype creation
+     * @return a list of created featuretypes
+     * @throws java.lang.Exception if any
      */
     public abstract List<SimpleFeatureType> createFeatureTypes(WaitPageStatus wps) throws Exception;
 }

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WFSFeatureSource.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WFSFeatureSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -67,6 +67,7 @@ public class WFSFeatureSource extends UpdatableFeatureSource {
     /**
      * Creates list of featuretypes for this FeatureSource
      * @return list of featuretypes.
+     * @throws java.lang.Exception if any
      */
     public List<SimpleFeatureType> createFeatureTypes() throws Exception{
         return createFeatureTypes(new WaitPageStatus());

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -105,6 +105,8 @@ public class WMSService extends GeoService implements Updatable {
      * on a simple HTTP server. According to the standard the URL in the Capabilities
      * should be used, so set this to false by default except if the user requests
      * an override.
+     *
+     * @return true when set
      */
     public Boolean getOverrideUrl() {
         return overrideUrl;
@@ -131,9 +133,13 @@ public class WMSService extends GeoService implements Updatable {
     /**
      * Load WMS metadata from URL or only check if the service is online when
      * PARAM_ONLINE_CHECK_ONLY is true.
+     *
      * @param url The location of the WMS.
      * @param params Map containing parameters, keys are finals in this class.
      * @param status For reporting progress.
+     * @param em the entity manager to use
+     * @return the service as retrieved from the url
+     * @throws java.lang.Exception if any
      */
     @Override
     public WMSService loadFromUrl(String url, Map params, WaitPageStatus status, EntityManager em) throws Exception {
@@ -163,7 +169,15 @@ public class WMSService extends GeoService implements Updatable {
     }
 
     /**
-     * Do the actual loading work.
+     * Does the actual loading work.
+     *
+     * @param wms WMS service
+     * @param params unused?
+     * @param status progress page
+     * @param em the entity manager to use
+     * @throws IOException when retrieving the capabilities
+     * @throws MalformedURLException if wms capabilities has improper urls
+     * @throws ServiceException if any occurs parsng the capabilities etc.
      */
     protected void load(WebMapServer wms, Map params, WaitPageStatus status, EntityManager em) throws IOException, MalformedURLException, ServiceException {
         ServiceInfo si = wms.getInfo();
@@ -231,6 +245,11 @@ public class WMSService extends GeoService implements Updatable {
     
     /**
      * Construct the GeoTools WebMapServer metadata object.
+     *
+     * @return the webmapserver for this service
+     * @throws IOException when the http connection fails
+     * @throws MalformedURLException when the url is invalid
+     * @throws ServiceException when the service is invalid
      */
     protected WebMapServer getWebMapServer() throws IOException, MalformedURLException, ServiceException {
         HTTPClient client = new SimpleHttpClient();
@@ -696,6 +715,7 @@ public class WMSService extends GeoService implements Updatable {
      * @param wfsUrl the WFS URL
      * @param layerDescriptions description of which feature types of the WFS are
      *   used in layers of this service according to DescribeLayer
+     * @param em the entity manager to use
      */
     public void loadLayerFeatureTypes(String wfsUrl, List<LayerDescription> layerDescriptions, EntityManager em) {
         Map p = new HashMap();

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/LayerListHelper.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/LayerListHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,9 +33,19 @@ import nl.b3p.viewer.config.services.WMSService;
 public class LayerListHelper {
 
     /**
-     * Get a list of Layers from the level and its subLevels
+     * Get a list of Layers from the level and its subLevels.
      *
-     * @param level
+     * @param application the application
+     * @param filterable {@code true} to get filterable layers
+     * @param bufferable {@code true} to get bufferable layers
+     * @param editable {@code true} to get editable layers
+     * @param influence {@code true} to get influence map layers
+     * @param arc {@code true} to get arc layers
+     * @param wfs {@code true} to get wfs layers
+     * @param attribute {@code true} to get attribute
+     * @param hasConfiguredLayers {@code true} to get configured layers
+     * @param possibleLayers a list of layers
+     * @param em the entity manager to use
      * @return A list of Layer objects
      */
     public static List<ApplicationLayer> getLayers(Application application,Boolean filterable, Boolean bufferable, Boolean editable ,Boolean influence ,Boolean arc ,Boolean wfs ,Boolean attribute,

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -54,7 +54,7 @@ import org.stripesstuff.stripersist.Stripersist;
  * - the (at build) auto generated schema-export script
  * - the init script with data that is needed to start.
  * The database is at the latest defined version (fully up to date) so the latest
- * defined version is set in the metadata tabel. >> Update done.
+ * defined version is set in the metadata tabel. &gt;&gt; Update done.
  *
  * If there is a metadata table and a record with the key Metadata.DATABASE_VERSION_KEY
  * then that is the current version of the database model.
@@ -66,12 +66,13 @@ import org.stripesstuff.stripersist.Stripersist;
  * (without database product name) in the 'updates' param with a new version number.
  * When loading the scripts, the loader is first looking for the script with the defined
  * name. For example 'newscript.sql'. If the script is not found the loader is searching
- * for the script with the name '<database product name in lower case>-<script name>' for example:
- * 'postgresql-newscript.sql'.
+ * for the script with the name '&lt;database product name in lower
+ * case&gt;-&lt;script name&gt;' for example: 'postgresql-newscript.sql'.
  * So when a script is the same for all database products (for example simple inserts) you only
- * need to make 1 script '<script name>'. If there are specific database products statements make multiple
- * scripts and name them '<database product name in lower case>-<script name>' in the scripts
- * folder. Add the <script name> in the updates var of this class.
+ * need to make 1 script '&lt;script name&gt;'. If there are
+ * specific database products statements make multiple scripts and name them
+ * '&lt;database product name in lower case&gt;-&gt;script name&gt;' in the
+ * scripts folder. Add the &lt;script name&gt; in the updates var of this class.
  *
  *
  * @author Roy Braam
@@ -132,6 +133,8 @@ public class DatabaseSynchronizer implements Servlet {
     /**
      * Function is called in init() of servlet.
      * Starts the updating process.
+     *
+     * @param em the entity manager to use
      */
     public void doInit(EntityManager em){
 

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizerEM.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizerEM.java
@@ -1,7 +1,18 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (C) 2015-2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package nl.b3p.viewer.util.databaseupdate;
 
@@ -15,11 +26,18 @@ import nl.b3p.viewer.config.app.StartLayer;
 import nl.b3p.viewer.config.app.StartLevel;
 
 /**
- * This class will update the database to its newest version. Here methods will be made, which can be used in the databasesynchronizer class.
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * This class will update the database to its newest version. Here methods will
+ * be made, which can be used in the databasesynchronizer class.
+ *
+ * @author Meine Toonen meinetoonen@b3partners.nl
  */
 public class DatabaseSynchronizerEM {
 
+    /**
+     * convert Applications To start level Layer.
+     *
+     * @param em the entity manager to use
+     */
     public void convertApplicationsToStartLevelLayer(EntityManager em){
         List<Application> apps = em.createQuery("FROM Application", Application.class).getResultList();
         for (Application app : apps) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/ScriptRunner.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/ScriptRunner.java
@@ -40,7 +40,11 @@ public class ScriptRunner {
     private boolean fullLineDelimiter = false;
 
     /**
-     * Default constructor
+     * Default constructor.
+     *
+     * @param connection database connection
+     * @param autoCommit {@code true} when to autocommit
+     * @param stopOnError {@code true} when to stop on error
      */
     public ScriptRunner(Connection connection, boolean autoCommit,
             boolean stopOnError) {
@@ -55,9 +59,11 @@ public class ScriptRunner {
     }
 
     /**
-     * Runs an SQL script (read in using the Reader parameter)
+     * Runs a SQL script (read in using the Reader parameter).
      *
-     * @param reader - the source of the script
+     * @param reader the source of the script
+     * @throws IOException if any occurs connecting to the database
+     * @throws SQLException if any occurs executing the script
      */
     public void runScript(Reader reader) throws IOException, SQLException {
         try {
@@ -83,8 +89,8 @@ public class ScriptRunner {
      * Runs an SQL script (read in using the Reader parameter) using the
      * connection passed in
      *
-     * @param conn - the connection to use for the script
-     * @param reader - the source of the script
+     * @param conn the connection to use for the script
+     * @param reader the source of the script
      * @throws SQLException if any SQL errors occur
      * @throws IOException if there is an error reading from the Reader
      */

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/UpdateElement.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/UpdateElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@ import java.util.List;
 
 /**
  *
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * @author Meine Toonen meinetoonen@b3partners.nl
  */
 public class UpdateElement {
 

--- a/viewer/src/main/java/nl/b3p/viewer/image/Bbox.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/Bbox.java
@@ -150,6 +150,8 @@ public class Bbox {
     }
     /**
      * Give wkt of this bbox.
+     *
+     * @return WKT representation of this bbox
      */
     public String toWKT(){
         String s="POLYGON((";

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineArcIMSUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineArcIMSUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,13 +58,12 @@ public class CombineArcIMSUrl extends CombineXMLBodyUrl{
         super(caiu);
     }
     /**
-     * Create a new CombineImageUrl with the given values
-     * In this implementation the body is changed.
-     * @param width width
-     * @param height height
-     * @param bbox bbox
+     * Create a new CombineImageUrl with the given values. In this
+     * implementation the body is changed.
+     *
+     * @param bbox bbox of image
      * @return new clone of this CombineImageUrl but with changed values.
-     * @see CombineImageUrl#calculateNewUrl(java.lang.Integer, java.lang.Integer, nl.b3p.viewer.image.Bbox) 
+     * @see CombineImageUrl#calculateNewUrl(nl.b3p.viewer.image.ImageBbox)
      */    
     @Override
     public List<CombineImageUrl> calculateNewUrl(ImageBbox bbox) {

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineArcServerUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineArcServerUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,14 +58,13 @@ public class CombineArcServerUrl extends CombineXMLBodyUrl{
         super(casu);
     }
     /**
-     * Create a new CombineImageUrl with the given values
-     * In this implementation the body is changed.
-     * @param width width
-     * @param height height
-     * @param bbox bbox
+     * Create a new CombineImageUrl with the given values In this implementation
+     * the body is changed.
+     *
+     * @param imbbox bbox of image
      * @return new clone of this CombineImageUrl but with changed values.
-     * @see CombineImageUrl#calculateNewUrl(java.lang.Integer, java.lang.Integer, nl.b3p.viewer.image.Bbox) 
-     */    
+     * @see CombineImageUrl#calculateNewUrl(nl.b3p.viewer.image.ImageBbox)
+     */ 
     @Override
     public List<CombineImageUrl> calculateNewUrl(ImageBbox imbbox) {
         Integer width = imbbox.getWidth();

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineImageSettings.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineImageSettings.java
@@ -1,6 +1,18 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (C) 2012-2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package nl.b3p.viewer.image;
 
@@ -46,14 +58,17 @@ public class CombineImageSettings {
     
     /**
      * Calculate the urls in the combineImageSettings.
+     *
+     * @return list CombineImageUrl
      */
-    public List getCalculatedUrls(){
+    public List<CombineImageUrl> getCalculatedUrls() {
         return getCalculatedUrls(urls);
     }
     /**
-     * Return a list of CombineImagesUrl's with correct bbox,height and width
-     * @param oldList
-     * @return 
+     * Return a list of CombineImagesUrl's with correct bbox,height and width.
+     *
+     * @param oldList list of CombineImageUrl
+     * @return list of recalculated CombineImageUrl
      */
     private List<CombineImageUrl> getCalculatedUrls(List<CombineImageUrl> oldList){
         List<CombineImageUrl> returnValue=new ArrayList();
@@ -101,8 +116,9 @@ public class CombineImageSettings {
     }
     
     /**
-     * Add the CombineImageUrl
-     * @param ciu 
+     * Add the CombineImageUrl.
+     *
+     * @param ciu to add
      */
     public void addUrl(CombineImageUrl ciu) {
         if (this.urls==null){
@@ -111,8 +127,9 @@ public class CombineImageSettings {
         this.urls.add(ciu);
     }
     /**
-     * Set the wktGeoms
-     * @param wktGeoms Array of wktGeoms
+     * Set the wktGeoms.
+     *
+     * @param wktGeoms array of wktGeoms
      */
     public void setWktGeoms(String[] wktGeoms){
         this.wktGeoms=new ArrayList();
@@ -124,7 +141,9 @@ public class CombineImageSettings {
    
     
     /**
-     * Gets the bbox from a url
+     * Gets the bbox from a url.
+     *
+     * @return the bbox from a url
      */
     public Bbox getBboxFromUrls() {
         Bbox bb = null;
@@ -137,7 +156,8 @@ public class CombineImageSettings {
         return bb;
     }
     /**
-     * Try to resolve the width and height from the CombineImageUrl's
+     * Try to resolve the width and height from the CombineImageUrl's.
+     *
      * @return Array of int's width is the first in the array, height second
      */
     public Integer[] getWidthAndHeightFromUrls() {
@@ -230,10 +250,11 @@ public class CombineImageSettings {
    
     //</editor-fold>   
     /**
-     * Create a new BBOX that covers the original and the rotated bbox
-     * @param bbox
-     * @param rotation
-     * @return 
+     * Create a new BBOX that covers the original and the rotated bbox.
+     *
+     * @param bbox original bbox
+     * @param rotation angle in degrees
+     * @return a new BBOX that covers the original and the rotated bbox
      */
     private Bbox getBboxWithRotation(Bbox bb, Integer rotation) {
         //copy the bbox
@@ -291,8 +312,9 @@ public class CombineImageSettings {
         return returnValue;
     }
     /**
-     * Get the request Bbox,height and width
-     * @return 
+     * Get the request Bbox,height and width.
+     *
+     * @return the imagebox of the request
      */
     public ImageBbox getRequestBbox() {
         Bbox correctedBbox= getCalculatedBbox();
@@ -310,7 +332,7 @@ public class CombineImageSettings {
         return new ImageBbox(correctedBbox,reqWidth,reqHeight);
     }
     /**
-     * @settings a JSONObject in the following format:
+     * @param settings a JSONObject in the following format:      <pre>
      * {            
      *      requests: [
      *          {
@@ -335,6 +357,10 @@ public class CombineImageSettings {
      *      angle: "",
      *      quality: ""
      *  }
+     * </pre>
+     * @return a new CombineImageSettings from the passed in json
+     * @throws org.json.JSONException if parsing the json failed
+     * @throws Exception if any
      */
     public static CombineImageSettings fromJson(JSONObject settings) throws JSONException, Exception{        
         JSONObject jResponse = new JSONObject();

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineTMSUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineTMSUrl.java
@@ -1,7 +1,18 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (C) 2012-2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package nl.b3p.viewer.image;
 
@@ -31,7 +42,6 @@ public class CombineTMSUrl extends CombineTileImageUrl {
      * @param res The resolution for which the tile should be calculated
      * @param max If it is the max, increase the index with one more, to prevent missing tiles
      * @return The index of the tile specified at the coordinate/resolution pair
-     * @see coremodel.service.tiling.factory.TileFactoryInterface#getTileIndexX
      */
     @Override
     public Integer getTileIndexX(Double xCoord, Double res, boolean max) {
@@ -56,7 +66,7 @@ public class CombineTMSUrl extends CombineTileImageUrl {
 
     /**
      * Get the index number Y of the tile on coordinate 'yCoord' o
-     * @param xCoord The x coord.
+     * @param yCoord The y coord.
      * @param res The resolution for which the tile should be calculated
      * @param max If it is the max, increase the index with one more, to prevent missing tiles
      * @return The index of the tile specified at the coordinate/resolution pair

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineTileImageUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineTileImageUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -130,7 +130,7 @@ public abstract class CombineTileImageUrl extends CombineImageUrl{
         return tileImages;
     }
 
-    /**
+    /*
      * create the tile
      * @param imageBbox the original imageBbox reqeust
      * @param tileBbox the bbox of this tile
@@ -165,11 +165,14 @@ public abstract class CombineTileImageUrl extends CombineImageUrl{
         return tile;
     }
 
-    /** Get the index number X of the tile on coordinate 'xCoord'.
+    /**
+     * Get the index number X of the tile on coordinate 'xCoord'.
+     *
      * @param xCoord The x coord.
-     * @param zoomLevel the zoomLevel of the server.
-	 * @see coremodel.service.tiling.factory.TileFactoryInterface#getTileIndexX
-    */
+     * @param res The resolution for which the tile should be calculated
+     * @param max not used?
+     * @return the zoomlevel
+     */
     public Integer getTileIndexX(Double xCoord,Double res, boolean max){
         Double tileSpanX= res*getTileWidth();
         Double tileIndexX = Math.floor((xCoord - serviceBbox.getMinx()) / (tileSpanX+epsilon));
@@ -182,10 +185,15 @@ public abstract class CombineTileImageUrl extends CombineImageUrl{
         }
         return tileIndexX.intValue();
     }
-    /** Get the index number Y of the tile on coordinate 'yCoord' on zoomlevel 'zoomLevel'.
+    /**
+     * Get the index number Y of the tile on coordinate 'yCoord' on zoomlevel
+     * 'zoomLevel'.
+     *
      * @param yCoord The y coord.
-     * @param zoomLevel the zoomLevel of the server.
-    */
+     * @param res The resolution for which the tile should be calculated
+     * @param max not used?
+     * @return the zoomlevel
+     */
     public Integer getTileIndexY(double yCoord,Double res, boolean max){
        Double tileSpanY= res*getTileHeight();
         Double tileIndexY = Math.floor((yCoord - serviceBbox.getMiny()) / (tileSpanY+epsilon));

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineWmsUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineWmsUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -96,8 +96,8 @@ public class CombineWmsUrl extends CombineImageUrl{
     }
     
     /**
-     * Try to resolve the width and height from the given CombineImageUrl
-     * @param ciu 
+     * Try to resolve the width and height from the given CombineImageUrl.
+     *
      * @return Array of int's width is the first in the array, height second
      */
     public Integer[] getWidthAndHeightFromUrl() {
@@ -122,7 +122,9 @@ public class CombineWmsUrl extends CombineImageUrl{
         return result;
     }
     /**
-     * Gets the bbox from the url in the CombineImageUrl
+     * Gets the bbox from the url in the CombineImageUrl.
+     *
+     * @return the bbox for this url
      */
     public Bbox getBboxFromUrl() {
         if (this.getUrl()==null) {
@@ -154,7 +156,8 @@ public class CombineWmsUrl extends CombineImageUrl{
         }
     }
     /**
-     * Returned a url with changed param     
+     * Returned a url with changed param.
+     *
      * @param key the param name
      * @param newValue the new value
      * @return the changed url
@@ -187,10 +190,11 @@ public class CombineWmsUrl extends CombineImageUrl{
         }
     }
     /**
-      * Get a parameter from this url.      
-      * @param key
-      * @return 
-      */
+     * Get a parameter from this url.
+     *
+     * @param key param to get
+     * @return parameter value (possibly {@code null})
+     */
     public String getParameter(String key) {
         String lowerUrl = url.toLowerCase();
         if (lowerUrl.indexOf("?" + key + "=") >= 0 || lowerUrl.indexOf("&" + key + "=") >= 0) {

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineXMLBodyUrl.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineXMLBodyUrl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,8 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * A abstract class for implementing the body string as a xml (document)
+ * A abstract class for implementing the body string as a xml (document).
+ *
  * @author Roy Braam
  */
 public abstract class CombineXMLBodyUrl extends CombineImageUrl{
@@ -45,11 +46,12 @@ public abstract class CombineXMLBodyUrl extends CombineImageUrl{
     }
         
     /**
-     * Returns the body as a xml document
+     * Returns the body as a xml document.
+     *
      * @return the body as document
-     * @throws ParserConfigurationException
-     * @throws SAXException
-     * @throws IOException 
+     * @throws ParserConfigurationException if any
+     * @throws SAXException if any
+     * @throws IOException if any
      */
     protected Document bodyAsDocument() throws ParserConfigurationException, SAXException, IOException{
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -59,10 +61,11 @@ public abstract class CombineXMLBodyUrl extends CombineImageUrl{
         return doc;
     }
     /**
-     * Set the body with the given doc. Its transforms the document to a string
+     * Set the body with the given doc. Its transforms the document to a string.
+     *
      * @param doc the Document that's the new body
-     * @throws TransformerConfigurationException
-     * @throws TransformerException 
+     * @throws TransformerConfigurationException if any
+     * @throws TransformerException if any
      */
     protected void setBody(Document doc) throws TransformerConfigurationException, TransformerException{
         DOMSource domSource = new DOMSource(doc);

--- a/viewer/src/main/java/nl/b3p/viewer/image/ImageBbox.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ImageBbox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,15 +65,17 @@ public class ImageBbox {
         this.height = height;
     }
     /**
-     * Get the units per pixel x
-     * @return 
+     * Get the units per pixel y.
+     *
+     * @return units per pixel y
      */
     public double getUnitsPixelY() {
         return bbox.getHeight()/height;
     }
     /**
-     * Get the units per pixel y
-     * @return 
+     * Get the units per pixel x
+     *
+     * @return units per pixel x
      */
     public double getUnitsPixelX() {
         return bbox.getWidth()/width;

--- a/viewer/src/main/java/nl/b3p/viewer/image/ImageCollector.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ImageCollector.java
@@ -102,8 +102,8 @@ public class ImageCollector implements Callable<ImageCollector> {
      * @param user username
      * @param pass password
      * @return The image
-     * @throws IOException
-     * @throws Exception 
+     * @throws IOException if any
+     * @throws Exception if any
      */
     protected BufferedImage loadImage(String url, String user, String pass) throws IOException, Exception {
         HttpMethod method = null;

--- a/viewer/src/main/java/nl/b3p/viewer/image/ImageManager.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ImageManager.java
@@ -110,9 +110,10 @@ public class ImageManager {
         threadPool.shutdown();
     }
     /**
-     * Combine all the images recieved
+     * Combine all the images recieved.
+     *
      * @return a combined image
-     * @throws Exception 
+     * @throws Exception if any
      */
     public List<ReferencedImage> getCombinedImages() throws Exception {
         ImageCollector ic = null;

--- a/viewer/src/main/java/nl/b3p/viewer/image/ImageTool.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ImageTool.java
@@ -2,7 +2,7 @@
  * B3P Kaartenbalie is a OGC WMS/WFS proxy that adds functionality
  * for authentication/authorization, pricing and usage reporting.
  *
- * Copyright 2006, 2007, 2008 B3Partners BV
+ * Copyright 2006, 2007, 2008, 2016 B3Partners BV
  * 
  * This file is part of B3P Kaartenbalie.
  * 
@@ -75,7 +75,7 @@ public class ImageTool {
      *
      * @return BufferedImage
      *
-     * @throws Exception
+     * @throws Exception if any
      */
     // <editor-fold defaultstate="" desc="readImage(GetMethod method, String mime) method.">
     public static BufferedImage readImage(HttpMethod method, String mime) throws Exception {
@@ -145,13 +145,12 @@ public class ImageTool {
 
     /** First combines the given images to one image and then sends this image back to the client.
      *
-     * @param images BufferedImage array with the images tha have to be combined and sent to the client.
+     * @param image image to be sent to the client.
      * @param mime String representing the mime type of the image.
-     * @param dw DataWrapper object in which the request object is stored.
+     * @param os DataWrapper used to write the image.
      *
-     * @throws Exception
+     * @throws Exception if any
      */
-    // <editor-fold defaultstate="" desc="writeImage(BufferedImage [] images, String mime, DataWrapper dw) method.">
     public static void writeImage(BufferedImage image, String mime, OutputStream os) throws Exception {
 
         String mimeType = getMimeType(mime);
@@ -569,9 +568,6 @@ public class ImageTool {
         return imTest;
     }
 
-    /**
-     *
-     */
     public static BufferedImage changeColor(BufferedImage im, Color color, Color newColor) {
         for (int x = 0; x < im.getWidth(); x++) {
             for (int y = 0; y < im.getHeight(); y++) {

--- a/viewer/src/main/java/nl/b3p/viewer/image/PrePostImageCollector.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/PrePostImageCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -84,9 +84,9 @@ public abstract class PrePostImageCollector extends ImageCollector{
      * Recieve the url from the xml.
      * @param returnXML The xml that is recieved bij doing a post request
      * @return the url.
-     * @throws XPathExpressionException
-     * @throws JDOMException
-     * @throws IOException 
+     * @throws XPathExpressionException if any
+     * @throws JDOMException if any
+     * @throws IOException if any
      */
     protected abstract String getUrlFromXML(String returnXML) throws XPathExpressionException, JDOMException, IOException;
 

--- a/viewer/src/main/java/nl/b3p/viewer/image/TileServerSettings.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/TileServerSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -135,13 +135,8 @@ public class TileServerSettings {
         
         return tileImages;
     }
-    /**
+    /*
      * Calculate the index of the tiling.
-     * @param serviceMin
-     * @param serviceMax
-     * @param tileSizeMapUnits
-     * @param coord
-     * @return 
      */
     public static int getTilingCoord(Double serviceMin, Double serviceMax,
             Double tileSizeMapUnits, Double coord) {
@@ -164,15 +159,8 @@ public class TileServerSettings {
         return tileIndex.intValue();   
     }
     
-    /**
-     * Calculate the position of the tile
-     * @param mapWidth
-     * @param mapHeight
-     * @param tileBbox
-     * @param requestBbox
-     * @param offsetX
-     * @param offsetY
-     * @return 
+    /*
+     * Calculate the position of the tile.
      */
     public CombineStaticImageUrl calcTilePosition(Integer mapWidth, Integer mapHeight,
             Bbox tileBbox, Bbox requestBbox, int offsetX, int offsetY) {

--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
@@ -1,9 +1,19 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (C) 2012-2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package nl.b3p.viewer.print;
 
 import java.io.File;
@@ -16,8 +26,6 @@ import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.util.JAXBSource;
@@ -28,7 +36,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 import nl.b3p.mail.Mailer;
-import nl.b3p.viewer.stripes.PrintActionBean;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -110,8 +117,9 @@ public class PrintGenerator  implements Runnable{
      * @param basePath the base path of that sheet
      * @param addJavascript addJavascript?
      * @param response the response for the outputstream
-     * @throws MalformedURLException
-     * @throws IOException 
+     * @param filename output filename
+     * @throws MalformedURLException if getting th eimage fails
+     * @throws IOException if saving the image fails
      */
     public static void createOutput(PrintInfo info, String mimeType, InputStream xslIs, String basePath,
             boolean addJavascript, HttpServletResponse response, String filename) throws MalformedURLException, IOException {
@@ -140,7 +148,8 @@ public class PrintGenerator  implements Runnable{
     }
     
     
-    public static void createOutput(PrintInfo info, String mimeType, InputStream xslIs, String basePath, OutputStream out, String filename) throws MalformedURLException, IOException {
+    public static void createOutput(PrintInfo info, String mimeType, InputStream xslIs, String basePath, OutputStream out, String filename)
+            throws MalformedURLException, IOException {
         
         /* Setup fopfactory */
         FopFactory fopFactory = FopFactory.newInstance();

--- a/viewer/src/main/java/nl/b3p/viewer/search/SearchClient.java
+++ b/viewer/src/main/java/nl/b3p/viewer/search/SearchClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 B3Partners B.V.
+ * Copyright (C) 2013-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -36,13 +36,13 @@ public abstract class SearchClient {
      * [
      *      { 
      *          location :{ 
-     *              minx: <double>,
-     *              miny: <double>,
-     *              maxx: <double>,
-     *              maxy: <double>
+     *              minx: double,
+     *              miny: double,
+     *              maxx: double,
+     *              maxy: double
      *          }, 
-     *          type: <string>, // For openLS this is one of: Street, MunicipalitySubdivision, Municipality,CountrySubdivision, for solr it is the name of the configuration
-     *          label: <string>
+     *          type: {String}, // For openLS this is one of: Street, MunicipalitySubdivision, Municipality,CountrySubdivision, for solr it is the name of the configuration
+     *          label: {String}
      *      }
      * ]
      * </pre>

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ApplicationActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ApplicationActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -248,6 +248,9 @@ public class ApplicationActionBean implements ActionBean {
      * Build a hash key to make the single component source for all components
      * cacheable but updateable when the roles of the user change. This is not
      * meant to be a secure hash, the roles of a user are not secret.
+     *
+     * @param request servlet request with user credential
+     * @return a key to use as a cache identifyer
      */
     public static int getRolesCachekey(HttpServletRequest request) {
         Set<String> roles = Authorizations.getRoles(request);

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2015 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -305,7 +305,10 @@ public class AttributesActionBean implements ActionBean {
 
     /**
      * Call this to clear the "total feature count" cached value when a new feature
-     * is added to a feature source. Only clears the cache for the current session.
+     * is added to a feature source. Only clears the cache for the
+     * current session.
+     *
+     * @param context the context that holds the session data
      */
     public static void clearTotalCountCache(ActionBeanContext context) {
         HttpSession sess = context.getRequest().getSession();

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/CombineImageActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/CombineImageActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -185,8 +185,9 @@ public class CombineImageActionBean implements ActionBean {
     }
     /**
      * Combines the image settings to a new image.
-     * @return a image.
-     * @throws Exception
+     *
+     * @return an image
+     * @throws Exception if any
      */
     public Resolution getImage() throws Exception {
         if (imageId==null || imageSettings.get(imageId)==null){
@@ -246,6 +247,7 @@ public class CombineImageActionBean implements ActionBean {
 
     /**
      * Create unique number.
+     * @return a unique number
      */
     public static String uniqueId() {
         // Use miliseconds to generate a code

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2013 B3Partners B.V.
+ * Copyright (C) 2012-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -342,14 +342,14 @@ public class FeatureInfoActionBean implements ActionBean {
      * This will execute the actual featureinfo query, can be overridden in
      * subclasses to modify behaviour such as workflow.
      *
-     * @param al
-     * @param ft
-     * @param fs
-     * @param q
+     * @param al the application layer
+     * @param ft the featuretype
+     * @param fs the feature source
+     * @param q a query
      * @return the features embedded in a {@code JSONArray}
-     * @throws IOException
-     * @throws JSONException
-     * @throws Exception
+     * @throws IOException if any
+     * @throws JSONException if transforming to json fails
+     * @throws Exception if any
      */
     protected JSONArray executeQuery(ApplicationLayer al, SimpleFeatureType ft, FeatureSource fs, Query q)
             throws IOException, JSONException, Exception {

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/LayarActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/LayarActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -113,6 +113,8 @@ public class LayarActionBean implements ActionBean {
     /**
      * Get's the LayarService by the given name.
      * Loads features with the LayarSources and makes the hotspots.
+     * @return json for the layar component
+     * @throws org.json.JSONException if transforming to json fails
      */
     public Resolution json() throws JSONException{
         String error="";

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/MergeFeaturesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/MergeFeaturesActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,7 +65,7 @@ import org.stripesstuff.stripersist.Stripersist;
  * and B and B will cease to exist. A may be a new feature if that strategy is
  * chosen.
  *
- * @author Mark Prins <mark@b3partners.nl>
+ * @author Mark Prins mark@b3partners.nl
  */
 @UrlBinding("/action/feature/merge")
 @StrictBinding
@@ -197,17 +197,17 @@ public class MergeFeaturesActionBean implements ActionBean {
     }
 
     /**
-     * Handle extra data, delegates to {@link #handleExtraData(java.util.List).
+     * Handle extra data, delegates to {@link #handleExtraData(java.util.List)}.
      *
      * @param feature the feature that can be modified
      * @return the feature to be committed to the database
      *
      * @throws java.lang.Exception if any
      *
-     * @see #handleExtraData(java.util.List<SimpleFeature>)
+     * @see #handleExtraData(java.util.List)
      */
     protected SimpleFeature handleExtraData(SimpleFeature feature) throws Exception {
-        final List<SimpleFeature> features = new ArrayList<SimpleFeature>();
+        final List<SimpleFeature> features = new ArrayList();
         features.add(feature);
         return this.handleExtraData(features).get(0);
     }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -71,7 +71,7 @@ import org.stripesstuff.stripersist.Stripersist;
  * one or more new features are created or the split feature is deleted and all
  * new features are created.
  *
- * @author Mark Prins <mark@b3partners.nl>
+ * @author Mark Prins mark@b3partners.nl
  */
 @UrlBinding("/action/feature/split")
 @StrictBinding
@@ -195,15 +195,15 @@ public class SplitFeatureActionBean implements ActionBean {
     }
 
     /**
-     * Handle extra data, delegates to {@link #handleExtraData(java.util.List).
+     * Handle extra data, delegates to {@link #handleExtraData(java.util.List)}.
      *
      * @param feature the feature that can be modified
-     * @return the feature to be committed to the database @see
-     * #handleExtraData(java.util.List)
+     * @return the feature to be committed to the database
+     * @see #handleExtraData(java.util.List)
      * @throws Exception if any
      */
     protected SimpleFeature handleExtraData(SimpleFeature feature) throws Exception {
-        final List<SimpleFeature> features = new ArrayList<SimpleFeature>();
+        final List<SimpleFeature> features = new ArrayList();
         features.add(feature);
         return this.handleExtraData(features).get(0);
     }
@@ -348,8 +348,8 @@ public class SplitFeatureActionBean implements ActionBean {
     }
 
     /**
-     * @param toSplit
-     * @param line
+     * @param toSplit the line to split
+     * @param line the line to use for the split
      * @return a sorted list of geometries as a result of splitting toSplit with
      * line
      */
@@ -369,8 +369,8 @@ public class SplitFeatureActionBean implements ActionBean {
     }
 
     /**
-     * @param poly
-     * @param line
+     * @param poly the polygon to split
+     * @param line the line to use for the split
      * @return a sorted list of geometries as a result of splitting poly with
      * line
      */

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013 B3Partners B.V.
+ * Copyright (C) 2013-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -81,9 +81,9 @@ public class FeatureToJson {
      * @param sort The attribute name that is used to sort
      * @param dir Sort direction (DESC or ASC)
      * @return JSONArray with features.
-     * @throws IOException
-     * @throws JSONException
-     * @throws Exception
+     * @throws IOException if any
+     * @throws JSONException if transforming to json fails
+     * @throws Exception if any
      */
     public JSONArray getJSONFeatures(ApplicationLayer al,SimpleFeatureType ft, FeatureSource fs, Query q, String sort, String dir) throws IOException, JSONException, Exception{
         Map<String,String> attributeAliases = new HashMap<String,String>();

--- a/web-commons/src/main/java/nl/b3p/web/SharedSessionData.java
+++ b/web-commons/src/main/java/nl/b3p/web/SharedSessionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2015-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@ import org.apache.commons.logging.LogFactory;
  * Maintain a list of active sessions on the application to provide a means of
  * sharing session data.
  *
- * @author Mark Prins <mark@b3partners.nl>
+ * @author mprins
  */
 public class SharedSessionData implements HttpSessionListener {
     private static final Log log = LogFactory.getLog(SharedSessionData.class);

--- a/web-commons/src/main/java/nl/b3p/web/filter/SetCharacterEncodingFilter.java
+++ b/web-commons/src/main/java/nl/b3p/web/filter/SetCharacterEncodingFilter.java
@@ -101,7 +101,7 @@ public class SetCharacterEncodingFilter implements Filter {
      * interpret request parameters for this request.
      *
      * @param request The servlet request we are processing
-     * @param result The servlet response we are creating
+     * @param response The servlet response we are creating
      * @param chain The filter chain we are processing
      *
      * @exception IOException if an input/output error occurs
@@ -160,6 +160,8 @@ public class SetCharacterEncodingFilter implements Filter {
      * filter.
      *
      * @param request The servlet request we are processing
+     * @return the encoding of the request
+     *
      */
     protected String selectEncoding(ServletRequest request) {
 


### PR DESCRIPTION
Due to stricter javadoc linting a release build fails because any invalid javadoc will cause an ERROR during the build. see `mvn javadoc:javadoc` output when running on java 8

The quick-and-dirty way is specifying the doclint to none:

``` xml
<plugin>
  <groupId>org.apache.maven.plugins</groupId>
  <artifactId>maven-javadoc-plugin</artifactId>
    <configuration>
      <additionalparam>-Xdoclint:none</additionalparam>
    </configuration>
  </plugin>
</plugins>
```

This would need to be set up in a build profile that is automatically activated when building on java 8

The proper way is to fix the javadoc in the artifacts.
- [x] solr-commons
- [x] web-commons
- [x] viewer-commons
- [x] viewer-config-persistence
- [x] viewer
- [x] viewer-admin
