### PR TITLE
Explicitly set autocomplete to off for username/password fields

### DIFF
--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/security/edituser.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/security/edituser.jsp
@@ -66,11 +66,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </tr>
                                     <tr>
                                         <td>Gebruikersnaam *:</td>
-                                        <td><stripes:text name="username" disabled="${!empty actionBean.user.username}" maxlength="255" size="30"/></td>
+                                        <td><stripes-dynattr:text name="username" autocomplete="off" required="" disabled="${!empty actionBean.user.username}" maxlength="255" size="30">${user.username}</stripes-dynattr:text></td>
                                     </tr>
                                     <tr>
                                         <td>Wachtwoord *:</td>
-                                        <td><stripes:password name="password" maxlength="255" size="30"/></td>
+                                        <td><stripes-dynattr:password name="password" autocomplete="off" required="" maxlength="255" size="30"/></td>
                                     </tr>
                                 </table>
                             </td>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/security/edituser.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/security/edituser.jsp
@@ -66,11 +66,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </tr>
                                     <tr>
                                         <td>Gebruikersnaam *:</td>
-                                        <td><stripes-dynattr:text name="username" autocomplete="off" required="" disabled="${!empty actionBean.user.username}" maxlength="255" size="30">${user.username}</stripes-dynattr:text></td>
+                                        <td><stripes-dynattr:text name="username" required="" disabled="${!empty actionBean.user.username}" maxlength="255" size="30">${user.username}</stripes-dynattr:text></td>
                                     </tr>
                                     <tr>
                                         <td>Wachtwoord *:</td>
-                                        <td><stripes-dynattr:password name="password" autocomplete="off" required="" maxlength="255" size="30"/></td>
+                                        <td><stripes-dynattr:password name="password" autocomplete="new-password" required="" maxlength="255" size="30"/></td>
                                     </tr>
                                 </table>
                             </td>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/cyclorama.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/cyclorama.jsp
@@ -33,13 +33,13 @@
                 <table class="formtable">
                     <tr>
                         <td>Gebruikersnaam</td>
-                        <td><stripes:text name="account.username"/></td>
-                    </tr>
-                    <tr>
+                        <td><stripes-dynattr:text autocomplete="off" name="account.username">${account.username}</stripes-dynattr:text></td>
+                </tr>
+                <tr>
                         <td>Wachtwoord</td>
-                        <td><stripes:text name="account.password"/></td>
-                    </tr>
-                    <tr>
+                        <td><stripes-dynattr:text autocomplete="off" name="account.password"/></td>
+                </tr>
+                <tr>
                         <td>PFX-bestand</td>
                         <td><stripes:file name="key"/></td>
                     </tr>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/cyclorama.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/cyclorama.jsp
@@ -33,11 +33,11 @@
                 <table class="formtable">
                     <tr>
                         <td>Gebruikersnaam</td>
-                        <td><stripes-dynattr:text autocomplete="off" name="account.username">${account.username}</stripes-dynattr:text></td>
+                        <td><stripes-dynattr:text name="account.username">${account.username}</stripes-dynattr:text></td>
                 </tr>
                 <tr>
                         <td>Wachtwoord</td>
-                        <td><stripes-dynattr:text autocomplete="off" name="account.password"/></td>
+                        <td><stripes-dynattr:text autocomplete="new-password" name="account.password"/></td>
                 </tr>
                 <tr>
                         <td>PFX-bestand</td>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
@@ -56,11 +56,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </tr>
                         <tr>
                             <td>Gebruikersnaam:</td>
-                            <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
+                            <td><stripes-dynattr:text name="username" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
                         </tr>
                         <tr>
                             <td>Wachtwoord:</td>
-                            <td><stripes-dynattr:password name="password" autocomplete="off" maxlength="255" size="30"/></td>
+                            <td><stripes-dynattr:password name="password" autocomplete="new-password" maxlength="255" size="30"/></td>
                         </tr>
                     </table>
                     <div class="submitbuttons">
@@ -185,11 +185,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 </tr>
                                 <tr>
                                     <td>Gebruikersnaam:</td>
-                                    <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
+                                    <td><stripes-dynattr:text name="username" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
                                 </tr>
                                 <tr>
                                     <td>Wachtwoord:</td>
-                                    <td><stripes-dynattr:password name="password" autocomplete="off" maxlength="255" size="30"/></td>
+                                    <td><stripes-dynattr:password name="password" autocomplete="new-password" maxlength="255" size="30"/></td>
                                 </tr>
                             </table>
                             <div class="submitbuttons">

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </tr>
                         <tr>
                             <td>Gebruikersnaam:</td>
-                            <td><stripes:text name="username"  maxlength="255" size="30"/></td>
+                            <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
                         </tr>
                         <tr>
                             <td>Wachtwoord:</td>
@@ -185,7 +185,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                 </tr>
                                 <tr>
                                     <td>Gebruikersnaam:</td>
-                                    <td><stripes:text name="username" maxlength="255" size="30"/></td>
+                                    <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
                                 </tr>
                                 <tr>
                                     <td>Wachtwoord:</td>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
@@ -196,7 +196,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </tr>
         <tr>
             <td>Gebruikersnaam:</td>
-            <td><stripes:text name="username" maxlength="255" size="30"/></td>
+            <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
         </tr>
         <tr>
             <td>Wachtwoord:</td>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
@@ -196,11 +196,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         </tr>
         <tr>
             <td>Gebruikersnaam:</td>
-            <td><stripes-dynattr:text name="username" autocomplete="off" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
+            <td><stripes-dynattr:text name="username" maxlength="255" size="30">${username}</stripes-dynattr:text></td>
         </tr>
         <tr>
             <td>Wachtwoord:</td>
-            <td><stripes-dynattr:password name="password" autocomplete="off" maxlength="255" size="30"/></td>
+            <td><stripes-dynattr:password name="password" autocomplete="new-password" maxlength="255" size="30"/></td>
         </tr>
         <tr>
             <td colspan="2">


### PR DESCRIPTION
This PR sets the autocomplete attribute on username/password to off ( #507 )

Even though these are specified I'm still seeing autocomplete behaviour in both Chrome as well as Firefox (as noted in the linked article in the comment: https://github.com/flamingo-geocms/flamingo/issues/507#issuecomment-168408269 )

Also: Chrome fills in the (client-side stored) username to the input closest (in the dom) to the password input (eg the "Telefoon:" input in case of the user editor) if the username input is read-only 
(Firefox will then respect the requested autocomplete)

A hack around his may be to set both username and password to readonly and add a focus handler to remove the readonly attribute, eg:

``` html
<input type="text" readonly  onfocus="this.removeAttribute('readonly');"/>
<input type="password" readonly  onfocus="this.removeAttribute('readonly');"/>
```

see also: https://stackoverflow.com/a/24247840/5454667

Another hack that is reported to work involves adding a dummy, hidden password field to the forms in order to confuse the browser...
