### PR TITLE
Database update scripts for new gt-wfs-ng typename scheme

### DIFF
--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/AttributeSourceActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/AttributeSourceActionBean.java
@@ -138,46 +138,10 @@ public class AttributeSourceActionBean implements ActionBean {
 
     @WaitPage(path = "/WEB-INF/jsp/waitpage.jsp", delay = 2000, refresh = 1000, ajax = "/WEB-INF/jsp/waitpageajax.jsp")
     public Resolution save() throws JSONException, Exception {
-        Map params = new HashMap();
+        
 
         try {
-            if (protocol.equals("jdbc")) {
-                params.put("dbtype", dbtype);
-                params.put("host", host);
-                params.put("port", port);
-                params.put("database", database);
-                params.put("schema", schema);
-                params.put("user", username);
-                params.put("passwd", password);
-
-                JDBCFeatureSource fs = new JDBCFeatureSource(params);
-                fs.setName(name);
-                fs.loadFeatureTypes(status);
-
-                Stripersist.getEntityManager().persist(fs);
-                Stripersist.getEntityManager().getTransaction().commit();
-
-                featureSource = fs;
-
-                getContext().getMessages().add(new SimpleMessage("Attribuutbron is ingeladen"));
-
-            } else if (protocol.equals("wfs")) {
-                params.put(WFSDataStoreFactory.URL.key, url);
-                params.put(WFSDataStoreFactory.USERNAME.key, username);
-                params.put(WFSDataStoreFactory.PASSWORD.key, password);
-                WFSFeatureSource fs = new WFSFeatureSource(params);
-                fs.setName(name);
-                fs.loadFeatureTypes(status);
-                Stripersist.getEntityManager().persist(fs);
-                Stripersist.getEntityManager().getTransaction().commit();
-
-                featureSource = fs;
-
-                getContext().getMessages().add(new SimpleMessage("Attribuutbron is ingeladen"));
-
-            } else {
-                getContext().getValidationErrors().add("protocol", new SimpleError("Ongeldig"));
-            }
+            addService(Stripersist.getEntityManager());
         } catch (Exception e) {
             log.error("Error loading new feauture source", e);
             String s = e.toString();
@@ -188,6 +152,47 @@ public class AttributeSourceActionBean implements ActionBean {
         }
 
         return new ForwardResolution(EDITJSP);
+    }
+
+    protected void addService(EntityManager em) throws Exception {
+        Map params = new HashMap();
+        if (protocol.equals("jdbc")) {
+            params.put("dbtype", dbtype);
+            params.put("host", host);
+            params.put("port", port);
+            params.put("database", database);
+            params.put("schema", schema);
+            params.put("user", username);
+            params.put("passwd", password);
+
+            JDBCFeatureSource fs = new JDBCFeatureSource(params);
+            fs.setName(name);
+            fs.loadFeatureTypes(status);
+
+            em.persist(fs);
+            em.getTransaction().commit();
+
+            featureSource = fs;
+
+            getContext().getMessages().add(new SimpleMessage("Attribuutbron is ingeladen"));
+
+        } else if (protocol.equals("wfs")) {
+            params.put(WFSDataStoreFactory.URL.key, url);
+            params.put(WFSDataStoreFactory.USERNAME.key, username);
+            params.put(WFSDataStoreFactory.PASSWORD.key, password);
+            WFSFeatureSource fs = new WFSFeatureSource(params);
+            fs.setName(name);
+            fs.loadFeatureTypes(status);
+            em.persist(fs);
+            em.getTransaction().commit();
+
+            featureSource = fs;
+
+            getContext().getMessages().add(new SimpleMessage("Attribuutbron is ingeladen"));
+
+        } else {
+            getContext().getValidationErrors().add("protocol", new SimpleError("Ongeldig"));
+        }
     }
 
     public Resolution saveEdit() {

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
@@ -56,29 +56,41 @@ public class WFSTypeNamingTest extends TestUtil {
 
     private AttributeSourceActionBean sb;
 
+    /**
+     * The parameter collection for this testcase. A paramet set consists of an
+     * array containing:
+     * <ol>
+     * <li>(String) service url</li>
+     * <li>(String) server type</li>
+     * <li>(String) service type</li>
+     * <li>(int) expected number of feature types</li>
+     * </ol>
+     *
+     * @return parameter collection that contains input and response values for
+     * this test.
+     */
     @Parameters
     public static Collection params() {
         return Arrays.asList(new Object[][]{
-            //{"url","name","wfs",typecount},
+            // {"url","name","wfs",typecount},
             {"http://ibis.b3p.nl/geoserver/ibis/wfs?SERVICE=WFS", "geoserver-namespaced-url", "wfs", 3},
-            {"http://ibis.b3p.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 3}
-
-        // {"url", "ags", "wfs", 5},
-        // disable for now as the describeFeaturetype responsen fail to validate
+            {"http://ibis.b3p.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 3},
+            {"http://services.geodataoverijssel.nl/geoserver/B07_Adressen/wfs?SERVICE=WFS", "geoserver", "wfs", 2},
+            {"http://services.geodataoverijssel.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 467}
+        // disable for now as the describeFeaturetype responses fail to validate
         // ,{"http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS", "mapserver", "wfs", 10}
-        /* some more mapserver WFS
-         http://geoservices.knmi.nl/cgi-bin/SCIA__CONS_V___IMAP____L2__2004.cgi?SERVICE=WFS
-         http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS
-         */
+        //    http://geoservices.knmi.nl/cgi-bin/SCIA__CONS_V___IMAP____L2__2004.cgi?SERVICE=WFS
+        //    http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS
         });
     }
 
+    /* test parameter */
     private final String serviceUrl;
-
+    /* test parameter */
     private final String serviceName;
-
+    /* test parameter */
     private final String serviceProtocol;
-
+    /* test expectation */
     private final int serviceTypeCount;
 
     public WFSTypeNamingTest(String serviceUrl, String serviceName, String serviceProtocol, int serviceTypeCount) {
@@ -123,7 +135,7 @@ public class WFSTypeNamingTest extends TestUtil {
         List<SimpleFeatureType> types = fs.getFeatureTypes();
         assertEquals("The number of layers should be the same", serviceTypeCount, types.size());
         for (SimpleFeatureType type : types) {
-            log.debug("testing type: " + type.getTypeName());
+            log.debug("Testing type: " + type.getTypeName());
             assertFalse("Type name does not contain a colon", type.getTypeName().contains(":"));
             try {
                 FeatureSource fs2 = type.openGeoToolsFeatureSource();
@@ -136,7 +148,7 @@ public class WFSTypeNamingTest extends TestUtil {
     }
 
     @Override
-    public String toString() {
+    public final String toString() {
         return this.getClass().getCanonicalName()
                 + ", serviceUrl: " + this.serviceUrl
                 + ", serviceName: " + this.serviceName

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.admin.stripes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import net.sourceforge.stripes.action.ActionBeanContext;
+import net.sourceforge.stripes.action.Message;
+import nl.b3p.viewer.config.services.SimpleFeatureType;
+import nl.b3p.viewer.config.services.WFSFeatureSource;
+import nl.b3p.viewer.util.TestUtil;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.geotools.data.FeatureSource;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * testcases for
+ * <a href="https://github.com/flamingo-geocms/flamingo/issues/517">#517</a>.
+ *
+ * @author Mark Prins
+ */
+@RunWith(Parameterized.class)
+public class WFSTypeNamingTest extends TestUtil {
+
+    private static final Log log = LogFactory.getLog(WFSTypeNamingTest.class);
+
+    private ActionBeanContext context;
+
+    private AttributeSourceActionBean sb;
+
+    @Parameters
+    public static Collection params() {
+        return Arrays.asList(new Object[][]{
+            //{"url","name","wfs",typecount},
+            {"http://ibis.b3p.nl/geoserver/ibis/wfs?SERVICE=WFS", "geoserver-namespaced-url", "wfs", 3},
+            {"http://ibis.b3p.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 3}
+
+        // {"url", "ags", "wfs", 5},
+        // disable for now as the describeFeaturetype responsen fail to validate
+        // ,{"http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS", "mapserver", "wfs", 10}
+        /* some more mapserver WFS
+         http://geoservices.knmi.nl/cgi-bin/SCIA__CONS_V___IMAP____L2__2004.cgi?SERVICE=WFS
+         http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS
+         */
+        });
+    }
+
+    private final String serviceUrl;
+
+    private final String serviceName;
+
+    private final String serviceProtocol;
+
+    private final int serviceTypeCount;
+
+    public WFSTypeNamingTest(String serviceUrl, String serviceName, String serviceProtocol, int serviceTypeCount) {
+        this.serviceUrl = serviceUrl;
+        this.serviceName = serviceName;
+        this.serviceProtocol = serviceProtocol;
+        this.serviceTypeCount = serviceTypeCount;
+        log.debug("Starting test with: " + this.toString());
+    }
+
+    @Before
+    public void createContext() {
+        context = new ActionBeanContext() {
+            @Override
+            public List<Message> getMessages() {
+                return new ArrayList<>();
+            }
+        };
+        sb = new AttributeSourceActionBean();
+        sb.setContext(context);
+    }
+
+    @After
+    public void cleanupContext() {
+        context = null;
+        sb = null;
+    }
+
+    @Test
+    public void addService() {
+        try {
+            sb.setProtocol(serviceProtocol);
+            sb.setUrl(serviceUrl);
+            sb.setName(serviceName);
+            sb.addService(entityManager);
+        } catch (Exception ex) {
+            log.error("Saving WFS attribute source failed", ex);
+            fail("Saving WFS attribute source failed.");
+        }
+
+        WFSFeatureSource fs = (WFSFeatureSource) sb.getFeatureSource();
+        List<SimpleFeatureType> types = fs.getFeatureTypes();
+        assertEquals("The number of layers should be the same", serviceTypeCount, types.size());
+        for (SimpleFeatureType type : types) {
+            log.debug("testing type: " + type.getTypeName());
+            assertFalse("Type name does not contain a colon", type.getTypeName().contains(":"));
+            try {
+                FeatureSource fs2 = type.openGeoToolsFeatureSource();
+                assertThat("No exception was thrown and fs2 not null", fs2, not(nullValue()));
+            } catch (Exception ex) {
+                log.error("Opening featuresource failed.", ex);
+                fail("Opening featuresource failed.");
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getCanonicalName()
+                + ", serviceUrl: " + this.serviceUrl
+                + ", serviceName: " + this.serviceName
+                + ", typeCount: " + this.serviceTypeCount;
+    }
+}

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -76,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -128,6 +128,8 @@ public class DatabaseSynchronizer implements Servlet {
         updates.put("14", new UpdateElement(Collections.singletonList("add_disableEditing.sql"), String.class));
         updates.put("15", new UpdateElement(Collections.singletonList("convertApplicationsToStartLevelLayer"), DatabaseSynchronizerEM.class));
 
+        updates.put("16", new UpdateElement(Collections.singletonList("rename_wfsfeaturetype.sql"), String.class));
+
         // NB when adding an update also update the metadata version in the testdata.sql file around line 326
     }
     /**

--- a/viewer-config-persistence/src/main/resources/scripts/oracle-rename_wfsfeaturetype.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/oracle-rename_wfsfeaturetype.sql
@@ -1,0 +1,13 @@
+--
+-- Update the name of wfs featuretype to follow the GT-WFS-NG scheme where
+-- the colon is no longer a valid separator between namespace and typename.
+-- See: https://github.com/flamingo-geocms/flamingo/issues/517
+--
+UPDATE FEATURE_TYPE ft
+SET ft.TYPE_NAME = REPLACE(ft.TYPE_NAME,':','_')
+WHERE EXISTS
+  (SELECT 1
+  FROM FEATURE_SOURCE fs
+  WHERE ft.FEATURE_SOURCE = fs.ID
+  AND fs.PROTOCOL         = 'wfs'
+  );

--- a/viewer-config-persistence/src/main/resources/scripts/postgresql-rename_wfsfeaturetype.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/postgresql-rename_wfsfeaturetype.sql
@@ -1,0 +1,10 @@
+--
+-- Update the name of wfs featuretype to follow the GT-WFS-NG scheme where
+-- the colon is no longer a valid separator between namespace and typename.
+-- See: https://github.com/flamingo-geocms/flamingo/issues/517
+--
+UPDATE feature_type ft
+   SET type_name = replace(type_name,':','_')
+  FROM feature_source fs
+ WHERE ft.feature_source = fs.id
+   AND fs.protocol = 'wfs';

--- a/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
+++ b/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
@@ -324,7 +324,7 @@ INSERT INTO level_layers (level_, layer, list_index) VALUES (6, 5, 0);
 
 
 
-INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '15');
+INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '16');
 
 
 INSERT INTO user_ (username, password) VALUES ('admin', '14c06474bec5e7def0304925d09f2b977af3146a');


### PR DESCRIPTION
The gt-wfs-ng module introduce in flaming 4.6.0 has a different naming scheme, typenames now use an underscore instead of a colon to separate the namespace from the typename.

This PR:
- [x] adds a testcase
- [x] provides an update script
- [x] increments database version to 16

As a collateral a minor refactoring in the AttributeSourceActionBean to provide a way of injecting the EntityManager so we can create/run a unittest.

fix #517 
