### PR TITLE
Replace any colon in the WFS feature type name as geotools gt-wfs-ng does this as well

### DIFF
--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/WFSTypeNamingTest.java
@@ -20,8 +20,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import net.sourceforge.stripes.action.Message;
+import nl.b3p.viewer.config.services.Category;
+import nl.b3p.viewer.config.services.GeoService;
+import nl.b3p.viewer.config.services.Layer;
 import nl.b3p.viewer.config.services.SimpleFeatureType;
 import nl.b3p.viewer.config.services.WFSFeatureSource;
 import nl.b3p.viewer.util.TestUtil;
@@ -56,6 +61,8 @@ public class WFSTypeNamingTest extends TestUtil {
 
     private AttributeSourceActionBean sb;
 
+    private GeoServiceActionBean gsb;
+
     /**
      * The parameter collection for this testcase. A paramet set consists of an
      * array containing:
@@ -73,32 +80,46 @@ public class WFSTypeNamingTest extends TestUtil {
     public static Collection params() {
         return Arrays.asList(new Object[][]{
             // {"url","name","wfs",typecount},
-            {"http://ibis.b3p.nl/geoserver/ibis/wfs?SERVICE=WFS", "geoserver-namespaced-url", "wfs", 3},
-            {"http://ibis.b3p.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 3},
-            {"http://services.geodataoverijssel.nl/geoserver/B07_Adressen/wfs?SERVICE=WFS", "geoserver", "wfs", 2},
-            {"http://services.geodataoverijssel.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 467}
-        // disable for now as the describeFeaturetype responses fail to validate
-        // ,{"http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS", "mapserver", "wfs", 10}
+            {"http://ibis.b3p.nl/geoserver/ibis/wfs?SERVICE=WFS", "geoserver-namespaced-wfsurl", "wfs", 3, 0},
+            {"http://ibis.b3p.nl/geoserver/wfs?SERVICE=WFS", "geoserver-wfsurl", "wfs", 3, 0},
+            {"http://services.geodataoverijssel.nl/geoserver/B07_Adressen/wfs?SERVICE=WFS", "geoserver", "wfs", 2, 0},
+            // {"http://services.geodataoverijssel.nl/geoserver/wfs?SERVICE=WFS", "geoserver", "wfs", 467,0},
+            {"http://ibis.b3p.nl/geoserver/wms?SERVICE=WMS&", "geoserver-wmsurl", "wms", 3, 1},
+            {"http://ibis.b3p.nl/geoserver/ibis/wms?SERVICE=WMS&", "geoserver-namespaced-wmsurl", "wms", 3, 1}
+        // disable for now as the describeFeatureType responses fail to validate
+        // ,{"http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS", "mapserver", "wfs", 10,0}
         //    http://geoservices.knmi.nl/cgi-bin/SCIA__CONS_V___IMAP____L2__2004.cgi?SERVICE=WFS
         //    http://geoservices.rijkswaterstaat.nl/verkeersscheidingsstelsel_noordzee?SERVICE=WFS
         });
     }
 
-    /* test parameter */
+    /**
+     * test parameter.
+     */
     private final String serviceUrl;
-    /* test parameter */
+    /**
+     * test parameter.
+     */
     private final String serviceName;
-    /* test parameter */
+    /**
+     * test parameter.
+     */
     private final String serviceProtocol;
-    /* test expectation */
+    /**
+     * test expectation.
+     */
     private final int serviceTypeCount;
+    /**
+     * test expectation.
+     */
+    private final int groupLayerCount;
 
-    public WFSTypeNamingTest(String serviceUrl, String serviceName, String serviceProtocol, int serviceTypeCount) {
+    public WFSTypeNamingTest(String serviceUrl, String serviceName, String serviceProtocol, int serviceTypeCount, int groupLayerCount) {
         this.serviceUrl = serviceUrl;
         this.serviceName = serviceName;
         this.serviceProtocol = serviceProtocol;
         this.serviceTypeCount = serviceTypeCount;
-        log.debug("Starting test with: " + this.toString());
+        this.groupLayerCount = groupLayerCount;
     }
 
     @Before
@@ -109,8 +130,6 @@ public class WFSTypeNamingTest extends TestUtil {
                 return new ArrayList<>();
             }
         };
-        sb = new AttributeSourceActionBean();
-        sb.setContext(context);
     }
 
     @After
@@ -120,29 +139,75 @@ public class WFSTypeNamingTest extends TestUtil {
     }
 
     @Test
-    public void addService() {
-        try {
-            sb.setProtocol(serviceProtocol);
-            sb.setUrl(serviceUrl);
-            sb.setName(serviceName);
-            sb.addService(entityManager);
-        } catch (Exception ex) {
-            log.error("Saving WFS attribute source failed", ex);
-            fail("Saving WFS attribute source failed.");
-        }
-
-        WFSFeatureSource fs = (WFSFeatureSource) sb.getFeatureSource();
-        List<SimpleFeatureType> types = fs.getFeatureTypes();
-        assertEquals("The number of layers should be the same", serviceTypeCount, types.size());
-        for (SimpleFeatureType type : types) {
-            log.debug("Testing type: " + type.getTypeName());
-            assertFalse("Type name does not contain a colon", type.getTypeName().contains(":"));
+    public void addWMSGeoservice() {
+        if (serviceProtocol.equalsIgnoreCase("wms")) {
+            log.debug("Starting WMS test with: " + this.toString());
             try {
-                FeatureSource fs2 = type.openGeoToolsFeatureSource();
-                assertThat("No exception was thrown and fs2 not null", fs2, not(nullValue()));
+                Category cat = new Category();
+                cat.setId(1L);
+                gsb = new GeoServiceActionBean();
+                gsb.setCategory(cat);
+                gsb.setContext(context);
+                gsb.setProtocol(serviceProtocol);
+                gsb.setOverrideUrl(false);
+                gsb.setUrl(serviceUrl);
+                gsb.setName(serviceName);
+                gsb.addService(entityManager);
             } catch (Exception ex) {
-                log.error("Opening featuresource failed.", ex);
-                fail("Opening featuresource failed.");
+                log.error("adding WMS service  failed", ex);
+                fail("Saving WFS attribute source failed.");
+            }
+            GeoService service = gsb.getService();
+            assertEquals("The url should be the same", serviceUrl, service.getUrl());
+
+            List<Layer> layers = service.loadLayerTree(entityManager);
+            assertEquals("The number of layers should be the same", serviceTypeCount + groupLayerCount, layers.size());
+
+            for (Layer lyr : layers) {
+                if (!lyr.isVirtual()) {
+                    log.debug("Inspecting layer, name: " + lyr.getName() + ", featuretype: " + lyr.getFeatureType().getDescription());
+                    assertFalse("Attribute type name does not contain a colon", lyr.getFeatureType().getTypeName().contains(":"));
+                    try {
+                        FeatureSource fs2 = lyr.getFeatureType().openGeoToolsFeatureSource();
+                        assertThat("No exception was thrown and featuresource not null", fs2, not(nullValue()));
+                    } catch (Exception ex) {
+                        log.error("Opening featuresource failed.", ex);
+                        fail("Opening featuresource failed.");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void addService() {
+        if (serviceProtocol.equalsIgnoreCase("wfs")) {
+            log.debug("Starting WFS test with: " + this.toString());
+            try {
+                sb = new AttributeSourceActionBean();
+                sb.setContext(context);
+                sb.setProtocol(serviceProtocol);
+                sb.setUrl(serviceUrl);
+                sb.setName(serviceName);
+                sb.addService(entityManager);
+            } catch (Exception ex) {
+                log.error("Saving WFS attribute source failed", ex);
+                fail("Saving WFS attribute source failed.");
+            }
+
+            WFSFeatureSource fs = (WFSFeatureSource) sb.getFeatureSource();
+            List<SimpleFeatureType> types = fs.getFeatureTypes();
+            assertEquals("The number of layers should be the same", serviceTypeCount, types.size());
+            for (SimpleFeatureType type : types) {
+                log.debug("Testing type: " + type.getTypeName());
+                assertFalse("Type name does not contain a colon", type.getTypeName().contains(":"));
+                try {
+                    FeatureSource fs2 = type.openGeoToolsFeatureSource();
+                    assertThat("No exception was thrown and featuresource not null", fs2, not(nullValue()));
+                } catch (Exception ex) {
+                    log.error("Opening featuresource failed.", ex);
+                    fail("Opening featuresource failed.");
+                }
             }
         }
     }
@@ -152,6 +217,7 @@ public class WFSTypeNamingTest extends TestUtil {
         return this.getClass().getCanonicalName()
                 + ", serviceUrl: " + this.serviceUrl
                 + ", serviceName: " + this.serviceName
-                + ", typeCount: " + this.serviceTypeCount;
+                + ", typeCount: " + this.serviceTypeCount
+                + ", groupLayerCount: " + this.groupLayerCount;
     }
 }

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
@@ -739,7 +739,10 @@ public class WMSService extends GeoService implements Updatable {
                         log.warn("Cannot handle multiple typeNames for layer " + l.getName() + ", only using the first. Type names: " + Arrays.toString(ld.getQueries()));
                     }
                     // Queries is not empty, checked before this method is called
-                    SimpleFeatureType sft = wfsFs.getFeatureType(uniqueQueries.first());
+                    // replace any colon in the feature type name as geotools gt-wfs-ng does this as well
+                    // ie the namespace:typename separator ':' is replaced by a '_'
+                    // see: https://github.com/flamingo-geocms/flamingo/issues/519
+                    SimpleFeatureType sft = wfsFs.getFeatureType(uniqueQueries.first().replace(':', '_'));
                     if(sft != null) {
                         // Type name may not exist in the referenced WFS
                         l.setFeatureType(sft);


### PR DESCRIPTION
ie. the namespace:typename separator ':' is replaced by a '_' giving namespace_typename

close #519
