### PR TITLE
Filter geometry fields from the featureinfo pop-out window

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -892,6 +892,22 @@ Ext.define("viewer.viewercontroller.ViewerController", {
         return layerObj;
     },
     /**
+     * Get the geometry attributes from the argument.
+     * @param {appLayer} the initialized appLayer
+     * @returns {Array} of attributes
+     */
+    getAppLayerGeometryAttributes: function (appLayer) {
+        var geomFields = appLayer.attributes.filter(function (obj) {
+            if (obj.type === "polygon" || obj.type === "multipolygon"
+                    || obj.type === "point" || obj.type === "multipoint"
+                    || obj.type === "multilinestring" || obj.type === "linestring"
+                    || obj.type === "geometry") {
+                return obj.alias || obj.name;
+            }
+        });
+        return geomFields;
+    },
+    /**
      *Get map layer with id of the layer in the service object
      *@param id the id of the layer in a service object
      *@return viewer.viewercontroller.controller.Layer object

--- a/viewer/src/main/webapp/viewer-html/components/FeatureInfo-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/FeatureInfo-config.js
@@ -131,6 +131,14 @@ Ext.define("viewer.components.CustomConfiguration",{
                     inputValue: true,
                     checked: this.configObject.detailShowAttr !== undefined ? this.configObject.detailShowAttr : true,
                     labelWidth:this.labelWidth
+                }, {
+                    xtype: 'checkbox',
+                    fieldLabel: 'Verberg geometrie attributen',
+                    name: 'detailHideGeomAttr',
+                    id: 'detailHideGeomAttr',
+                    inputValue: true,
+                    checked: this.configObject.detailHideGeomAttr !== undefined ? this.configObject.detailHideGeomAttr : true,
+                    labelWidth: this.labelWidth
                 }
             ]
         } 

--- a/viewer/src/main/webapp/viewer-html/components/Maptip.js
+++ b/viewer/src/main/webapp/viewer-html/components/Maptip.js
@@ -34,6 +34,7 @@ Ext.define ("viewer.components.Maptip",{
         detailShowTitle: true,
         detailShowDesc: true,
         detailShowImage: true,
+        detailHideGeomAttr: true,
         heightDescription: null,
         clickRadius:null,
         spinnerWhileIdentify:null
@@ -466,14 +467,30 @@ Ext.define ("viewer.components.Maptip",{
                 featureDiv.appendChild(descriptionDiv);
             }
         }
-        if (this.config.detailShowAttr){
+        if (this.config.detailShowAttr) {
             //attributes:
-            if (!Ext.isEmpty(feature)){
-                var html="<table>";
+            if (!Ext.isEmpty(feature)) {
+                // find geometry attributes, a WFS attribute source may provide more than one geometry attribute,
+                // and a join may result in more than one as well
+                var geomFields = this.config.viewerController.getAppLayerGeometryAttributes(appLayer);
+
+                var html = "<table>";
+                outerloop:
                 for( var key in feature) {
                     if (!feature.hasOwnProperty(key) || key === "related_featuretypes" || key === "__fid") {
                         continue;
                     }
+                    if (!this.detailHideGeomAttr) {
+                        if (key === appLayer.geometryAttribute) {
+                            continue;
+                        }
+                        for (var n = 0; n < geomFields.length; n++) {
+                            if (key === geomFields[n].name || key === geomFields[n].alias) {
+                                continue outerloop;
+                            }
+                        }
+                    }
+
                     html+="<tr>"
                     html+="<td class='feature_detail_attr_key'>"+key+"</td>";
                     var value = String(feature[key]);


### PR DESCRIPTION
In some cases it's necessary to send the feature geometry to the client when using a feature info, eg. when you want to create a factsheet/printout and want to zoom in to the feature.

The downside is that the second level feature info popup (eg. "toon alle gegevens" link) will show the geometry (or geometries) which is generally unwanted.

This changes the behaviour of the pop-out window to skip rendering geometry fields in the table of all attributes
