### PR TITLE
Add a css class to labels of the editing fields

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -56,6 +56,7 @@ Ext.define("viewer.components.Edit", {
             minHeight: 250
         }
     },
+    editLblClass: 'editCmpLbl',
     constructor: function (conf) {
         this.initConfig(conf);
 		viewer.components.Edit.superclass.constructor.call(this, this.config);
@@ -504,7 +505,8 @@ Ext.define("viewer.components.Edit", {
             name: attribute.name,
             fieldLabel: attribute.editAlias || attribute.name,
             value: fieldText,
-            disabled: !this.allowedEditable(attribute)
+            disabled: !this.allowedEditable(attribute),
+            labelClsExtra: editLblClass
         };
         var input;
         if (attribute.editHeight) {
@@ -518,7 +520,7 @@ Ext.define("viewer.components.Edit", {
             // FeatureToJson#formatValue eg. 14-11-2013 00:00:00
             // Ext uses PHP conventions! see:
             // https://docs.sencha.com/extjs/5.1/5.1.0-apidocs/#!/api/Ext.Date
-            options.format = 'd-m-Y H:i:s';
+            options.format = 'd-m-Y';
             options.altFormats = 'd-m-y|d-M-Y';
             // ISO 8601 (local time + UTC offset)
             options.submitFormat = 'c';
@@ -614,7 +616,8 @@ Ext.define("viewer.components.Edit", {
             id: attribute.name,
             valueField: 'id',
             disabled: !this.allowedEditable(attribute),
-            editable: !(attribute.hasOwnProperty('allowValueListOnly') && attribute.allowValueListOnly)
+            editable: !(attribute.hasOwnProperty('allowValueListOnly') && attribute.allowValueListOnly),
+            labelClsExtra: editLblClass
         });
 
         if (attribute.hasOwnProperty('disallowNullValue') && attribute.disallowNullValue) {


### PR DESCRIPTION
This adds a css class `editCmpLbl` to the labels so these can be styled using an external stylesheet eg. to change the width of the label

``` css
.editCmpLbl {
    width: 205px !important;
}
.editCmpLbl span {
    width: 200px !important;
}
```

Also use day-month-year formatting for the date picker in the edit fields (and omit the timestamp)
