### PR TITLE
Better default application handling

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayoutManagerActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayoutManagerActionBean.java
@@ -74,6 +74,7 @@ public class LayoutManagerActionBean extends ApplicationActionBean {
     private Boolean loadCustomConfig = false;
     private JSONObject details;
     private String appConfigJSON;
+    private String defaultAppId;
 
     // <editor-fold defaultstate="collapsed" desc="getters and setters">
     public JSONArray getComponents() {
@@ -178,6 +179,14 @@ public class LayoutManagerActionBean extends ApplicationActionBean {
 
     public void setAppConfigJSON(String appConfigJSON) {
         this.appConfigJSON = appConfigJSON;
+    }
+
+    public String getDefaultAppId() {
+        return defaultAppId;
+    }
+
+    public void setDefaultAppId(String defaultAppId) {
+        this.defaultAppId = defaultAppId;
     }
     //</editor-fold>
     

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayoutManagerActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/LayoutManagerActionBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2013 B3Partners B.V.
+ * Copyright (C) 2011-2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,6 +75,7 @@ public class LayoutManagerActionBean extends ApplicationActionBean {
     private JSONObject details;
     private String appConfigJSON;
     private String defaultAppId;
+    private List<Application> apps;
 
     // <editor-fold defaultstate="collapsed" desc="getters and setters">
     public JSONArray getComponents() {
@@ -187,6 +188,14 @@ public class LayoutManagerActionBean extends ApplicationActionBean {
 
     public void setDefaultAppId(String defaultAppId) {
         this.defaultAppId = defaultAppId;
+    }
+
+    public List<Application> getApps() {
+        return apps;
+    }
+
+    public void setApps(List<Application> apps) {
+        this.apps = apps;
     }
     //</editor-fold>
     

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/application/chooseApplication.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/application/chooseApplication.jsp
@@ -43,7 +43,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div class="applicaties">
                     <stripes:form beanclass="nl.b3p.viewer.admin.stripes.ChooseApplicationActionBean">
                         <stripes:select id="defaultAppSelector" name="defaultAppId" value="${actionBean.defaultAppId}" style="display: none;">
-                            <stripes:option label="- Kies een applicatie - "/>
+                            <stripes:option label="- Kies een applicatie - " value="" />
                             <stripes:options-collection collection="${actionBean.apps}" label="nameWithVersion"></stripes:options-collection>
                         </stripes:select>
                     </stripes:form>

--- a/viewer-admin/src/main/webapp/resources/js/application/chooseApplication.js
+++ b/viewer-admin/src/main/webapp/resources/js/application/chooseApplication.js
@@ -253,11 +253,19 @@ Ext.define('vieweradmin.components.ChooseApplication', {
         });
     },
     
-    defaultApplicationChanged : function(combobox, application){
-         Ext.Ajax.request({
+    defaultApplicationChanged: function (combobox, application) {
+        var defaultApp, appLabel;
+        if (application === null) {
+            defaultApp = null;
+            appLabel = 'uitgezet'
+        } else {
+            defaultApp = application.get('value');
+            appLabel = ': "' + application.get('label') + '"';
+        }
+        Ext.Ajax.request({
             url: this.config.setDefaultApplication,
             params: {
-                defaultApplication: application.get('value')
+                defaultApplication: defaultApp
             },
             scope: this,
             success: function(result) {
@@ -266,7 +274,7 @@ Ext.define('vieweradmin.components.ChooseApplication', {
                 if(!response.success) {
                     Ext.Msg.alert('Fout bij opslaan', 'Er is iets fout gegaan bij het opslaan van de standaard applicatie. Probeer opnieuw.');
                 } else {
-                    Ext.Msg.alert('Standaard applicatie opgeslagen', 'De standaard applicatie is opgeslagen. De nieuwe standaard applicatie is ' + application.get('label'));
+                    Ext.Msg.alert('Standaard applicatie opgeslagen', 'De standaard applicatie is opgeslagen. De standaard applicatie is nu' + appLabel);
                 }
             },
             failure: function(result) {


### PR DESCRIPTION
This adds a  `defaultAppId` property to the LayoutManagerActionBean to prevent a NPE (close #597) and allows setting a `null` value for the default app, effectively unsetting the property.

There is still some strangeness when the session expires; when the session has expired and the user changes the value, the backed sends the login page as a response; this is not handled properly.
