### PR TITLE
Upgrades the closure compiler dependency to a current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>com.google.javascript</groupId>
                 <artifactId>closure-compiler</artifactId>
-                <version>rr2079.1</version>
+                <version>v20160619</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>guava</artifactId>

--- a/viewer-commons/src/main/java/nl/b3p/viewer/components/ComponentRegistry.java
+++ b/viewer-commons/src/main/java/nl/b3p/viewer/components/ComponentRegistry.java
@@ -16,8 +16,11 @@
  */
 package nl.b3p.viewer.components;
 
+import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.Compiler;
-import com.google.javascript.jscomp.*;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.SourceFile;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -69,9 +72,9 @@ public class ComponentRegistry {
                 Compiler compiler = new Compiler();
                 CompilerOptions options = new CompilerOptions();
                 CompilationLevel.WHITESPACE_ONLY.setOptionsForCompilationLevel(options);
-                options.setOutputCharset("UTF-8");
+                options.setOutputCharset(Charset.forName("UTF-8"));
 
-                compiler.compile(JSSourceFile.fromCode("dummy.js",""), JSSourceFile.fromFile(filename, Charset.forName("UTF-8")), options);
+                compiler.compile(SourceFile.fromCode("dummy.js", ""), SourceFile.fromFile(filename, Charset.forName("UTF-8")), options);
 
                 if(compiler.hasErrors()) {
                     log.warn(compiler.getErrorCount() + " error(s) minifying source file " + filename + "; using original source");
@@ -83,7 +86,7 @@ public class ComponentRegistry {
                                 i+1,
                                 error.lineNumber,
                                 error.getCharno(),
-                                error.level.toString(),
+                                error.getDefaultLevel(),
                                 error.description);
                         log.warn(er);
                     }
@@ -101,9 +104,9 @@ public class ComponentRegistry {
                         /* NOTE: org.json version in Maven repo's don't ignore
                          * comments before '['! Patched version is in local repo.
                          */
-                        JSONArray components = new JSONArray(contents);
-                        for(int i = 0; i < components.length(); i++) {
-                            loadComponentMetadata(path, components.getJSONObject(i));
+                        JSONArray cpms = new JSONArray(contents);
+                        for (int i = 0; i < cpms.length(); i++) {
+                            loadComponentMetadata(path, cpms.getJSONObject(i));
                         }
                     } catch(JSONException e2) {
                         log.error("Exception parsing file " + file, e2);

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ComponentActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ComponentActionBean.java
@@ -16,13 +16,17 @@
  */
 package nl.b3p.viewer.stripes;
 
+import com.google.javascript.jscomp.CompilationLevel;
 import com.google.javascript.jscomp.Compiler;
-import com.google.javascript.jscomp.*;
+import com.google.javascript.jscomp.CompilerOptions;
+import com.google.javascript.jscomp.JSError;
+import com.google.javascript.jscomp.SourceFile;
 import java.util.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import javax.servlet.http.HttpServletResponse;
 import net.sourceforge.stripes.action.*;
 import net.sourceforge.stripes.controller.LifecycleStage;
@@ -258,8 +262,8 @@ public class ComponentActionBean implements ActionBean {
             Compiler compiler = new Compiler();
             CompilerOptions options = new CompilerOptions();
             CompilationLevel.SIMPLE_OPTIMIZATIONS.setOptionsForCompilationLevel(options);
-            options.setOutputCharset("UTF-8");
-            compiler.compile(JSSourceFile.fromCode("dummy.js",""), JSSourceFile.fromFile(f), options);
+            options.setOutputCharset(Charset.forName("UTF-8"));
+            compiler.compile(SourceFile.fromCode("dummy.js", ""), SourceFile.fromFile(f), options);
 
             if(compiler.hasErrors()) {
                 log.warn(compiler.getErrorCount() + " error(s) minifying source file " + f.getCanonicalPath() + "; using original source");
@@ -271,7 +275,7 @@ public class ComponentActionBean implements ActionBean {
                             i+1,
                             error.lineNumber,
                             error.getCharno(),
-                            error.level.toString(),
+                            error.getDefaultLevel(),
                             error.description));
                 }
                 


### PR DESCRIPTION
This was attempted earlier (a4c8f914fc5f5dc80e057be6024a2e47622c5a5a), but reverted as at that time we were still aiming to be java 6 compatible, we're now aiming to be java 7 compatible

see #620 
