### PR TITLE
Upgrade Xalan from 2.7.0 to 2.7.2, XercesImpl from 2.7.1 to 2.11.0, FOP from 1.0 to 2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
             <dependency>
                 <groupId>xalan</groupId>
                 <artifactId>xalan</artifactId>
-                <version>2.7.0</version>
+                <version>2.7.2</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>fop</artifactId>
-                <version>1.0</version>
+                <version>2.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.7.1</version>
+                <version>2.11.0</version>
             </dependency>
 
             <!-- nl b3p csw-->

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -136,9 +136,15 @@ public class PrintActionBean implements ActionBean {
                     jarray = new JSONArray();
                     jarray.put(o);
                 }
-                for (int i=0; i < jarray.length();i++){
-                    JSONObject legendJson = new JSONObject(jarray.getString(i));
-                    Legend legend = new Legend(legendJson);   
+                for (int i = 0; i < jarray.length(); i++) {
+                    JSONObject legendJson;
+                    try {
+                        legendJson = jarray.getJSONObject(i);
+                    } catch (JSONException jse) {
+                        // for some historic reason the print component sends double encoded json for legend url
+                        legendJson = new JSONObject(jarray.getString(i));
+                    }
+                    Legend legend = new Legend(legendJson);
                     info.getLegendUrls().add(legend);
                 }
             }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -154,9 +154,10 @@ public class PrintActionBean implements ActionBean {
         }
         
         final String mimeType;
-        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("saveRTF")){
-            mimeType=MimeConstants.MIME_RTF;
-        }else if(jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("savePDF")){
+//        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("saveRTF")){
+//            mimeType=MimeConstants.MIME_RTF;
+//        }else
+        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("savePDF")) {
             mimeType=MimeConstants.MIME_PDF;
         }else if(jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("mailPDF")){
             mimeType=MimeConstants.MIME_PDF;
@@ -217,10 +218,13 @@ public class PrintActionBean implements ActionBean {
                 /* Set filename and extension */
                 String filename = "Kaart_" + info.getDate();
 
-                if (mimeType.equals(MimeConstants.MIME_PDF)) {
-                    filename += ".pdf";
-                } else if (mimeType.equals(MimeConstants.MIME_RTF)) {
-                    filename += ".rtf";
+                switch (mimeType) {
+                    case MimeConstants.MIME_PDF:
+                        filename += ".pdf";
+                        break;
+//                    case MimeConstants.MIME_RTF:
+//                        filename += ".rtf";
+//                        break;
                 }
                 if (templateUrl.toLowerCase().startsWith("http://") || templateUrl.toLowerCase().startsWith("ftp://")){
                     PrintGenerator.createOutput(info,mimeType, new URL(templateUrl),true,response,filename);

--- a/viewer/src/main/webapp/viewer-html/components/Print-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Print-config.js
@@ -85,15 +85,15 @@ Ext.define("viewer.components.CustomConfiguration",{
                 name: "max_imagesize",
                 value: me.configObject.max_imagesize ? me.configObject.max_imagesize :"2048"
             },{
-                xtype: "label",
-                text: "RTF-Knop",
-                style: "font-weight: bold;"                
-            },{
-                xtype: "checkbox",
-                name: "showPrintRtf",
-                checked: me.configObject.showPrintRtf ? me.configObject.showPrintRtf : true,
-                boxLabel: "Laat de print via RTF knop zien"
-            },{
+//                xtype: "label",
+//                text: "RTF-Knop",
+//                style: "font-weight: bold;"
+//            },{
+//                xtype: "checkbox",
+//                name: "showPrintRtf",
+//                checked: me.configObject.showPrintRtf ? me.configObject.showPrintRtf : true,
+//                boxLabel: "Laat de print via RTF knop zien"
+//            },{
                 xtype: "label",
                 text: "Overzichtskaart",
                 style: "font-weight: bold;"                

--- a/viewer/src/main/webapp/viewer-html/components/Print.js
+++ b/viewer/src/main/webapp/viewer-html/components/Print.js
@@ -41,7 +41,7 @@ Ext.define ("viewer.components.Print",{
         orientation: null,
         legend: null,
         max_imagesize: "2048",
-        showPrintRtf:null,
+//        showPrintRtf:null,
         label: "",
         overview:null,
         mailprint:null,
@@ -57,7 +57,7 @@ Ext.define ("viewer.components.Print",{
      * creating a print module.
      */
     constructor: function (conf){
-        if(!Ext.isDefined(conf.showPrintRtf)) conf.showPrintRtf = true;
+//        if(!Ext.isDefined(conf.showPrintRtf)) conf.showPrintRtf = true;
         this.initConfig(conf);
         viewer.components.Print.superclass.constructor.call(this, this.config);
         this.legends=[];
@@ -467,23 +467,23 @@ Ext.define ("viewer.components.Print",{
                         }
                     }
                 },{
-                    xtype: 'button',
-                    text: 'Opslaan als RTF'  ,
-                    hidden: !this.showPrintRtf || this.config.mailPrint === "canOnlyMail",
-                    componentCls: 'mobileLarge',
-                    style: {
-                        "float": "right",
-                        marginLeft: '5px'
-                    },
-                    listeners: {
-                        click:{
-                            scope: this,
-                            fn: function (){
-                                this.submitSettings("saveRTF");
-                            }
-                        }
-                    }
-                },{
+//                    xtype: 'button',
+//                    text: 'Opslaan als RTF'  ,
+//                    hidden: !this.showPrintRtf || this.config.mailPrint === "canOnlyMail",
+//                    componentCls: 'mobileLarge',
+//                    style: {
+//                        "float": "right",
+//                        marginLeft: '5px'
+//                    },
+//                    listeners: {
+//                        click:{
+//                            scope: this,
+//                            fn: function (){
+//                                this.submitSettings("saveRTF");
+//                            }
+//                        }
+//                    }
+//                },{
                     xtype: 'button',
                     text: 'Printen via PDF'  ,
                     hidden: this.config.mailPrint === "canOnlyMail",

--- a/viewer/src/main/webapp/viewer-html/components/Print.js
+++ b/viewer/src/main/webapp/viewer-html/components/Print.js
@@ -733,6 +733,7 @@ Ext.define ("viewer.components.Print",{
     */
     submitSettings: function(action){
         var properties = this.getAllProperties(action);
+        // console.debug("submitting print values:", properties);
         Ext.getCmp('formParams').setValue(Ext.JSON.encode(properties));
         //this.combineImageService.getImageUrl(Ext.JSON.encode(properties),this.imageSuccess,this.imageFailure);
         this.printForm.submit({


### PR DESCRIPTION
These updates fix the following security issues: 
- [CVE-2014-0107](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0107)
- [CVE-2015-0250](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0250)
## Xalan

upgrade from 2.7.1 to 2.7.2 fixes some security issues as well as some bugs: https://xalan.apache.org/xalan-j/readme.html#notes_latest and the upgrade from 2.7.0 to 2.7.1 fixes a large number of bugs: https://xalan.apache.org/xalan-j/readme.html#notes_271
## Xerces

The Xalan project recommends having an in-sync version of Xerces in our project; so also upgrading xercexImpl from 2.7.1 to 2.11.0 

Xerces release notes: https://xerces.apache.org/xerces2-j/releases.html
## FOP

FOP relies heavily on xalan, so pull this up to a recent release as well.
- [x] disable RTF export ~~fix known issue of RTF not supporting gif/png (https://issues.apache.org/jira/browse/FOP-2156)~~ 

FOP upgrade notes: https://xmlgraphics.apache.org/fop/2.1/upgrading.html

see also: #620 and #664
