### PR TITLE
Upgrade to GeoTools 14.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 
 addons:
   postgresql: "9.4"
+  hosts: travis-fla4
   hostname: travis-fla4
 
 before_install:
@@ -13,6 +14,8 @@ before_install:
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
   # create Flamingo database
+  - psql --version
+  - psql -U postgres -d postgres -c 'SELECT Version();'
   - psql -U postgres -a -c "CREATE ROLE flamingo4 LOGIN PASSWORD 'flamingo4' SUPERUSER CREATEDB;"
   - psql -U postgres -a -c 'create database flamingo4;'
   - psql -U postgres -a -c 'ALTER DATABASE flamingo4 OWNER TO flamingo4;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - unzip -qq apache-maven-3.3.9-bin.zip
   - export M2_HOME=$PWD/apache-maven-3.3.9
   - export PATH=$M2_HOME/bin:$PATH
+  - export PAGER=cat
   # create Flamingo database
   - psql --version
   - psql -U postgres -d postgres -c 'SELECT Version();'

--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,11 @@
         <project.build.targetVersion>1.7</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>14.4</geotools.version>
+        <geotools.version>14.5</geotools.version>
         <powermock.version>1.5.5</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>9.4.1207</postgresql.version>
+        <postgresql.version>9.4.1209.jre7</postgresql.version>
         <apache.poi.version>3.14</apache.poi.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->


### PR DESCRIPTION
Tweak the Travis-CI build and update the postgresql test dependency while we're here.
- releasenotes:  https://osgeo-org.atlassian.net/secure/ReleaseNote.jspa?projectId=10001&version=13400
- blogpost: https://geotoolsnews.blogspot.nl/2016/08/geotools-145-released.html

see also: #620 
