### PR TITLE
[WIP] Restore RTF printing

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
@@ -46,6 +46,7 @@ import org.apache.fop.apps.FOPException;
 import org.apache.fop.apps.FOUserAgent;
 import org.apache.fop.apps.Fop;
 import org.apache.fop.apps.FopFactory;
+import org.xml.sax.SAXException;
 
 /**
  *
@@ -102,13 +103,13 @@ public class PrintGenerator  implements Runnable{
     
     
     public static void createOutput(PrintInfo info, String mimeType, File xslFile,
-            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException {
+            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException, SAXException {
 
         String path = new File(xslFile.getParent()).toURI().toString();
         createOutput(info, mimeType, new FileInputStream(xslFile), path, addJavascript, response,filename);
     }
     public static void createOutput(PrintInfo info, String mimeType, URL xslUrl,
-            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException {
+            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException, SAXException {
 
         String path = xslUrl.toString().substring(0, xslUrl.toString().lastIndexOf("/")+1);
         createOutput(info, mimeType, xslUrl.openStream(), path, addJavascript, response,filename);
@@ -126,7 +127,7 @@ public class PrintGenerator  implements Runnable{
      * @throws IOException if saving the image fails
      */
     public static void createOutput(PrintInfo info, String mimeType, InputStream xslIs, String basePath,
-            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException {
+            boolean addJavascript, HttpServletResponse response, String filename) throws URISyntaxException, IOException, SAXException {
 
   
         /* Setup output stream */
@@ -153,10 +154,11 @@ public class PrintGenerator  implements Runnable{
     
     
     public static void createOutput(PrintInfo info, String mimeType, InputStream xslIs, String basePath, OutputStream out, String filename)
-            throws URISyntaxException, IOException {
+            throws URISyntaxException, IOException, SAXException {
         
         /* Setup fopfactory */
-        FopFactory fopFactory = FopFactory.newInstance(new URI(basePath));
+        FopFactory fopFactory = FopFactory.newInstance(new URI(basePath),
+                PrintGenerator.class.getClassLoader().getResourceAsStream("fop.xconf"));
 
         try {
             /* Construct fop */

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -160,10 +160,9 @@ public class PrintActionBean implements ActionBean {
         }
         
         final String mimeType;
-//        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("saveRTF")){
-//            mimeType=MimeConstants.MIME_RTF;
-//        }else
-        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("savePDF")) {
+        if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("saveRTF")){
+            mimeType=MimeConstants.MIME_RTF;
+        } else if (jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("savePDF")) {
             mimeType=MimeConstants.MIME_PDF;
         }else if(jRequest.has("action") && jRequest.getString("action").equalsIgnoreCase("mailPDF")){
             mimeType=MimeConstants.MIME_PDF;
@@ -228,9 +227,9 @@ public class PrintActionBean implements ActionBean {
                     case MimeConstants.MIME_PDF:
                         filename += ".pdf";
                         break;
-//                    case MimeConstants.MIME_RTF:
-//                        filename += ".rtf";
-//                        break;
+                    case MimeConstants.MIME_RTF:
+                        filename += ".rtf";
+                        break;
                 }
                 if (templateUrl.toLowerCase().startsWith("http://") || templateUrl.toLowerCase().startsWith("ftp://")){
                     PrintGenerator.createOutput(info,mimeType, new URL(templateUrl),true,response,filename);

--- a/viewer/src/main/resources/fop.xconf
+++ b/viewer/src/main/resources/fop.xconf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fop version="1.0">
+    <image-loading>
+        <penalty value="-1000" class="org.apache.xmlgraphics.image.loader.impl.PreloaderRawPNG"/>
+        <penalty value="-1000" class="org.apache.xmlgraphics.image.loader.impl.ImageLoaderRawPNG"/>
+        <penalty value="1000" class="org.apache.xmlgraphics.image.loader.impl.ImageLoaderPNG"/>
+        <penalty value="1000" class="org.apache.xmlgraphics.image.loader.impl.imageio.ImageLoaderImageIO"/>
+    </image-loading>
+</fop>

--- a/viewer/src/main/webapp/viewer-html/components/Print.js
+++ b/viewer/src/main/webapp/viewer-html/components/Print.js
@@ -41,7 +41,7 @@ Ext.define ("viewer.components.Print",{
         orientation: null,
         legend: null,
         max_imagesize: "2048",
-//        showPrintRtf:null,
+        showPrintRtf:null,
         label: "",
         overview:null,
         mailprint:null,
@@ -57,7 +57,7 @@ Ext.define ("viewer.components.Print",{
      * creating a print module.
      */
     constructor: function (conf){
-//        if(!Ext.isDefined(conf.showPrintRtf)) conf.showPrintRtf = true;
+        if(!Ext.isDefined(conf.showPrintRtf)) conf.showPrintRtf = true;
         this.initConfig(conf);
         viewer.components.Print.superclass.constructor.call(this, this.config);
         this.legends=[];
@@ -467,23 +467,23 @@ Ext.define ("viewer.components.Print",{
                         }
                     }
                 },{
-//                    xtype: 'button',
-//                    text: 'Opslaan als RTF'  ,
-//                    hidden: !this.showPrintRtf || this.config.mailPrint === "canOnlyMail",
-//                    componentCls: 'mobileLarge',
-//                    style: {
-//                        "float": "right",
-//                        marginLeft: '5px'
-//                    },
-//                    listeners: {
-//                        click:{
-//                            scope: this,
-//                            fn: function (){
-//                                this.submitSettings("saveRTF");
-//                            }
-//                        }
-//                    }
-//                },{
+                    xtype: 'button',
+                    text: 'Opslaan als RTF'  ,
+                    hidden: !this.showPrintRtf || this.config.mailPrint === "canOnlyMail",
+                    componentCls: 'mobileLarge',
+                    style: {
+                        "float": "right",
+                        marginLeft: '5px'
+                    },
+                    listeners: {
+                        click:{
+                            scope: this,
+                            fn: function (){
+                                this.submitSettings("saveRTF");
+                            }
+                        }
+                    }
+                },{
                     xtype: 'button',
                     text: 'Printen via PDF'  ,
                     hidden: this.config.mailPrint === "canOnlyMail",


### PR DESCRIPTION
This is a work-in-progress to restore RTF printing, which was disabled in #659 

see also:
- bc0dfa69a51fb143f84e4a7d538206bfd4313754
- 8cefde5ba0c357d2e6de857b244676562e76f36b
- https://issues.apache.org/jira/browse/FOP-2156
- ~~https://issues.apache.org/jira/browse/XGC-97~~ (fixed)
- https://issues.apache.org/jira/browse/XGC-99

basically we need to wait for a new release of [FOP](https://xmlgraphics.apache.org/fop/trunk/#versions) (>2.1) and/or [XML Graphics Commons](https://xmlgraphics.apache.org/commons/#News) (>2.1)
