### PR TITLE
update mock libaries (mockito en powermock)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <geotools.version>14.5</geotools.version>
-        <powermock.version>1.5.5</powermock.version>
+        <powermock.version>1.6.5</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>9.4.1209.jre7</postgresql.version>
@@ -208,6 +208,12 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.10.19</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.geotools</groupId>
@@ -368,11 +374,6 @@
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi</artifactId>
                 <version>${apache.poi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.8.4</version>
             </dependency>
             <dependency>
                 <groupId>eu.medsea.mimeutil</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -123,6 +123,10 @@
             <scope>test</scope>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/AttributeSourceActionBeanTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/AttributeSourceActionBeanTest.java
@@ -21,7 +21,7 @@ import org.mockito.Mockito;
 
 /**
  *
- * @author Meine Toonen <meinetoonen@b3partners.nl>
+ * @author Meine Toonen
  */
 public class AttributeSourceActionBeanTest extends TestUtil {
 

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -60,10 +60,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
         </dependency>


### PR DESCRIPTION
org.powermock:powermock-api-mockito en org.powermock:powermock-module-junit4 van 1.5.5 naar 1.6.5, org.mockito:mockito-all van 1.8.4 naar 1.10.19

see #620
