### PR TITLE
Upgrade commons-lang3 and closure-compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,12 +142,12 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.4</version>
+                <version>3.5</version>
             </dependency>
             <dependency>
                 <groupId>com.google.javascript</groupId>
                 <artifactId>closure-compiler</artifactId>
-                <version>v20160911</version>
+                <version>v20161024</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -500,7 +500,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <source>${project.build.sourceVersion}</source>
                         <target>${project.build.targetVersion}</target>


### PR DESCRIPTION
Upgrade commons-lang3 and jsonassert dependencies:

  - commons-lang3: 3.4 -> 3.5 [release notes](https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.5.txt)
  - closure-compiler: v20160911 -> v20161024 [release notes](https://github.com/google/closure-compiler/wiki/Releases#october-24-2016-v20161024)

And upgrade Maven compiler plugin.