### PR TITLE
Upgrade jsonassert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>org.skyscreamer</groupId>
                 <artifactId>jsonassert</artifactId>
-                <version>1.3.0</version>
+                <version>1.4.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -165,6 +165,15 @@
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
+            <exclusions>
+                <exclusion>
+                    <!-- the F* vaadin team decided it would be a good idea to
+                        issue a lib packaged as org.json with incompatibe JSONArray -->
+                    <groupId>com.vaadin.external.google</groupId>
+                    <artifactId>android-json</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Upgrade jsonassert and give it `test` scope

  - jsonassert:    1.3.0 -> 1.4.0 [release notes](https://github.com/skyscreamer/JSONassert/releases)

_ps. an exclusion was added for the incompatible Vaadin version of json.org_