### PR TITLE
Library upgrades for Powermock and Closure compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <geotools.version>14.5</geotools.version>
-        <powermock.version>1.6.5</powermock.version>
+        <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>9.4.1209.jre7</postgresql.version>
@@ -147,7 +147,7 @@
             <dependency>
                 <groupId>com.google.javascript</groupId>
                 <artifactId>closure-compiler</artifactId>
-                <version>v20161024</version>
+                <version>v20161201</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -549,6 +549,9 @@
                 <plugin>
                     <groupId>nl.geodienstencentrum.maven</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
+                    <!-- current of the compiler versions (2.5 atm) fail on an inline finction:
+                    [ERROR] JSC_BAD_FUNCTION_DECLARATION. functions can only be declared at top level or immediately within another function in ES5 strict mode at /home/mark/dev/projects/flamingo/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js line 381 : 16
+                    -->
                     <version>2.4</version>
                 </plugin>
                 <plugin>
@@ -564,7 +567,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.tomcat.maven</groupId>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -336,6 +336,7 @@
                             <compilationLevel>SIMPLE_OPTIMIZATIONS</compilationLevel>
                             <compilerOptions>
                                 <prettyPrint>true</prettyPrint>
+                                <languageIn>ECMASCRIPT3</languageIn>
                             </compilerOptions>
                             <externFiles />
                             <sourceFiles>


### PR DESCRIPTION
- upgrade com.google.javascript:closure-compiler v20161024 -> v20161201
- upgrade org.powermock libraries 1.6.5 -> 1.6.6

Also update maven-site-plugin.