### PR TITLE
Use tomcat's LockOutRealm to prevent brute-force / dictionary attacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>9.4.1209.jre7</postgresql.version>
+        <postgresql.version>9.4.1212.jre7</postgresql.version>
         <apache.poi.version>3.15</apache.poi.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -195,7 +195,6 @@
                 <configuration>
                     <prefix>builddetails</prefix>
                     <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-                    <verbose>true</verbose>
                     <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
                     <skipPoms>true</skipPoms>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>
@@ -223,4 +222,102 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>travis-ci</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>${postgresql.version}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>read-project-properties</goal>
+                                </goals>
+                                <configuration>
+                                    <files>
+                                        <file>src/test/resources/postgres.properties</file>
+                                    </files>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                            <trimStackTrace>false</trimStackTrace>
+                            <testFailureIgnore>!${test.skip.integrationtests}</testFailureIgnore>
+                            <skipTests>!${test.skip.integrationtests}</skipTests>
+                            <systemPropertyVariables>
+                                <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
+                            </systemPropertyVariables>
+                            <useFile>false</useFile>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.tomcat.maven</groupId>
+                        <artifactId>tomcat7-maven-plugin</artifactId>
+                        <configuration>
+                            <port>9091</port>
+                            <contextFile>src/test/tomcatconf/context.xml</contextFile>
+                            <systemProperties />
+                            <useTestClasspath>true</useTestClasspath>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>tomcat-startup</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>pre-integration-test</phase>
+                                <configuration>
+                                    <fork>true</fork>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>tomcat-shutdown</id>
+                                <goals>
+                                    <goal>shutdown</goal>
+                                </goals>
+                                <phase>post-integration-test</phase>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>javax.mail</groupId>
+                                <artifactId>mail</artifactId>
+                                <version>1.4.7</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.postgresql</groupId>
+                                <artifactId>postgresql</artifactId>
+                                <version>${postgresql.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -59,7 +59,7 @@
   <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
   <!-- Security configuration -->
   <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
-  <Realm className="org.apache.catalina.realm.LockoutRealm">
+  <Realm className="org.apache.catalina.realm.LockOutRealm">
     <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/geo_viewer" digest="SHA-1" roleNameCol="group_" userCredCol="password" userNameCol="username" userRoleTable="user_groups" userTable="user_"/>
     <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):

--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -35,7 +35,7 @@
   <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
   <!-- For Tomcat: define JavaMail resource in server.xml. See:
 
-    http://tomcat.apache.org/tomcat-6.0-doc/jndi-resources-howto.html#JavaMail_Sessions
+    http://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html#JavaMail_Sessions
 
     Don't forget to put mail.jar in the Tomcat lib directory.
 
@@ -58,13 +58,13 @@
     -->
   <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
   <!-- Security configuration -->
-  <!-- Optional: use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
-  <Realm className="org.apache.catalina.realm.CombinedRealm">
+  <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
+  <Realm className="org.apache.catalina.realm.LockoutRealm">
     <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/geo_viewer" digest="SHA-1" roleNameCol="group_" userCredCol="password" userNameCol="username" userRoleTable="user_groups" userTable="user_"/>
     <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):
-             http://tomcat.apache.org/tomcat-6.0-doc/config/realm.html
-             http://tomcat.apache.org/tomcat-6.0-doc/realm-howto.html#JNDIRealm
+             http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html
+             http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#JNDIRealm
         -->
     <!--Realm className="org.apache.catalina.realm.JNDIRealm"
             allRolesMode="authOnly"

--- a/viewer-admin/src/main/webapp/WEB-INF/web.xml
+++ b/viewer-admin/src/main/webapp/WEB-INF/web.xml
@@ -5,7 +5,7 @@
         Note: for Tomcat, change these values in the Context in the Tomcat
         conf directory so it does not require modification of the deployment
         descriptor (this file) to customize these values.
-        http://tomcat.apache.org/tomcat-6.0-doc/config/context.html#Context_Parameters
+        http://tomcat.apache.org/tomcat-8.0-doc/config/context.html#Context_Parameters
     -->
     <context-param>
         <description>

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/ViewerAdminLockoutIntegrationTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/ViewerAdminLockoutIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 B3Partners B.V.
+ * Copyright (C) 2016 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,59 +14,69 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package nl.b3p.viewer;
+package nl.b3p.viewer.admin;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Scanner;
 import nl.b3p.viewer.util.databaseupdate.DatabaseSynchronizer;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
+ * test het tomcat lockout mechanisme.
  *
  * @author Mark Prins
  */
-public class ViewerIntegrationTest {
+public class ViewerAdminLockoutIntegrationTest {
 
     /**
      * the viewer url. {@value}
      */
-    public static final String BASE_TEST_URL = "http://localhost:9090/viewer/";
+    public static final String BASE_TEST_URL = "http://localhost:9091/viewer-admin/";
 
     /**
      * our test client.
      */
     private static CloseableHttpClient client;
+
+    private static final Properties POSTGRESPROP = new Properties();
+
     /**
      * our test response.
      */
     private HttpResponse response;
 
-    private static final Properties postgresprop = new Properties();
-
     /**
      * initialize database props.
+     *
      * @throws java.io.IOException if loading the property file fails
      */
     @BeforeClass
     public static void loadDBprop() throws IOException {
-        postgresprop.load(ViewerIntegrationTest.class.getClassLoader().getResourceAsStream("postgres.properties"));
+        POSTGRESPROP.load(ViewerAdminLockoutIntegrationTest.class.getClassLoader().getResourceAsStream("postgres.properties"));
     }
 
     /**
@@ -80,7 +90,7 @@ public class ViewerIntegrationTest {
     /**
      * close http client connections.
      *
-     * @throws IOException if any occurs closing th ehttp connection
+     * @throws IOException if any occurs closing the http connection
      */
     @AfterClass
     public static void tearDownClass() throws IOException {
@@ -88,7 +98,8 @@ public class ViewerIntegrationTest {
     }
 
     /**
-     * Test if the Flaming viewer application has started.
+     * Test if the Flamingo viewer-admin application has started and can be
+     * reached.
      *
      * @throws UnsupportedEncodingException if any
      * @throws IOException if any
@@ -101,34 +112,95 @@ public class ViewerIntegrationTest {
         assertNotNull("Response body should not be null.", body);
         assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
                 equalTo(HttpStatus.SC_OK));
+        assertTrue("Response moet 'Inloggen' title hebben.",
+                body.contains("<title>Inloggen</title>"));
     }
 
     /**
-     * test if the database has the right metadata version.
+     * Test login/index/about/logout sequentie.
      *
-     * @throws SQLException if something goes wrong executing the query
-     * @throws ClassNotFoundException if the postgres driver cannot be found.
+     * @throws IOException mag niet optreden
+     * @throws URISyntaxException mag niet optreden
      */
     @Test
-    public void testMetadataVersion() throws SQLException, ClassNotFoundException {
-        // get 'database_version' from table metadata and check that is has the value of '15'
-        Class.forName(postgresprop.getProperty("postgres.driverClassName"));
-        Connection connection = DriverManager.getConnection(
-                postgresprop.getProperty("postgres.url"),
-                postgresprop.getProperty("postgres.username"),
-                postgresprop.getProperty("postgres.password")
-        );
-        ResultSet rs = connection.createStatement().executeQuery("SELECT config_value FROM metadata WHERE config_key = 'database_version';");
+    @Ignore("fails because there is a problem setting up the jndi authentication realm")
+    public void testLoginLogout() throws IOException, URISyntaxException {
+        // login page
+        response = client.execute(new HttpGet(BASE_TEST_URL));
+        EntityUtils.consume(response.getEntity());
 
-        String actual_config_value = "-1";
-        while (rs.next()) {
-            actual_config_value = rs.getString("config_value");
+        HttpUriRequest login = RequestBuilder.post()
+                .setUri(new URI(BASE_TEST_URL + "j_security_check"))
+                .addParameter("j_username", "admin")
+                .addParameter("j_password", "flamingo")
+                .build();
+        response = client.execute(login);
+        EntityUtils.consume(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+
+        // index
+        response = client.execute(new HttpGet(BASE_TEST_URL + "index.jsp"));
+        String body = EntityUtils.toString(response.getEntity());
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'Beheeromgeving geo-viewers' title hebben.",
+                body.contains("<title>Beheeromgeving geo-viewers</title>"));
+
+        // about
+        response = client.execute(new HttpGet(BASE_TEST_URL + "about.jsp"));
+        body = EntityUtils.toString(response.getEntity());
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'About' title hebben.", body.contains("<title>About</title>"));
+
+        // logout
+        response = client.execute(new HttpGet(BASE_TEST_URL + "logout.jsp"));
+        body = EntityUtils.toString(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+        assertNotNull("Response body mag niet null zijn.", body);
+        assertTrue("Response moet 'Uitgelogd' heading hebben.", body.contains("<h1>Uitgelogd</h1>"));
+    }
+
+    @Test
+    @Ignore("fails because there is a problem setting up the jndi authentication realm")
+    public void testLockout() throws IOException, URISyntaxException {
+        response = client.execute(new HttpGet(BASE_TEST_URL));
+        EntityUtils.consume(response.getEntity());
+
+        HttpUriRequest login = RequestBuilder.post()
+                .setUri(new URI(BASE_TEST_URL + "j_security_check"))
+                .addParameter("j_username", "fout")
+                .addParameter("j_password", "fout")
+                .build();
+        response = client.execute(login);
+        EntityUtils.consume(response.getEntity());
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+
+//        String body = EntityUtils.toString(response.getEntity());
+//        assertNotNull("Response body mag niet null zijn.", body);
+//        assertTrue("Response moet 'Ongeldige logingegevens.' in pagina hebben.",
+//                body.contains("Ongeldige logingegevens."));
+
+        for (int c = 1; c < 6; c++) {
+            response = client.execute(login);
+            EntityUtils.consume(response.getEntity());
+            assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                    equalTo(HttpStatus.SC_OK));
         }
-        assertThat("There is only one 'database_version' record (first and last should be same record).", rs.isLast(), equalTo(rs.isFirst()));
+        // user 'fout' is now locked out, but we have no way to detect apart from looking in the cataline logfile,
+        //   the status for a form-based login page is (and should be) 200
 
-        rs.close();
-        connection.close();
-
-        assertEquals("The database version should be the same.", DatabaseSynchronizer.getUpdateNumber(), actual_config_value);
+        // the will be a message in catalina.out similar to: `WARNING .... An attempt was made to authenticate the locked user "test"`
+        Scanner s = new Scanner(ViewerAdminLockoutIntegrationTest.class.getClassLoader().getResourceAsStream("catalina.log"));
+        boolean lokkedOut = false;
+        while (s.hasNextLine()) {
+            final String lineFromFile = s.nextLine();
+            if (lineFromFile.contains("An attempt was made to authenticate the locked user \"test\"")) {
+                lokkedOut = true;
+                break;
+            }
+        }
+        assertTrue("gebruiker is buitengesloten", lokkedOut);
     }
 }

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/ViewerAdminLockoutIntegrationTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/ViewerAdminLockoutIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Properties;
+import nl.b3p.viewer.util.databaseupdate.DatabaseSynchronizer;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author Mark Prins
+ */
+public class ViewerIntegrationTest {
+
+    /**
+     * the viewer url. {@value}
+     */
+    public static final String BASE_TEST_URL = "http://localhost:9090/viewer/";
+
+    /**
+     * our test client.
+     */
+    private static CloseableHttpClient client;
+    /**
+     * our test response.
+     */
+    private HttpResponse response;
+
+    private static final Properties postgresprop = new Properties();
+
+    /**
+     * initialize database props.
+     * @throws java.io.IOException if loading the property file fails
+     */
+    @BeforeClass
+    public static void loadDBprop() throws IOException {
+        postgresprop.load(ViewerIntegrationTest.class.getClassLoader().getResourceAsStream("postgres.properties"));
+    }
+
+    /**
+     * initialize http client.
+     */
+    @BeforeClass
+    public static void setUpClass() {
+        client = HttpClientBuilder.create().build();
+    }
+
+    /**
+     * close http client connections.
+     *
+     * @throws IOException if any occurs closing th ehttp connection
+     */
+    @AfterClass
+    public static void tearDownClass() throws IOException {
+        client.close();
+    }
+
+    /**
+     * Test if the Flaming viewer application has started.
+     *
+     * @throws UnsupportedEncodingException if any
+     * @throws IOException if any
+     */
+    @Test
+    public void request() throws UnsupportedEncodingException, IOException {
+        response = client.execute(new HttpGet(BASE_TEST_URL));
+
+        final String body = EntityUtils.toString(response.getEntity());
+        assertNotNull("Response body should not be null.", body);
+        assertThat("Response status is OK.", response.getStatusLine().getStatusCode(),
+                equalTo(HttpStatus.SC_OK));
+    }
+
+    /**
+     * test if the database has the right metadata version.
+     *
+     * @throws SQLException if something goes wrong executing the query
+     * @throws ClassNotFoundException if the postgres driver cannot be found.
+     */
+    @Test
+    public void testMetadataVersion() throws SQLException, ClassNotFoundException {
+        // get 'database_version' from table metadata and check that is has the value of '15'
+        Class.forName(postgresprop.getProperty("postgres.driverClassName"));
+        Connection connection = DriverManager.getConnection(
+                postgresprop.getProperty("postgres.url"),
+                postgresprop.getProperty("postgres.username"),
+                postgresprop.getProperty("postgres.password")
+        );
+        ResultSet rs = connection.createStatement().executeQuery("SELECT config_value FROM metadata WHERE config_key = 'database_version';");
+
+        String actual_config_value = "-1";
+        while (rs.next()) {
+            actual_config_value = rs.getString("config_value");
+        }
+        assertThat("There is only one 'database_version' record (first and last should be same record).", rs.isLast(), equalTo(rs.isFirst()));
+
+        rs.close();
+        connection.close();
+
+        assertEquals("The database version should be the same.", DatabaseSynchronizer.getUpdateNumber(), actual_config_value);
+    }
+}

--- a/viewer-admin/src/test/resources/log4j.xml
+++ b/viewer-admin/src/test/resources/log4j.xml
@@ -25,6 +25,9 @@ LEVELS: debug, info, warn, error, fatal en off, all -->
     <logger name="org.hibernate.SQL">
         <level value="error" />
     </logger>
+    <logger name="org.apache.http.wire">
+        <level value="debug" />
+    </logger>
     <root>
         <level value="info" />
         <appender-ref ref="consoleAppender" />

--- a/viewer-admin/src/test/resources/postgres.properties
+++ b/viewer-admin/src/test/resources/postgres.properties
@@ -1,0 +1,4 @@
+postgres.username=flamingo4
+postgres.password=flamingo4
+postgres.driverClassName=org.postgresql.Driver
+postgres.url=jdbc:postgresql://localhost:5432/flamingo4

--- a/viewer-admin/src/test/tomcatconf/context.xml
+++ b/viewer-admin/src/test/tomcatconf/context.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Context path="/viewer-admin" reloadable="true" crossContext="true" backgroundProcessorDelay="5">
+    <Parameter name="componentregistry.path"
+               override="false"
+               value="/viewer-html/components"
+    />
+    
+    <!-- properties below are expanded at runtime and are available
+    in ../resources/postgres.properties -->
+    <Resource name="jdbc/geo_viewer"
+              auth="Container"
+              type="javax.sql.DataSource"
+              username="${postgres.username}"
+              password="${postgres.password}"
+              driverClassName="${postgres.driverClassName}"
+              url="${postgres.url}"
+              maxActive="40"
+              validationQuery="select 1"
+              timeBetweenEvictionRunsMillis="30000"
+              minEvictableIdleTimeMillis="5000"
+    />
+
+    <Resource name="mail/session"
+              auth="Container"
+              type="javax.mail.Session"
+              mail.smtp.host="localhost"
+              mail.smtp.from="no-reply@b3partners.nl"
+    />
+
+    <!-- org.apache.catalina.realm.CombinedRealm or org.apache.catalina.realm.LockOutRealm -->
+    <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm allRolesMode="authOnly"
+               className="org.apache.catalina.realm.DataSourceRealm"
+               dataSourceName="jdbc/geo_viewer"
+               digest="SHA-1"
+               roleNameCol="group_"
+               userCredCol="password"
+               userNameCol="username"
+               userRoleTable="user_groups"
+               userTable="user_"
+        />
+    </Realm>
+</Context>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -395,7 +395,6 @@
                 <configuration>
                     <prefix>builddetails</prefix>
                     <dateFormat>dd.MM.yyyy '@' HH:mm:ss z</dateFormat>
-                    <verbose>true</verbose>
                     <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
                     <skipPoms>true</skipPoms>
                     <generateGitPropertiesFile>true</generateGitPropertiesFile>

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -26,13 +26,13 @@
   <!-- Tomcat resource link -->
   <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
   <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
-  <!-- Optional: use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
-  <Realm className="org.apache.catalina.realm.CombinedRealm">
+  <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
+  <Realm className="org.apache.catalina.realm.LockOutRealm">
     <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/geo_viewer" digest="SHA-1" roleNameCol="group_" userCredCol="password" userNameCol="username" userRoleTable="user_groups" userTable="user_"/>
     <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):
-             http://tomcat.apache.org/tomcat-6.0-doc/config/realm.html
-             http://tomcat.apache.org/tomcat-6.0-doc/realm-howto.html#JNDIRealm
+             http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html
+             http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#JNDIRealm
         -->
     <!--Realm className="org.apache.catalina.realm.JNDIRealm"
             allRolesMode="authOnly"


### PR DESCRIPTION
Note that, because Flamingo uses form based authentication with the failed login providing the option to retry the HTTP response status is always 200-OK; this is expected behaviour; unless the failed login page page is rendered incorrectly or the failed login page requires authentication (which makes no sense!) 

So the only effect here is actually that the underlying database (JNDI authentication realm) is no longer hit with a request once a user is locked out; an automated brute-force script will still be able to send login requests indefinitely (to prevent this there should be a script that scans catalina.out and the request log an then instructs the firewall to block the misbehaving IP address.


close #726 

