### PR TITLE
Add a bean + client error handler to enable clients to send messages to the application log

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ClientsideErrorLoggerActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ClientsideErrorLoggerActionBean.java
@@ -37,7 +37,7 @@ import org.json.JSONObject;
 @StrictBinding
 public class ClientsideErrorLoggerActionBean implements ActionBean {
 
-    private static final Log LOG = LogFactory.getLog(CatalogSearchActionBean.class);
+    private static final Log LOG = LogFactory.getLog(ClientsideErrorLoggerActionBean.class);
     private ActionBeanContext context;
     @Validate
     private String msg;
@@ -52,10 +52,10 @@ public class ClientsideErrorLoggerActionBean implements ActionBean {
      */
     @DefaultHandler
     public Resolution log() {
-        LOG.warn(msg);
+        LOG.debug(msg);
 
         JSONObject json = new JSONObject();
-        json.put("logged", LOG.isWarnEnabled());
+        json.put("logged", LOG.isDebugEnabled());
 
         return new StreamingResolution("application/json", new StringReader(json.toString()));
     }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ClientsideErrorLoggerActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ClientsideErrorLoggerActionBean.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.stripes;
+
+import java.io.StringReader;
+import net.sourceforge.stripes.action.ActionBean;
+import net.sourceforge.stripes.action.ActionBeanContext;
+import net.sourceforge.stripes.action.DefaultHandler;
+import net.sourceforge.stripes.action.Resolution;
+import net.sourceforge.stripes.action.StreamingResolution;
+import net.sourceforge.stripes.action.StrictBinding;
+import net.sourceforge.stripes.action.UrlBinding;
+import net.sourceforge.stripes.validation.Validate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.json.JSONObject;
+
+/**
+ *
+ * @author mprins
+ */
+@UrlBinding("/action/errorlog")
+@StrictBinding
+public class ClientsideErrorLoggerActionBean implements ActionBean {
+
+    private static final Log LOG = LogFactory.getLog(CatalogSearchActionBean.class);
+    private ActionBeanContext context;
+    @Validate
+    private String msg;
+
+    /**
+     * Log the message to the application log with a WARN severity. The message
+     * will only show up in the log if the logging is setup for warn logging or
+     * lower.
+     *
+     * @return a success message {@code {"logged":true}} if warn level logging
+     * is enabled
+     */
+    @DefaultHandler
+    public Resolution log() {
+        LOG.warn(msg);
+
+        JSONObject json = new JSONObject();
+        json.put("logged", LOG.isWarnEnabled());
+
+        return new StreamingResolution("application/json", new StringReader(json.toString()));
+    }
+
+    @Override
+    public void setContext(ActionBeanContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public ActionBeanContext getContext() {
+        return this.context;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+
+}

--- a/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -1,9 +1,9 @@
 logFilePath=${catalina.base}/logs
 logFile=geo-viewer.log
 
-log4j.rootLogger=INFO,file
+log4j.rootLogger=DEBUG,file
 
-log4j.logger.nl.b3p=INFO
+log4j.logger.nl.b3p=DEBUG
 
 # Set to INFO or DEBUG to view more information about loading components
 log4j.logger.nl.b3p.viewer.components=INFO

--- a/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
+++ b/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
@@ -25,56 +25,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
+        <script type="text/javascript" src="${contextPath}/viewer-html/common/FlamingoErrorLogger.js"></script>
         <script type="text/javascript">
-
-            function FlamingoErrorLogger(messageOrEvent, source, lineno, colno) {
-                try {
-                    var request = null;
-                    var error = [];
-                    var basedata = [
-                        "Application ${actionBean.application.name} (${actionBean.application.id})",
-                        window.location
-                    ];
-                    if(window.navigator) {
-                        basedata.push(window.navigator.userAgent);
-                        basedata.push(window.navigator.platform);
-                    }
-                    error.push(basedata.join(" - "));
-
-                    if(typeof messageOrEvent === "string") {
-                        error.push(messageOrEvent);
-                        if(source) {
-                            error.push("Source: " + source);
-                        }
-                        if(lineno) {
-                            error.push("Line: " + lineno + "," + colno);
-                        }
-                    } else if(messageOrEvent instanceof Error) {
-                        error.push(messageOrEvent.name, messageOrEvent.message, messageOrEvent.stack, "Line: " + messageOrEvent.lineNumber + "," + messageOrEvent.columnNumber);
-                    } else {
-                        error.push(messageOrEvent);
-                    }
-
-                    if (window.XMLHttpRequest) {
-                        request = new XMLHttpRequest();
-                    } else if (window.ActiveXObject) { // IE
-                        try {
-                            request = new ActiveXObject('Msxml2.XMLHTTP');
-                        }
-                        catch (e) {
-                            try {
-                                request = new ActiveXObject('Microsoft.XMLHTTP');
-                            }
-                            catch (e) {}
-                        }
-                    }
-                    if(request !== null) {
-                        request.open('POST', <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ClientsideErrorLoggerActionBean"/></js:quote>, true);
-                        request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-                        request.send('msg=' + encodeURIComponent(error.join("\n\t")));
-                    }
-                } catch(e) {}
-            }
+            var FlamingoErrorLogger = createFlamingoErrorLogger(
+                "${actionBean.application.name}",
+                "${actionBean.application.id}",
+                <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ClientsideErrorLoggerActionBean"/></js:quote>
+            );
             window.onerror = FlamingoErrorLogger;
 
             var MobileManager = function() {

--- a/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
+++ b/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
@@ -26,6 +26,57 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
         <script type="text/javascript">
+
+            function FlamingoErrorLogger(messageOrEvent, source, lineno, colno) {
+                try {
+                    var request = null;
+                    var error = [];
+                    var basedata = [
+                        "Application ${actionBean.application.name} (${actionBean.application.id})",
+                        window.location
+                    ];
+                    if(window.navigator) {
+                        basedata.push(window.navigator.userAgent);
+                        basedata.push(window.navigator.platform);
+                    }
+                    error.push(basedata.join(" - "));
+
+                    if(typeof messageOrEvent === "string") {
+                        error.push(messageOrEvent);
+                        if(source) {
+                            error.push("Source: " + source);
+                        }
+                        if(lineno) {
+                            error.push("Line: " + lineno + "," + colno);
+                        }
+                    } else if(messageOrEvent instanceof Error) {
+                        error.push(messageOrEvent.name, messageOrEvent.message, messageOrEvent.stack, "Line: " + messageOrEvent.lineNumber + "," + messageOrEvent.columnNumber);
+                    } else {
+                        error.push(messageOrEvent);
+                    }
+
+                    if (window.XMLHttpRequest) {
+                        request = new XMLHttpRequest();
+                    } else if (window.ActiveXObject) { // IE
+                        try {
+                            request = new ActiveXObject('Msxml2.XMLHTTP');
+                        }
+                        catch (e) {
+                            try {
+                                request = new ActiveXObject('Microsoft.XMLHTTP');
+                            }
+                            catch (e) {}
+                        }
+                    }
+                    if(request !== null) {
+                        request.open('POST', <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ClientsideErrorLoggerActionBean"/></js:quote>, true);
+                        request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+                        request.send('msg=' + encodeURIComponent(error.join("\n\t")));
+                    }
+                } catch(e) {}
+            }
+            window.onerror = FlamingoErrorLogger;
+
             var MobileManager = function() {
                 // Originial script: http://detectmobilebrowsers.com
                 var mobile = (function(a){return(/android|avantgo|bada\/|blackberry|playbook|silk|blazer|compal|elaine|fennec|hiptop|iemobile|ip(ad|hone|od)|iris|kindle|lge |maemo|meego.+mobile|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(di|rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4)))})(navigator.userAgent||navigator.vendor||window.opera);
@@ -258,7 +309,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 "buffergeom":         <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.BufferActionBean" event="bufferGeometry"/></js:quote>,
                 "cyclorama":          <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.CycloramaActionBean"/></js:quote>,
                 "featureExtent":      <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.FeatureExtentActionBean"/></js:quote>
-                "errorlog":           <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ClientsideErrorLoggerActionBean"/></js:quote>
             };
 
             <c:if test="${actionBean.viewerType == 'openlayers'}">

--- a/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
+++ b/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
@@ -1,5 +1,5 @@
 <%--
-Copyright (C) 2011-2014 B3Partners B.V.
+Copyright (C) 2011-2016 B3Partners B.V.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -25,8 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
-		<script type="text/javascript">
-			var MobileManager = function() {
+        <script type="text/javascript">
+            var MobileManager = function() {
                 // Originial script: http://detectmobilebrowsers.com
                 var mobile = (function(a){return(/android|avantgo|bada\/|blackberry|playbook|silk|blazer|compal|elaine|fennec|hiptop|iemobile|ip(ad|hone|od)|iris|kindle|lge |maemo|meego.+mobile|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(a)||/1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(di|rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(a.substr(0,4)))})(navigator.userAgent||navigator.vendor||window.opera);
                 var ios = /ip(ad|hone|od)/i.test(navigator.userAgent);
@@ -57,7 +57,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             document.documentElement.className += ' mobile-mode';
                             document.write('<link rel="stylesheet" type="text/css" href="${contextPath}/extjs/resources/css/touch-crisp/ext-theme-crisp-touch-all.css">');
                     }
-		</script>
+        </script>
 
         <link href="${contextPath}/resources/css/viewer.css" rel="stylesheet">
 
@@ -117,14 +117,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <script type="text/javascript" src="${scriptDir}/ServiceInfo.js"></script>
                 <script type="text/javascript" src="${scriptDir}/CSWClient.js"></script>
                 <script type="text/javascript" src="${scriptDir}/FeatureExtent.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/FeatureService.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/SLD.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/Bookmark.js"></script>
+                <script type="text/javascript" src="${scriptDir}/FeatureService.js"></script>
+                <script type="text/javascript" src="${scriptDir}/SLD.js"></script>
+                <script type="text/javascript" src="${scriptDir}/Bookmark.js"></script>
                 <script type="text/javascript" src="${scriptDir}/LayerSelector.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/CombineImage.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/FeatureInfo.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/EditFeature.js"></script>
-       			<script type="text/javascript" src="${scriptDir}/ArcQueryUtil.js"></script>
+                <script type="text/javascript" src="${scriptDir}/CombineImage.js"></script>
+                <script type="text/javascript" src="${scriptDir}/FeatureInfo.js"></script>
+                <script type="text/javascript" src="${scriptDir}/EditFeature.js"></script>
+                <script type="text/javascript" src="${scriptDir}/ArcQueryUtil.js"></script>
 
                 <c:set var="scriptDir" value="${contextPath}/viewer-html/common/viewercontroller/controller"/>
                 <script type="text/javascript" src="${scriptDir}/Map.js"></script>
@@ -202,14 +202,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             </c:otherwise>
         </c:choose>
 
-		<script type="text/javascript">
-			if(MobileManager.isMobile()) {
-				document.write('<meta name="HandheldFriendly" content="True">');
-				document.write('<meta name="MobileOptimized" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0; maximum-scale=1.0; minimum-scale=1.0">');
-				document.write('<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0">');
-				document.write('<meta http-equiv="cleartype" content="on">');
-			}
-		</script>
+        <script type="text/javascript">
+            if(MobileManager.isMobile()) {
+                document.write('<meta name="HandheldFriendly" content="True">');
+                document.write('<meta name="MobileOptimized" content="width=device-width; height=device-height; user-scalable=no; initial-scale=1.0; maximum-scale=1.0; minimum-scale=1.0">');
+                document.write('<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0">');
+                document.write('<meta http-equiv="cleartype" content="on">');
+            }
+        </script>
         <script type="text/javascript" src="${contextPath}/viewer-html/common/layout.js"></script>
 
         <%@include file="app/style.jsp" %>
@@ -253,11 +253,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 "datastorespinup":    <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.DataStoreSpinupActionBean"/></js:quote>,
                 "autosuggest":        <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.SearchActionBean" event="autosuggest"/></js:quote>,
                 "componentresource":  <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ComponentResourceActionBean"/></js:quote>,
-                "css":                 <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.CSSActionBean"/></js:quote>,
-                "download":            <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.DownloadFeaturesActionBean"/></js:quote>,
-                "buffergeom":          <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.BufferActionBean" event="bufferGeometry"/></js:quote>,
+                "css":                <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.CSSActionBean"/></js:quote>,
+                "download":           <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.DownloadFeaturesActionBean"/></js:quote>,
+                "buffergeom":         <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.BufferActionBean" event="bufferGeometry"/></js:quote>,
                 "cyclorama":          <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.CycloramaActionBean"/></js:quote>,
                 "featureExtent":      <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.FeatureExtentActionBean"/></js:quote>
+                "errorlog":           <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ClientsideErrorLoggerActionBean"/></js:quote>
             };
 
             <c:if test="${actionBean.viewerType == 'openlayers'}">

--- a/viewer/src/main/webapp/viewer-html/common/FlamingoErrorLogger.js
+++ b/viewer/src/main/webapp/viewer-html/common/FlamingoErrorLogger.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012-2016 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+(function(window) {
+    window.createFlamingoErrorLogger = function(appName, appId, errorUrl) {
+        function flamingoLogFn(messageOrEvent, source, lineno, colno) {
+            try {
+                var request = null;
+                var error = [];
+                var basedata = [
+                    "Application " + appName + " (" + appId + ")",
+                    window.location
+                ];
+                if(window.navigator) {
+                    basedata.push(window.navigator.userAgent);
+                    basedata.push(window.navigator.platform);
+                }
+                error.push(basedata.join(" - "));
+
+                if(typeof messageOrEvent === "string") {
+                    error.push(messageOrEvent);
+                    if(source) {
+                        error.push("Source: " + source);
+                    }
+                    if(lineno) {
+                        error.push("Line: " + lineno + "," + colno);
+                    }
+                } else if(messageOrEvent instanceof Error) {
+                    error.push(messageOrEvent.name, messageOrEvent.message, messageOrEvent.stack, "Line: " + messageOrEvent.lineNumber + "," + messageOrEvent.columnNumber);
+                } else {
+                    error.push(messageOrEvent);
+                }
+
+                if (window.XMLHttpRequest) {
+                    request = new XMLHttpRequest();
+                } else if (window.ActiveXObject) { // IE
+                    try {
+                        request = new ActiveXObject('Msxml2.XMLHTTP');
+                    }
+                    catch (e) {
+                        try {
+                            request = new ActiveXObject('Microsoft.XMLHTTP');
+                        }
+                        catch (e) {}
+                    }
+                }
+                if(request !== null) {
+                    request.open('POST', errorUrl, true);
+                    request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+                    request.send('msg=' + encodeURIComponent(error.join("\n\t")));
+                }
+            } catch(e) {}
+        }
+        return flamingoLogFn;
+    }
+})(window);

--- a/viewer/src/main/webapp/viewer-html/components/Logger.js
+++ b/viewer/src/main/webapp/viewer-html/components/Logger.js
@@ -46,8 +46,9 @@ Ext.define ("viewer.components.Logger",{
             me.onResize();            
         }, this);
     },
-    error: function(message){
+    error: function(message) {
         if (this.config.logLevel <= viewer.components.Logger.LEVEL_ERROR){
+            FlamingoErrorLogger(message);
             this.message(message, viewer.components.LogMessage.ERROR);
             console.log(message);
         }


### PR DESCRIPTION
Will log any message to the application log, if that is set up for ~~WARN~~ DEBUG severity logging (by default it isn't);

  - [x] Maybe we want this to only log things when logging severity is DEBUG (off by default) as this makes it possible for clients to write (to the log file) on the server., 
 - [x] Maybe we want to add application info (id/name/version) as well?