### PR TITLE
Upgrade org.eclipse.emf.common 2.10.1 -> 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
             <dependency>
                 <groupId>org.eclipse.emf</groupId>
                 <artifactId>org.eclipse.emf.common</artifactId>
-                <version>2.10.1</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>xalan</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -514,7 +514,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.18.1</version>
+                    <version>2.19.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -534,7 +534,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
@@ -549,7 +549,7 @@
                 <plugin>
                     <groupId>nl.geodienstencentrum.maven</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
-                    <!-- current of the compiler versions (2.5 atm) fail on an inline finction:
+                    <!-- current release of the compiler versions (2.5 atm) fails on an inline function:
                     [ERROR] JSC_BAD_FUNCTION_DECLARATION. functions can only be declared at top level or immediately within another function in ES5 strict mode at /home/mark/dev/projects/flamingo/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js line 381 : 16
                     -->
                     <version>2.4</version>


### PR DESCRIPTION
Upgrade org.eclipse.emf:org.eclipse.emf.common from 2.10.1 to 2.12.0

 (the only class used from this library seems to be org.eclipse.emf.common.util.URI in SldActionBean which uses the decode method)