### PR TITLE
Upgrade/override Javassist version from the version Hibernate pulls in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,12 @@
                 <version>2.2.3</version>
             </dependency>
             <dependency>
+                <!-- override the version provided by hibernate -->
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>3.22.0-CR1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
                 <version>3.6.8.Final</version>
@@ -283,6 +289,16 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
                 <version>3.6.8.Final</version>
+                <exclusions>
+                    <exclusion>
+                        <!--
+                        exclude old javassist so we can use 3.22.0-CR1, see issue #745
+                        when upgrading hibernate this should be removed
+                        -->
+                        <groupId>javassist</groupId>
+                        <artifactId>javassist</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- viewer-config-persistence -->

--- a/solr-commons/pom.xml
+++ b/solr-commons/pom.xml
@@ -36,12 +36,8 @@
         <dependency>
             <groupId>org.stripesstuff</groupId>
             <artifactId>stripersist</artifactId>
-        </dependency>   
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
         </dependency>
-        <dependency>
+         <dependency>
             <groupId>org.flamingo-mc</groupId>
             <artifactId>viewer-config-persistence</artifactId>
         </dependency>

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -76,7 +76,11 @@
         <dependency>
             <groupId>org.stripesstuff</groupId>
             <artifactId>stripersist</artifactId>
-        </dependency>      
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -146,6 +146,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/User.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/User.java
@@ -22,7 +22,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Principal;
 import javax.persistence.*;
 import java.util.*;
-import javax.security.auth.Subject;
 
 /**
  *
@@ -126,9 +125,4 @@ public class User implements Principal{
     public String getName() {
         return username;
     }
-/*
-    @Override
-    public boolean implies(Subject subject) {
-        return Principal.super.implies(subject); //To change body of generated methods, choose Tools | Templates.
-    }*/
 }


### PR DESCRIPTION
This pulls in `org.javassist:javassist:3.22.0-CR1` to override `javassist:javassist:3.12.0.GA` that is pulled in by `hibernate-entitymanager` and close #745 

While here also remove the `hibernate-entitymanager` dependency from `solr-commons` as there is no direct dependency from `solr-commons` to `hibernate-entitymanager`.