### PR TITLE
Add event-listening in vector layer for undo/redo/cancel

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/VectorLayer.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/controller/VectorLayer.js
@@ -16,8 +16,9 @@
  */
 
 /**
- * Abstract component to for vectorlayers
-  *@author <a href="mailto:meinetoonen@b3partners.nl">Meine Toonen</a>
+ * Abstract component to for vectorlayers.
+ * @author <a href="mailto:meinetoonen@b3partners.nl">Meine Toonen</a>
+ * @author mprins
  */
 Ext.define("viewer.viewercontroller.controller.VectorLayer",{
     extend: "viewer.viewercontroller.controller.Layer",
@@ -70,10 +71,58 @@ Ext.define("viewer.viewercontroller.controller.VectorLayer",{
     addFeatures : function(features){
         Ext.Error.raise({msg: "VectorLayer.addFeatures() Not implemented! Must be implemented in sub-class"});
     },
+    /**
+     ** Note: subclasses should call this method to add the keylistener.
+     * @param {String} type geometry type to draw
+     *
+     */
     drawFeature : function(type){
-        Ext.Error.raise({msg: "VectorLayer.drawFeature() Not implemented! Must be implemented in sub-class"});  
+        // listen for certain key-press events in the document to undo editing
+        var me = this;
+        Ext.getDoc().on('keydown', me._keyListener, me);
     },
-    stopDrawing : function(){
-        Ext.Error.raise({msg: "VectorLayer.stopDrawing() Not implemented! Must be implemented in sub-class"});
+    /**
+     * Note: subclasses should call this method to remove the added keylistener.
+     */
+    stopDrawing: function () {
+        // remove the previously added key listener
+        var me = this;
+        Ext.getDoc().un('keydown', me._keyListener, me);
+    },
+    /**
+     * handle CTRL-Z, CTRL-Y and ESC keydown.
+     * @param {Ext.event.Event} evt the Ext.event.Event
+     * @param {Ext.dom.Element} t the targett (not used)
+     * @param {Object} eOpts any options from the addListener call (not used)
+     */
+    _keyListener: function (evt, t, eOpts) {
+        //var me = this;
+        switch (evt.keyCode) {
+            case 90: // z
+                if (evt.metaKey || evt.ctrlKey) {
+                    this.undoSketch();
+                }
+                break;
+            case 89: // y
+                if (evt.metaKey || evt.ctrlKey) {
+                    this.redoSketch();
+                }
+                break;
+            case 27: // esc
+                this.cancelSketch();
+                break;
+        }
+    },
+    /** handle CTRL-Z key when drawing. */
+    undoSketch: function () {
+        Ext.Error.raise({msg: "VectorLayer.undoSketch() Not implemented! Must be implemented in sub-class"});
+    },
+    /** handle CTRL-Y key when drawing. */
+    redoSketch: function () {
+        Ext.Error.raise({msg: "VectorLayer.redoSketch() Not implemented! Must be implemented in sub-class"});
+    },
+    /** handle ESC key when drawing. */
+    cancelSketch: function () {
+        Ext.Error.raise({msg: "VectorLayer.cancelSketch() Not implemented! Must be implemented in sub-class"});
     }
 });


### PR DESCRIPTION
This adds an event listener when the draw control is activated so drawing can be un-done using `CTRL-Z`, re-done using `CTRL-Y` and cancelled using `ESCAPE` keys. The eventlistener is removed when closing the control.

This affects any control drawing on the OpenlayersVectorLayer (Drawing, Edit, Split) but not he Modify action(as that does not draw). For sanity sake the circle tool is excluded.