### PR TITLE
GeoTools 17 upgrade (on ext-620)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>17-RC1</geotools.version>
+        <geotools.version>17.0</geotools.version>
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>17-beta</geotools.version>
+        <geotools.version>17-RC1</geotools.version>
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>16.2</geotools.version>
+        <geotools.version>17-beta</geotools.version>
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
  - [x] start test runs with 17-beta
  - [x] start test runs with 17.0-rc1
  - [x] start test runs with 17.0
  - [x] upgrade to 17.0

Similar to #784 (master) but against the upcoming 5.0.0 (impr/ext-620) branch