### PR TITLE
Add an option to provide attributes without alias substitution

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
@@ -99,6 +99,13 @@ public class AttributesActionBean implements ActionBean {
     @Validate
     private String filter;
 
+    /**
+     * set to {@code false}/{@code 0} to get attributes without alias
+     * substitution.
+     */
+    @Validate
+    private boolean aliases = true;
+
     @Validate
     private boolean debug;
     @Validate
@@ -269,7 +276,15 @@ public class AttributesActionBean implements ActionBean {
     public void setAttributesNotNull(List<Long> attributesNotNull) {
         this.attributesNotNull = attributesNotNull;
     }
-    
+
+    public boolean isAliases() {
+        return aliases;
+    }
+
+    public void setAliases(boolean aliases) {
+        this.aliases = aliases;
+    }
+
     //</editor-fold>
 
     @After(stages=LifecycleStage.BindingAndValidation)
@@ -498,7 +513,7 @@ public class AttributesActionBean implements ActionBean {
                 q.setStartIndex(start);
                 q.setMaxFeatures(Math.min(limit,FeatureToJson.MAX_FEATURES));
 
-                FeatureToJson ftoj = new FeatureToJson(arrays, this.edit, graph, attributesToInclude);
+                FeatureToJson ftoj = new FeatureToJson(arrays, this.edit, graph, aliases, attributesToInclude);
 
                 JSONArray features = ftoj.getJSONFeatures(appLayer,ft, fs, q, sort, dir);
 

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
@@ -59,7 +59,8 @@ public class FeatureToJson {
     private boolean arrays = false;
     private boolean edit = false;
     private boolean graph = false;
-    private List<Long> attributesToInclude = new ArrayList<Long>();
+    private boolean aliases = true;
+    private List<Long> attributesToInclude = new ArrayList();
     private static final int TIMEOUT = 5000;
     private FilterFactory2 ff2 = CommonFactoryFinder.getFilterFactory2(GeoTools.getDefaultHints());
 
@@ -74,6 +75,15 @@ public class FeatureToJson {
         this.graph = graph;
         this.attributesToInclude=attributesToInclude;
     }
+
+    public FeatureToJson(boolean arrays, boolean edit, boolean graph, boolean aliases, List<Long> attributesToInclude) {
+        this.arrays = arrays;
+        this.edit = edit;
+        this.graph = graph;
+        this.attributesToInclude = attributesToInclude;
+        this.aliases = aliases;
+    }
+
     /**
      * Get the features as JSONArray with the given params
      * @param al The application layer(if there is a application layer)
@@ -155,12 +165,16 @@ public class FeatureToJson {
                 j.put("c" + index++, formatValue(value));
             }
         } else {
-            for(String name: propertyNames) {
-                String alias = null;
-                if (attributeAliases!=null){
-                    alias=attributeAliases.get(name);
+            for (String name : propertyNames) {
+                if (!aliases) {
+                    j.put(name, formatValue(f.getAttribute(name)));
+                } else {
+                    String alias = null;
+                    if (attributeAliases != null) {
+                        alias = attributeAliases.get(name);
+                    }
+                    j.put(alias != null ? alias : name, formatValue(f.getAttribute(name)));
                 }
-                j.put(alias != null ? alias : name, formatValue(f.getAttribute(name)));
             }
         }
         //if edit and not yet set


### PR DESCRIPTION
This enables matching the attributes on the field name; as eg for showing a previous version of attributes in the editor.

Previous Flamingo behaviour is preserved by defaulting to `true`

see B3Partners/flamingo-ibis#68