### PR TITLE
Upgrade FOP from 2.1 -> 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <dependency>
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>fop</artifactId>
-                <version>2.1</version>
+                <version>2.2</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,18 @@
                 <version>2.2</version>
             </dependency>
             <dependency>
+                <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-i18n</artifactId>
+                <version>1.9</version>
+            </dependency>
+            <dependency>
+                <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>batik-constants</artifactId>
+                <version>1.9</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.5</version>

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBeanTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBeanTest.java
@@ -16,7 +16,6 @@
  */
 package nl.b3p.viewer.admin.stripes;
 
-import java.net.URL;
 import java.util.List;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import nl.b3p.viewer.config.services.Category;
@@ -60,8 +59,8 @@ public class GeoServiceActionBeanTest extends TestUtil{
 
             List<Layer> layers = service.loadLayerTree(entityManager);
             // hmmmp PDOK weirdness v1.1.0 caps file has 3 layers, v1.3.0 has 6
-            //assertEquals("The number of layers should be the same", 6, layers.size());
-            assertEquals("The number of layers should be the same", 3, layers.size());
+            assertEquals("The number of layers should be the same", 6, layers.size());
+            //assertEquals("The number of layers should be the same", 3, layers.size());
             assertEquals("The url should be the same", url, service.getUrl());
         } catch (Exception ex) {
             log.error("Error testing adding a geoservice:", ex);

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
-        </dependency>      
+        </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -84,6 +84,16 @@
             <artifactId>fop</artifactId>
         </dependency>
         <dependency>
+            <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-i18n</artifactId>
+        </dependency>
+        <dependency>
+            <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>batik-constants</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>


### PR DESCRIPTION
release notes: https://xmlgraphics.apache.org/fop/2.2/releaseNotes_2.2.html and https://xmlgraphics.apache.org/fop/2.2/changes_2.2.html

This also brings in new versions of the batik (1.9) and xmlgraphics-commons (2.2) libraries.

fixes [CVE-2017-5661](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5661) which is unlikely to affect Flamingo installations as the attack vector -SVG from untrusted/non-admin source- does not exist.

related #664