### PR TITLE
reduce HttpClient logging

### DIFF
--- a/viewer-admin/src/test/resources/log4j.xml
+++ b/viewer-admin/src/test/resources/log4j.xml
@@ -31,7 +31,13 @@ LEVELS: debug, info, warn, error, fatal en off, all -->
     <logger name="org.apache.http.client">
         <level value="info" />
     </logger>
+    <logger name="org.apache.commons.httpclient">
+        <level value="info" />
+    </logger>
     <logger name="org.apache.http.wire">
+        <level value="info" />
+    </logger>
+    <logger name="httpclient.wire">
         <level value="info" />
     </logger>
     <root>

--- a/viewer/src/test/resources/log4j.xml
+++ b/viewer/src/test/resources/log4j.xml
@@ -25,7 +25,13 @@
     <logger name="org.apache.http">
         <level value="info" />
     </logger>
+    <logger name="org.apache.commons.httpclient">
+        <level value="info" />
+    </logger>
     <logger name="org.apache.http.wire">
+        <level value="info" />
+    </logger>
+    <logger name="httpclient.wire">
         <level value="info" />
     </logger>
     <root>


### PR DESCRIPTION
to prevent the Travis-CI build failing/terminating with the message:
```

The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).

The job has been terminated
```
eg. https://travis-ci.org/flamingo-geocms/flamingo/jobs/221639749