### PR TITLE
Add an option to exclude retrieving joined/related attribute data to AtrributesActionBean

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
@@ -101,10 +101,17 @@ public class AttributesActionBean implements ActionBean {
 
     /**
      * set to {@code false}/{@code 0} to get attributes without alias
-     * substitution.
+     * substitution. (default is {@code true})
      */
     @Validate
     private boolean aliases = true;
+
+    /**
+     * Flag to include joined attribute data in the response (default is
+     * {@code true})
+     */
+    @Validate
+    private boolean includeRelations = true;
 
     @Validate
     private boolean debug;
@@ -285,6 +292,14 @@ public class AttributesActionBean implements ActionBean {
         this.aliases = aliases;
     }
 
+    public boolean isIncludeRelations() {
+        return includeRelations;
+    }
+
+    public void setIncludeRelations(boolean includeRelations) {
+        this.includeRelations = includeRelations;
+    }
+
     //</editor-fold>
 
     @After(stages=LifecycleStage.BindingAndValidation)
@@ -410,7 +425,7 @@ public class AttributesActionBean implements ActionBean {
             Filter f = ECQL.toFilter(filter);
             f = (Filter)f.accept(new RemoveDistanceUnit(), null);
             f = (Filter)f.accept(new ChangeMatchCase(false), null);
-            f = FeatureToJson.reformatFilter(f,ft);
+            f = FeatureToJson.reformatFilter(f, ft, includeRelations);
             q.setFilter(f);
         }
 

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeatureToJson.java
@@ -399,17 +399,45 @@ public class FeatureToJson {
         }
     }
 
+    /**
+     *
+     * Optimze and reformat filter. Delegates to
+     * {@link #reformatFilter(org.opengis.filter.Filter, nl.b3p.viewer.config.services.SimpleFeatureType, boolean)}
+     * with the {@code includeRelations} set to {@code true}.
+     *
+     * @param filter the filter to process
+     * @param ft featuretype to apply filter
+     * @return reformatted / optimised filter
+     * @throws Exception if any
+     * @see #reformatFilter(org.opengis.filter.Filter,
+     * nl.b3p.viewer.config.services.SimpleFeatureType, boolean)
+     */
     public static Filter reformatFilter(Filter filter, SimpleFeatureType ft) throws Exception {
-        if (Filter.INCLUDE.equals(filter) || Filter.EXCLUDE.equals(filter)){
+        return reformatFilter(filter, ft, true);
+    }
+
+    /**
+     * Optimze and reformat filter.
+     *
+     * @param filter the filter to process
+     * @param ft featuretype to apply filter
+     * @param includeRelations whether to include related (joined) data
+     * @return reformatted / optimised filter
+     * @throws Exception if any
+     */
+    public static Filter reformatFilter(Filter filter, SimpleFeatureType ft, boolean includeRelations) throws Exception {
+        if (Filter.INCLUDE.equals(filter) || Filter.EXCLUDE.equals(filter)) {
             return filter;
         }
-        for (FeatureTypeRelation rel : ft.getRelations()){
-            if (FeatureTypeRelation.JOIN.equals(rel.getType())){
-                filter= reformatFilter(filter, rel.getForeignFeatureType());
-                filter = (Filter) filter.accept(new ValidFilterExtractor(rel), filter);
+        if (includeRelations) {
+            for (FeatureTypeRelation rel : ft.getRelations()) {
+                if (FeatureTypeRelation.JOIN.equals(rel.getType())) {
+                    filter = reformatFilter(filter, rel.getForeignFeatureType(), includeRelations);
+                    filter = (Filter) filter.accept(new ValidFilterExtractor(rel), filter);
+                }
             }
         }
-        filter=(Filter) filter.accept(new SimplifyingFilterVisitor(),null);
+        filter = (Filter) filter.accept(new SimplifyingFilterVisitor(), null);
         return filter;
     }
 


### PR DESCRIPTION
The default behaviour is and stay to retrieve attributes that are joined, but setting the `includeRelations` flag to false/0 will prevent processing the related featuretype for attributes.

This handles a case where a FT hase overlapping (in name) attributes with a joined FT and the joined type has an overlapping attribute "turned off" while the main FT has the attribute turned on and needs to be retrieved.

This resolves B3Partners/flamingo-ibis#71 where the retrieval of a previous generation of an object fails for _kavels_ by `ibis_id` and `workflow_status` because _terreinen_ is joined and has an `ibis_id` attr as well.