### PR TITLE
Upgrade Apache POI, Quartz and PostgreSQL driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.3.4</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.0.0</postgresql.version>
-        <apache.poi.version>3.15</apache.poi.version>
+        <postgresql.version>42.1.1</postgresql.version>
+        <apache.poi.version>3.16</apache.poi.version>
         <apache.httpcomponents.version>4.5.3</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
@@ -288,7 +288,7 @@
             <dependency>
                 <groupId>org.quartz-scheduler</groupId>
                 <artifactId>quartz</artifactId>
-                <version>2.2.3</version>
+                <version>2.3.0</version>
             </dependency>
             <dependency>
                 <!-- override the version provided by hibernate -->
@@ -561,7 +561,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -212,7 +212,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
                 <configuration>
                     <skipTests>${test.skip.integrationtests}</skipTests>
                     <systemPropertyVariables>


### PR DESCRIPTION
This upgrade resolves [CVE-2017-5644](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5644). Note that Flamingo is not vulnerable because the attack vector -accepting OOXML- does not exist in Flamingo.


release notes / diffs:

  - https://poi.apache.org/changes.html
  - https://jdbc.postgresql.org/documentation/changelog.html#version_42.1.1
  - https://github.com/quartz-scheduler/quartz/compare/quartz-2.2.3...quartz-2.3.0

Also upgrade some Maven plugins.