### PR TITLE
Better test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ script:
   # run integration tests on viewer-admin module only
   - mvn -e clean verify -B -Ptravis-ci -pl 'viewer-admin'
   # run code coverage
-  - mvn cobertura:cobertura -Ptravis-ci
+  #- mvn cobertura:cobertura -Ptravis-ci
+  #- mvn cobertura:cobertura-integration-test -Ptravis-ci
   # on oracle java 8 run a javadoc build to check for errors
   - if [ "$TRAVIS_JDK_VERSION" == oraclejdk8 ]; then
          mvn javadoc:javadoc;
@@ -57,9 +58,7 @@ script:
     fi
 
 after_success:
-  - if [ "$TRAVIS_JDK_VERSION" == oraclejdk8 ]; then
-         bash <(curl -s https://codecov.io/bash)
-    fi
+  - bash <(curl -s https://codecov.io/bash)
   
 jdk:
   - oraclejdk8

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,9 +4,9 @@ timestamps {
         properties([
             [$class: 'jenkins.model.BuildDiscarderProperty', strategy: [$class: 'LogRotator',
                 artifactDaysToKeepStr: '5',
-                artifactNumToKeepStr: '3',
+                artifactNumToKeepStr: '5',
                 daysToKeepStr: '15',
-                numToKeepStr: '3']
+                numToKeepStr: '5']
             ]]);
 
         withEnv(["JAVA_HOME=${ tool 'JDK8' }", "PATH+MAVEN=${tool 'Maven 3.6.0'}/bin:${env.JAVA_HOME}/bin"]) {
@@ -44,6 +44,9 @@ timestamps {
             } finally {
                 stage('Publish Results'){
                     junit allowEmptyResults: true, testResults: '**/target/surefire-reports/TEST-*.xml, **/target/failsafe-reports/TEST-*.xml'
+                }
+                stage('Test Coverage results') {
+                    jacoco exclusionPattern: '**/*Test.class', execPattern: '**/target/**.exec'
                 }
             }
             

--- a/pom.xml
+++ b/pom.xml
@@ -49,19 +49,23 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.2.5</postgresql.version>
         <apache.poi.version>4.0.1</apache.poi.version>
+        <javax.mail.version>1.6.2</javax.mail.version>
         <apache.httpcomponents.version>4.5.6</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
         <tomcat.version>7.0.92</tomcat.version>
+        <jacoco-maven-plugin.version>0.8.2</jacoco-maven-plugin.version>
+        <!--<jacoco.it.execution.data.file>${project.build.directory}/jacoco-it.exec</jacoco.it.execution.data.file>-->
+        <!--<jacoco.ut.execution.data.file>${project.build.directory}/jacoco-ut.exec</jacoco.ut.execution.data.file>-->
     </properties>
     <dependencyManagement>
         <!--
             To check for dependency updates use the following command:
             mvn -U org.codehaus.mojo:versions-maven-plugin:display-dependency-updates > dependency-updates.log
             and check the output for any available updates.
-            
+
             To check for vulnarabilities in dependencies use the following command:
             mvn org.owasp:dependency-check-maven:check > vuln-check.log
         -->
@@ -418,7 +422,7 @@
             <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.6.2</version>
+                <version>${javax.mail.version}</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -706,9 +710,9 @@
                     <version>1.0.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -734,18 +738,7 @@
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
                     </systemPropertyVariables>
-                    <argLine>-Xmx1g -Xms1g -XX:+TieredCompilation -XX:TieredStopAtLevel=1</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check />
+                    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -769,8 +762,77 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <!--<destFile>${jacoco.ut.execution.data.file}</destFile>-->
+                            <propertyName>surefireArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <!--<destFile>${jacoco.it.execution.data.file}</destFile>-->
+                            <propertyName>failsafeArgLine</propertyName>
+                        </configuration>
+                    </execution>
+                   <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!--<dataFile>${jacoco.ut.execution.data.file}</dataFile>-->
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                        <configuration>
+                            <!--<dataFile>${jacoco.it.execution.data.file}</dataFile>-->
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <configuration>
+                    <dataFileIncludes>
+                        <dataFileInclude>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFileInclude>
+                        <dataFileInclude>${project.build.directory}/coverage-reports/jacoco-it.exec</dataFileInclude>
+                    </dataFileIncludes>
+                </configuration>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report-aggregate</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
     <profiles>
         <profile>
             <id>travis-ci</id>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -219,6 +219,7 @@
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
                     </systemPropertyVariables>
+                    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -266,6 +267,7 @@
                                 <database.properties.file>postgres.properties</database.properties.file>
                             </systemPropertyVariables>
                             <useFile>false</useFile>
+                            <argLine>${failsafeArgLine}</argLine>
                         </configuration>
                         <executions>
                             <execution>
@@ -318,14 +320,19 @@
                         </executions>
                         <dependencies>
                             <dependency>
-                                <groupId>javax.mail</groupId>
-                                <artifactId>mail</artifactId>
-                                <version>1.4.7</version>
+                                <groupId>com.sun.mail</groupId>
+                                <artifactId>javax.mail</artifactId>
+                                <version>${javax.mail.version}</version>
                             </dependency>
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
                                 <version>${postgresql.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.agent</artifactId>
+                                <version>${jacoco-maven-plugin.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -417,15 +424,20 @@
                             </execution>
                         </executions>
                         <dependencies>
-                            <dependency>
-                                <groupId>javax.mail</groupId>
-                                <artifactId>mail</artifactId>
-                                <version>1.4.7</version>
+                           <dependency>
+                                <groupId>com.sun.mail</groupId>
+                                <artifactId>javax.mail</artifactId>
+                                <version>${javax.mail.version}</version>
                             </dependency>
                             <dependency>
                                 <groupId>com.oracle</groupId>
                                 <artifactId>ojdbc7</artifactId>
                                 <version>12.1.0.2.0</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.agent</artifactId>
+                                <version>${jacoco-maven-plugin.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -78,6 +78,7 @@
                     <systemPropertyVariables>
                         <test.persistence.unit>${test.persistence.unit}</test.persistence.unit>
                     </systemPropertyVariables>
+                    <argLine>${surefireArgLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -487,6 +488,7 @@
                                 <database.properties.file>postgres.properties</database.properties.file>
                             </systemPropertyVariables>
                             <useFile>false</useFile>
+                            <argLine>${failsafeArgLine}</argLine>
                         </configuration>
                         <executions>
                             <execution>
@@ -526,15 +528,20 @@
                             </execution>
                         </executions>
                         <dependencies>
-                            <dependency>
-                                <groupId>javax.mail</groupId>
-                                <artifactId>mail</artifactId>
-                                <version>1.4.7</version>
+                           <dependency>
+                                <groupId>com.sun.mail</groupId>
+                                <artifactId>javax.mail</artifactId>
+                                <version>${javax.mail.version}</version>
                             </dependency>
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
                                 <version>${postgresql.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.agent</artifactId>
+                                <version>${jacoco-maven-plugin.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -624,15 +631,20 @@
                             </execution>
                         </executions>
                         <dependencies>
-                            <dependency>
-                                <groupId>javax.mail</groupId>
-                                <artifactId>mail</artifactId>
-                                <version>1.4.7</version>
+                           <dependency>
+                                <groupId>com.sun.mail</groupId>
+                                <artifactId>javax.mail</artifactId>
+                                <version>${javax.mail.version}</version>
                             </dependency>
                             <dependency>
                                 <groupId>com.oracle</groupId>
                                 <artifactId>ojdbc7</artifactId>
                                 <version>12.1.0.2.0</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.agent</artifactId>
+                                <version>${jacoco-maven-plugin.version}</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
Attempt to fix integration test coverage report and start using jacoco instead of cobertura

This should give us at least unit test coverage, integration test coverage is painful to set up because we run inside tomcat which is a forked process inside maven and it requires trickery to get the javaagent into tomcat.
See eg. https://stackoverflow.com/questions/16018698/tomcat7-maven-plugin-and-jacoco (and maybe links below) for some options and workarounds