### PR TITLE
Upgrade GeoTools to 17.2 (ext-620 branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>17.1</geotools.version>
+        <geotools.version>17.2</geotools.version>
         <powermock.version>1.6.6</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
Upgrading GeoTools to 17.2 will fix this issue for the ext-620 branch.

17.2 is expected to be released around 2017-07-18 (see: https://github.com/geoserver/geoserver/wiki/Release-Schedule)

close #825 
