### PR TITLE
use a native query to determine `isMashup` and cache the value

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ChooseApplicationActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ChooseApplicationActionBean.java
@@ -216,7 +216,7 @@ public class ChooseApplicationActionBean extends ApplicationActionBean {
         }
         return new ForwardResolution(EDITJSP);
     }
-    
+
     protected void deleteApplication(EntityManager em) {
         if (applicationToDelete.isMashup()) {
             applicationToDelete.setRoot(null);
@@ -358,23 +358,21 @@ public class ChooseApplicationActionBean extends ApplicationActionBean {
             j.put("baseName", app.getName());
             j.put("version", app.getVersion());
             j.put("baseUrl", baseUrl);
-            String mashup = "Nee";
-            if (app.getDetails().containsKey(Application.DETAIL_IS_MASHUP)) {
-                String mashupValue = app.getDetails().get(Application.DETAIL_IS_MASHUP).getValue();
-                mashup = Boolean.valueOf(mashupValue) ? "Ja" : "Nee";
-                if ( Boolean.valueOf(mashupValue)) {
+            boolean isMashup = app.isMashup(sess);
+            if (isMashup) {
                     List<Application> linkedApps = em.createQuery(
                             "from Application where root = :level and id <> :oldId")
-                            .setParameter("level", app.getRoot()).setParameter("oldId", app.getId()).getResultList();
+                            .setParameter("level", app.getRoot())
+                            .setParameter("oldId", app.getId())
+                            .getResultList();
                     for (Application linkedApp : linkedApps) {
-                        if (!linkedApp.isMashup()) {
+                        if (!linkedApp.isMashup(sess)) {
                             j.put("motherapplication", linkedApp.getNameWithVersion());
                             break;
                         }
                     }
                 }
-            } 
-            j.put("mashup",mashup);
+            j.put("mashup", (isMashup ? "Ja" : "Nee"));
             jsonData.put(j);
         }
 
@@ -403,7 +401,7 @@ public class ChooseApplicationActionBean extends ApplicationActionBean {
 
         try {
 
-            Application copy = createWorkversion(applicationWorkversion, em,version);
+            Application copy = createWorkversion(applicationWorkversion, em, version);
             getContext().getMessages().add(new SimpleMessage("Werkversie is gemaakt"));
             setApplication(copy);
 
@@ -459,7 +457,7 @@ public class ChooseApplicationActionBean extends ApplicationActionBean {
         JSONObject json = new JSONObject();
 
         json.put("success", Boolean.FALSE);
-        try{
+        try {
             EntityManager em = Stripersist.getEntityManager();
             Metadata md = null;
             try {
@@ -477,7 +475,7 @@ public class ChooseApplicationActionBean extends ApplicationActionBean {
             em.persist(md);
             em.getTransaction().commit();
             json.put("success", Boolean.TRUE);
-        }catch(Exception ex){
+        } catch (Exception ex) {
             log.error("Error during setting the default application: ", ex);
         }
         return new StreamingResolution("application/json", new StringReader(json.toString()));

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Application.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/Application.java
@@ -79,7 +79,6 @@ public class Application {
 
     @ElementCollection
     @JoinTable(joinColumns = @JoinColumn(name = "application"))
-    @Basic(fetch = FetchType.LAZY)
     // Element wrapper required because of http://opensource.atlassian.com/projects/hibernate/browse/JPA-11
     private Map<String, ClobElement> details = new HashMap<String, ClobElement>();
 
@@ -539,12 +538,11 @@ public class Application {
      * @see #isMashup(org.hibernate.Session)
      */
     public Boolean isMashup() {
-        if (this.isMashup_cached == null) {
-        this.isMashup_cached = Boolean.FALSE;
-            if (this.getDetails().containsKey(Application.DETAIL_IS_MASHUP)) {
-                String mashupValue = this.getDetails().get(Application.DETAIL_IS_MASHUP).getValue();
-                this.isMashup_cached = Boolean.valueOf(mashupValue);
-            }
+        if (this.getDetails().containsKey(Application.DETAIL_IS_MASHUP)) {
+            String mashupValue = this.getDetails().get(Application.DETAIL_IS_MASHUP).getValue();
+            this.isMashup_cached = Boolean.valueOf(mashupValue);
+        } else {
+            this.isMashup_cached = Boolean.FALSE;
         }
         return this.isMashup_cached;
     }
@@ -553,7 +551,7 @@ public class Application {
      * fast access to determine if we are mashup.
      *
      * @param sess the hibernate session
-     * @return {@code true} if we are a mashup
+     * @return {@code true} if we are a mashup, this may be a cached value
      *
      * @see #isMashup()
      */

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
@@ -517,6 +517,7 @@ public abstract class GeoService implements Serializable {
      * with the same name, a random non-virtual layer is returned.
      *
      * @param layerName the name of the layer to find
+     * @param em the EntityManager to use
      * @return the named layer
      */
     public Layer getSingleLayer(final String layerName, EntityManager em) {

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/ApplicationDetailsValueTransformer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/ApplicationDetailsValueTransformer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.util;
+
+import java.sql.Clob;
+import java.sql.SQLException;
+import java.util.Map;
+import org.apache.commons.collections.map.CaseInsensitiveMap;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hibernate.transform.BasicTransformerAdapter;
+
+/**
+ * Transform the clob in application details to a string. Avoid using with very
+ * large values.
+ *
+ * @author Mark Prins <mark@b3partners.nl>
+ */
+public class ApplicationDetailsValueTransformer extends BasicTransformerAdapter {
+
+    private static final Log LOG = LogFactory.getLog(ApplicationDetailsValueTransformer.class);
+    public final static ApplicationDetailsValueTransformer INSTANCE;
+
+    static {
+        INSTANCE = new ApplicationDetailsValueTransformer();
+    }
+
+    private ApplicationDetailsValueTransformer() {
+
+    }
+
+    /**
+     * create a CaseInsensitiveMap with key/values.
+     *
+     * Tuples are the elements making up each "row" of the query result. The
+     * contract here is to transform these elements into the final row.
+     *
+     * @param tuple The result elements
+     * @param aliases The result aliases ("parallel" array to tuple)
+     * @return The transformed row.
+     */
+    @Override
+    public Object transformTuple(Object[] tuple, String[] aliases) {
+        Map<String, Object> map = new CaseInsensitiveMap();
+        for (int i = 0; i < aliases.length; i++) {
+            Object t = tuple[i];
+            if (t != null && t instanceof Clob) {
+                Clob c = (Clob) tuple[i];
+                try {
+                    t = c.getSubString(1, (int) c.length());
+                } catch (SQLException e) {
+                    LOG.error("Error transforming data tuple of " + aliases[i], e);
+                }
+            }
+            map.put(aliases[i], t);
+        }
+        return map;
+    }
+}

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/ApplicationDetailsValueTransformer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/ApplicationDetailsValueTransformer.java
@@ -28,7 +28,7 @@ import org.hibernate.transform.BasicTransformerAdapter;
  * Transform the clob in application details to a string. Avoid using with very
  * large values.
  *
- * @author Mark Prins <mark@b3partners.nl>
+ * @author Mark Prins
  */
 public class ApplicationDetailsValueTransformer extends BasicTransformerAdapter {
 


### PR DESCRIPTION
Also use explicit lazy loading for application details.

it turns out that -on oracle- Application#isMashup() is slow because it needs to handle a potentially large amount of data in the application_details value CLOBs -specifically cachedExpandedSelectedContent and cachedSelectedContent can be in the order of 1.5-2 MB- 
(postgresql is much better at lazy loading)


reference [mantis 6724](http://mantis.b3p.nl/view.php?id=6724)