### PR TITLE
GeoTools 18 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>18-beta</geotools.version>
+        <geotools.version>18-RC1</geotools.version>
         <powermock.version>1.7.0RC2</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>17.2</geotools.version>
+        <geotools.version>18-beta</geotools.version>
         <powermock.version>1.7.0RC2</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <project.build.targetVersion>1.8</project.build.targetVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>18-RC1</geotools.version>
+        <geotools.version>18.0</geotools.version>
         <powermock.version>1.7.0RC2</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
- [x] 18-beta  [release notes](https://osgeo-org.atlassian.net/secure/ReleaseNote.jspa?projectId=10001&version=15600)
- [x] 18-RC1
- [x] 18.0

This also brings in jts 1.14

see also: [GeoTools Release Schedule](https://github.com/geoserver/geoserver/wiki/Release-Schedule)

close #884