### PR TITLE
Update various dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ script:
     fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [ "$TRAVIS_JDK_VERSION" == oraclejdk8 ]; then
+         bash <(curl -s https://codecov.io/bash)
+    fi
   
 jdk:
   - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,9 @@
                 <version>1.3.3</version>
             </dependency>
             <dependency>
-                <groupId>jdom</groupId>
-                <artifactId>jdom</artifactId>
-                <version>1.0</version>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom2</artifactId>
+                <version>2.0.6</version>
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.1.1</postgresql.version>
-        <apache.poi.version>3.16</apache.poi.version>
+        <apache.poi.version>3.17</apache.poi.version>
         <apache.httpcomponents.version>4.5.3</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.3.2</version>
+                <version>1.3.3</version>
             </dependency>
             <dependency>
                 <groupId>jdom</groupId>
@@ -121,13 +121,13 @@
                 <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>batik-i18n</artifactId>
-                <version>1.9</version>
+                <version>1.9.1</version>
             </dependency>
             <dependency>
                 <!-- work-around for https://issues.apache.org/jira/browse/BATIK-1185 -->
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>batik-constants</artifactId>
-                <version>1.9</version>
+                <version>1.9.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -166,7 +166,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.5</version>
+                <version>3.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.javascript</groupId>
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.7.22</version>
+                <version>2.10.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -301,7 +301,7 @@
                 <!-- override the version provided by hibernate -->
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.22.0-CR1</version>
+                <version>3.22.0-CR2</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -399,7 +399,7 @@
             <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.5.6</version>
+                <version>1.6.0</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.10.0</version>
+                <version>2.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -306,12 +306,12 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>3.6.8.Final</version>
+                <version>3.6.10.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-entitymanager</artifactId>
-                <version>3.6.8.Final</version>
+                <version>3.6.10.Final</version>
                 <exclusions>
                     <exclusion>
                         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>5.0.0-SNAPSHOT</version>
+                <version>5.0.0-RC1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.1.1</postgresql.version>
         <apache.poi.version>3.17</apache.poi.version>
-        <apache.httpcomponents.version>4.5.3</apache.httpcomponents.version>
+        <apache.httpcomponents.version>4.5.4</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
@@ -61,7 +61,7 @@
             and check the output for any available updates.
             
             To check for vulnarabilities in dependencies use the following command:
-            mvn org.owasp:dependency-check-maven:1.4.5:check > vuln-check.log
+            mvn org.owasp:dependency-check-maven:3.0.2:check > vuln-check.log
         -->
         <dependencies>
             <!-- viewer-->
@@ -161,12 +161,12 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>5.0.0-RC1</version>
+                <version>5.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.6</version>
+                <version>3.7</version>
             </dependency>
             <dependency>
                 <groupId>com.google.javascript</groupId>
@@ -175,14 +175,21 @@
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
-                <artifactId>servlet-api</artifactId>
-                <version>2.5</version>
+                <artifactId>javax.servlet-api</artifactId>
+                <version>3.0.1</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>jstl</groupId>
-                <artifactId>jstl</artifactId>
-                <version>1.2</version>
+                <groupId>org.glassfish.web</groupId>
+                <artifactId>javax.servlet.jsp.jstl</artifactId>
+                <version>1.2.4</version>
+                <exclusions>
+                    <exclusion>
+                        <!-- sleept servlet api 2.5 mee -->
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- geozet openls -->
             <dependency>
@@ -223,7 +230,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -363,9 +370,9 @@
 
             <!-- web-commons -->
             <dependency>
-                <groupId>javax.servlet</groupId>
+                <groupId>javax.servlet.jsp</groupId>
                 <artifactId>jsp-api</artifactId>
-                <version>2.0</version>
+                <version>2.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -548,7 +555,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.3</version>
+                    <version>2.2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>2.0</version>
+                <version>5.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/solr-commons/pom.xml
+++ b/solr-commons/pom.xml
@@ -27,7 +27,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -59,7 +59,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
 
         <dependency>
@@ -68,8 +68,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>jstl</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp.jstl</artifactId>
         </dependency>
         <!-- Flamingo dependencies -->
         <dependency>

--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- crossContext="true" is required to enable the viewer-admin to load the
-  components.json file and component config javascript sources from the viewer -->
-<Context antiJARLocking="true" crossContext="true" disableURLRewriting="true" path="/viewer-admin">
-  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components"/>
-  <!-- Customized context parameters; see web.xml -->
+<!-- 
+more about the available context attributes:
+  https://tomcat.apache.org/tomcat-7.0-doc/config/context.html
+or
+  https://tomcat.apache.org/tomcat-8.0-doc/config/context.html
+  
+crossContext="true" is required to enable the viewer-admin to load the
+  components.json file and component config javascript sources from the viewer
+-->
+<Context antiResourceLocking="true" crossContext="true" path="/viewer-admin">
+  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components" />
+  <!-- Customized context parameters; see also: web.xml -->
   <!--Parameter name="viewer.url" value="/viewer" override="false"/-->
   <!--Parameter name="monitoring.mail.from.email" value="no-reply@b3partners.nl" override="false"/-->
   <!--Parameter name="monitoring.mail.from.name" value="Geo services monitoring" override="false"/-->
@@ -53,8 +60,10 @@
                   validationQuery="select 1"
         />
     </Server>
+
+    NOTE: each JDBC driver version and each version of Tomcat will have different options that can be set
+    
     -->
-  <!-- Tomcat resource link -->
   <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
   <!-- For Tomcat: define JavaMail resource in server.xml. See:
 

--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
 more about the available context attributes:
   https://tomcat.apache.org/tomcat-7.0-doc/config/context.html
 or
   https://tomcat.apache.org/tomcat-8.0-doc/config/context.html
-  
+
 crossContext="true" is required to enable the viewer-admin to load the
   components.json file and component config javascript sources from the viewer
 -->
 <Context antiResourceLocking="true" crossContext="true" path="/viewer-admin">
-  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components" />
+  <Parameter name="componentregistry.path" override="false" value="/viewer-html/components"/>
   <!-- Customized context parameters; see also: web.xml -->
   <!--Parameter name="viewer.url" value="/viewer" override="false"/-->
   <!--Parameter name="monitoring.mail.from.email" value="no-reply@b3partners.nl" override="false"/-->
@@ -61,8 +61,8 @@ crossContext="true" is required to enable the viewer-admin to load the
         />
     </Server>
 
-    NOTE: each JDBC driver version and each version of Tomcat will have different options that can be set
-    
+    NOTE: each JDBC driver version and each version of Tomcat will have different options that can/must be set
+
     -->
   <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
   <!-- For Tomcat: define JavaMail resource in server.xml. See:
@@ -88,7 +88,7 @@ crossContext="true" is required to enable the viewer-admin to load the
         ...
     </Server>
     -->
-    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session" />
+    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
     <!-- Security configuration -->
     <!-- use LockOutRealm instead of CombinedRealm to prevent brute-forcing -->
     <Realm className="org.apache.catalina.realm.LockOutRealm">

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -52,7 +52,7 @@
         </dependency> 
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.mail</groupId>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -159,7 +159,7 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -29,8 +29,8 @@
             <artifactId>commons-fileupload</artifactId>
         </dependency>
         <dependency>
-            <groupId>jdom</groupId>
-            <artifactId>jdom</artifactId>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom2</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -118,11 +118,11 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>jstl</groupId>
-            <artifactId>jstl</artifactId>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp.jstl</artifactId>
         </dependency>
         <!-- geozet openls -->
         <dependency>

--- a/viewer/src/main/java/nl/b3p/viewer/features/ExcelDownloader.java
+++ b/viewer/src/main/java/nl/b3p/viewer/features/ExcelDownloader.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import nl.b3p.viewer.config.app.ConfiguredAttribute;
 import nl.b3p.viewer.config.services.AttributeDescriptor;
+import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.ClientAnchor;
@@ -38,7 +39,9 @@ import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.CreationHelper;
 import org.apache.poi.ss.usermodel.DataFormat;
 import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.usermodel.FillPatternType;
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.PrintSetup;
 import org.apache.poi.ss.usermodel.RichTextString;
@@ -222,11 +225,11 @@ public class ExcelDownloader extends FeatureDownloader{
 
         CellStyle style;
         Font headerFont = wb.createFont();
-        headerFont.setBoldweight(Font.BOLDWEIGHT_BOLD);
+        headerFont.setBold(true);
         style = createBorderedStyle(wb);
-        style.setAlignment(CellStyle.ALIGN_CENTER);
+        style.setAlignment(HorizontalAlignment.CENTER);
         style.setFillForegroundColor(IndexedColors.LIGHT_CORNFLOWER_BLUE.getIndex());
-        style.setFillPattern(CellStyle.SOLID_FOREGROUND);
+        style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
         style.setFont(headerFont);
         styles.put("header", style);
 
@@ -244,13 +247,13 @@ public class ExcelDownloader extends FeatureDownloader{
 
     private static CellStyle createBorderedStyle(Workbook wb){
         CellStyle style = wb.createCellStyle();
-        style.setBorderRight(CellStyle.BORDER_THIN);
+        style.setBorderRight(BorderStyle.THIN);
         style.setRightBorderColor(IndexedColors.BLACK.getIndex());
-        style.setBorderBottom(CellStyle.BORDER_THIN);
+        style.setBorderBottom(BorderStyle.THIN);
         style.setBottomBorderColor(IndexedColors.BLACK.getIndex());
-        style.setBorderLeft(CellStyle.BORDER_THIN);
+        style.setBorderLeft(BorderStyle.THIN);
         style.setLeftBorderColor(IndexedColors.BLACK.getIndex());
-        style.setBorderTop(CellStyle.BORDER_THIN);
+        style.setBorderTop(BorderStyle.THIN);
         style.setTopBorderColor(IndexedColors.BLACK.getIndex());
         return style;
     }

--- a/viewer/src/main/java/nl/b3p/viewer/image/ArcImsImageCollector.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ArcImsImageCollector.java
@@ -26,7 +26,7 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jdom.JDOMException;
+import org.jdom2.JDOMException;
 import org.xml.sax.InputSource;
 
 /**

--- a/viewer/src/main/java/nl/b3p/viewer/image/ArcServerImageCollector.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ArcServerImageCollector.java
@@ -26,7 +26,7 @@ import javax.xml.xpath.XPathFactory;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jdom.JDOMException;
+import org.jdom2.JDOMException;
 import org.xml.sax.InputSource;
 
 /**

--- a/viewer/src/main/java/nl/b3p/viewer/image/PrePostImageCollector.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/PrePostImageCollector.java
@@ -20,16 +20,13 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.xml.xpath.XPathExpressionException;
-import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
-import org.apache.commons.httpclient.auth.AuthScope;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.StringRequestEntity;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jdom.JDOMException;
+import org.jdom2.JDOMException;
 
 /**
  * Class that gets the image in 2 steps. First sumbit the body and then recieve the url from the response.

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/CatalogSearchActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/CatalogSearchActionBean.java
@@ -64,8 +64,8 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.util.Version;
-import org.jdom.Element;
-import org.jdom.JDOMException;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
 
 import org.json.*;
 import org.stripesstuff.stripersist.Stripersist;

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/CatalogSearchActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/CatalogSearchActionBean.java
@@ -412,7 +412,7 @@ public class CatalogSearchActionBean implements ActionBean {
 
             PropertyIsEqualTo propertyIsEqualTo = FilterCreator.createPropertyIsEqualTo(queryString, propertyName);
 
-            StandardAnalyzer standardAnalyzer = new StandardAnalyzer(Version.LUCENE_45,DutchAnalyzer.getDefaultStopSet());
+            StandardAnalyzer standardAnalyzer = new StandardAnalyzer(Version.LUCENE_46, DutchAnalyzer.getDefaultStopSet());
 
             orList.add(propertyIsEqualTo);
             try {

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -31,6 +31,7 @@
         ...
 
         PostgreSQL:
+
         <Resource auth="Container"
                   driverClassName="org.postgresql.Driver"
                   type="javax.sql.DataSource"
@@ -46,7 +47,7 @@
         />
     </Server>
 
-    NOTE: each JDBC driver version and each version of Tomcat will have different options that can be set
+    NOTE: each JDBC driver version and each version of Tomcat will have different options that can/must be set
     
     -->
   <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
@@ -62,12 +63,29 @@
     http://www.oracle.com/technetwork/java/javamail/index-141777.html
 
     <Server ...>
-        ...
-        <GlobalNamingResources>
-            <Resource name="mail/session"
-                    auth="Container"
-                    type="javax.mail.Session"
-                    mail.smtp.host="smtp.mycompany.com"
+    ...
+    <GlobalNamingResources>
+        <Resource name="mail/session"
+                auth="Container"
+                type="javax.mail.Session"
+                mail.smtp.host="smtp.mycompany.com"
+        />
+    -->
+    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
+    <!-- Security configuration -->
+    <!-- use LockOutRealm instead of CombinedRealm to prevent brute-forcing -->
+    <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm allRolesMode="authOnly"
+               className="org.apache.catalina.realm.DataSourceRealm"
+               dataSourceName="jdbc/geo_viewer"
+               roleNameCol="group_"
+               userCredCol="password"
+               userNameCol="username"
+               userRoleTable="user_groups"
+               userTable="user_"
+               digest="SHA-1">
+            <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
+                               algorithm="SHA-1"
             />
         </Realm>
         <!-- Use JNDIRealm for authenticating against a LDAP server (such as

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -45,23 +45,29 @@
                   validationQuery="select 1"
         />
     </Server>
+
+    NOTE: each JDBC driver version and each version of Tomcat will have different options that can be set
+    
     -->
-    <!-- Tomcat resource link -->
-    <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
-    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session" />
-    <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
-    <Realm className="org.apache.catalina.realm.LockOutRealm">
-        <Realm allRolesMode="authOnly"
-               className="org.apache.catalina.realm.DataSourceRealm"
-               dataSourceName="jdbc/geo_viewer"
-               roleNameCol="group_"
-               userCredCol="password"
-               userNameCol="username"
-               userRoleTable="user_groups"
-               userTable="user_"
-               digest="SHA-1">
-            <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
-                               algorithm="SHA-1"
+  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
+  <!-- For Tomcat: define JavaMail resource in server.xml. See:
+
+    http://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html#JavaMail_Sessions
+
+    Don't forget to put a mail.jar in the Tomcat lib directory.
+
+    To configure your mail server, use attributes like "mail.smtp.host" for
+    the Resource element. See Appendix A of the JavaMail spec for which
+    attributes you can use, possibly accessible at
+    http://www.oracle.com/technetwork/java/javamail/index-141777.html
+
+    <Server ...>
+        ...
+        <GlobalNamingResources>
+            <Resource name="mail/session"
+                    auth="Container"
+                    type="javax.mail.Session"
+                    mail.smtp.host="smtp.mycompany.com"
             />
         </Realm>
         <!-- Use JNDIRealm for authenticating against a LDAP server (such as

--- a/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
+++ b/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
@@ -225,7 +225,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             }
 
             var actionBeans = {
-                "appConfig":            <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ApplicationActionBean" event="retrieveAppConfigJSON" /></js:quote>,
+                "appConfig":          <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ApplicationActionBean" event="retrieveAppConfigJSON" /></js:quote>,
                 "service":            <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.ServiceActionBean"/></js:quote>,
                 "feature":            <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.FeatureActionBean"/></js:quote>,
                 "sld":                <js:quote><stripes:url beanclass="nl.b3p.viewer.stripes.SldActionBean"/></js:quote>,

--- a/web-commons/pom.xml
+++ b/web-commons/pom.xml
@@ -41,10 +41,10 @@
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
-            <artifactId>servlet-api</artifactId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
+            <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
These are all minor upgrades providing buxfixes

- Upgrade commons-fileupload:commons-fileupload (1.3.2 -> 1.3.3) [changes](https://commons.apache.org/proper/commons-fileupload/changes-report.html#a1.3.3), fixes CVE-2016-1000031
- Upgrade commons-io:commons-io (2.5 -> 2.6)
- Upgrade javax.mail:javax.mail-api (1.5.6 -> 1.6.0) [changes](https://javaee.github.io/javamail/docs/CHANGES.txt)
- Upgrade org.apache.commons:commons-lang3 (3.5 -> 3.7) [3.7 release notes](https://commons.apache.org/proper/commons-lang/release-notes/RELEASE-NOTES-3.7.txt)
- Upgrade org.apache.poi:poi and org.apache.poi:poi-ooxml(3.16 -> 3.17) [change log](https://poi.apache.org/changes.html#3.17)
- Upgrade org.apache.xmlgraphics:batik-constants and org.apache.xmlgraphics:batik-i18n (1.9 -> 1.9.1)
- Upgrade org.javassist:javassist (3.22.0-CR1 -> 3.22.0-CR2)
- Upgrade org.mockito:mockito-core (2.7.22 -> 2.11.0) [release notes](https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md)
- Upgrade org.powermock:powermock-api-mockito2 and org.powermock:powermock-module-junit4 (1.7.0RC2 -> 1.7.3) [release notes](https://github.com/powermock/powermock/releases)
- Upgrade jdom:jdom:1.0 to jdom:jdom2:2.0.6
- Upgrade b3p-commons-csw, 2.0 -> 5.0.1
- Upgrade org.hibernate:hibernate-core and org.hibernate:hibernate-entitymanager (3.6.8.Final -> 3.6.10.Final)
- Upgrade Apache HttpComponents (4.5.3 -> 4.5.4) [release notes](https://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt)
- Upgrade servlet-api (2.5 -> 3.0.1)* 
- Upgrade jsp-api (2.0 ->2.2)*
- Upgrade jstl (1.2 -> 1.2.4)
  
  *Tomcat 7 is built to support servlet-api 3.0 and jsp-api 2.2, see: https://tomcat.apache.org/whichversion.html


The two Batik dependencies can possibly be removed as these are only there as a workaround for [BATIK-1185](https://issues.apache.org/jira/browse/BATIK-1185), this will be looked into as part of #956