### PR TITLE
Make Flamingo work on Tomcat 8.5.x

### DIFF
--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -55,7 +55,7 @@
     </Server>
     -->
   <!-- Tomcat resource link -->
-  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
+  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
   <!-- For Tomcat: define JavaMail resource in server.xml. See:
 
     http://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html#JavaMail_Sessions
@@ -90,7 +90,8 @@
                userCredCol="password"
                userNameCol="username"
                userRoleTable="user_groups"
-               userTable="user_">
+               userTable="user_"
+               digest="SHA-1">
             <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
                                algorithm="SHA-1"
             />

--- a/viewer-admin/src/main/webapp/META-INF/context.xml
+++ b/viewer-admin/src/main/webapp/META-INF/context.xml
@@ -10,29 +10,52 @@
   <!--Parameter name="monitoring.schedule.minutes" value="30" override="false"/-->
   <!--Parameter name="flamingo.data.dir" value="/opt/flamingo_data" override="false"/-->
   <!-- For Tomcat: define datasource in server.xml, for example:
+    NOTE:
+        each version of tomcat comes with it's own version of the pooling library
+        that can have subtle difference so you must check for your version:
+
+        - https://tomcat.apache.org/tomcat-7.0-doc/jndi-datasource-examples-howto.html
+        - https://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html
+        - https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html
 
     <Server ...>
         ...
+        Oracle:
+
         <GlobalNamingResources>
             <Resource name="jdbc/geo_viewer"
                 auth="Container"
                 type="javax.sql.DataSource"
-                username="geo_viewer"
-                password="geo_viewer"
+                username="flamingo4"
+                password="flamingo4"
                 driverClassName="oracle.jdbc.OracleDriver"
                 url="jdbc:oracle:thin:@localhost:1521:orcl"
                 maxActive="40"
-                validationQuery="select 1 from dual"
-
                 timeBetweenEvictionRunsMillis="30000"
                 minEvictableIdleTimeMillis="5000"
+                validationQuery="select 1 from dual"
             />
         </GlobalNamingResources>
         ...
+
+        PostgreSQL:
+        <Resource auth="Container"
+                  driverClassName="org.postgresql.Driver"
+                  type="javax.sql.DataSource"
+                  name="jdbc/geo_viewer"
+                  url="jdbc:postgresql://localhost:5432/flamingo4"
+                  username="flamingo4"
+                  password="flamingo4"
+                  timeBetweenEvictionRunsMillis="30000"
+                  maxWaitMillis="15000"
+                  minEvictableIdleTimeMillis="5000"
+                  maxTotal="40"
+                  validationQuery="select 1"
+        />
     </Server>
     -->
   <!-- Tomcat resource link -->
-  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
+  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
   <!-- For Tomcat: define JavaMail resource in server.xml. See:
 
     http://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html#JavaMail_Sessions
@@ -56,17 +79,28 @@
         ...
     </Server>
     -->
-  <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
-  <!-- Security configuration -->
-  <!-- use LockOutRealm instead of CombinedRealm to prevent brute-forcing -->
-  <Realm className="org.apache.catalina.realm.LockOutRealm">
-    <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/geo_viewer" digest="SHA-1" roleNameCol="group_" userCredCol="password" userNameCol="username" userRoleTable="user_groups" userTable="user_"/>
-    <!-- Use JNDIRealm for authenticating against a LDAP server (such as
+    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session" />
+    <!-- Security configuration -->
+    <!-- use LockOutRealm instead of CombinedRealm to prevent brute-forcing -->
+    <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm allRolesMode="authOnly"
+               className="org.apache.catalina.realm.DataSourceRealm"
+               dataSourceName="jdbc/geo_viewer"
+               roleNameCol="group_"
+               userCredCol="password"
+               userNameCol="username"
+               userRoleTable="user_groups"
+               userTable="user_">
+            <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
+                               algorithm="SHA-1"
+            />
+        </Realm>
+        <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):
              http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html
              http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#JNDIRealm
         -->
-    <!--Realm className="org.apache.catalina.realm.JNDIRealm"
+        <!--Realm className="org.apache.catalina.realm.JNDIRealm"
             allRolesMode="authOnly"
             connectionURL="ldap://ldap:389"
             connectionName="cn=ServiceUser,ou=Services,o=MyOrg"
@@ -76,5 +110,5 @@
             userSearch="cn={0}"
             commonRole="ExtendedUser"
         /-->
-  </Realm>
+    </Realm>
 </Context>

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/stripersist/DynamicStripersistInitializer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/stripersist/DynamicStripersistInitializer.java
@@ -21,7 +21,9 @@ import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedMap;
+import javax.naming.Context;
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.servlet.ServletContext;
 import javax.sql.DataSource;
 import org.apache.commons.logging.Log;
@@ -37,7 +39,7 @@ public class DynamicStripersistInitializer implements InitializeSettings {
 
     private static final Log log = LogFactory.getLog(DynamicStripersistInitializer.class);
     
-    private static final String DATA_SOURCE_NAME = "java:comp/env/jdbc/geo_viewer";
+    private static final String DATA_SOURCE_NAME = "jdbc/geo_viewer";
 
     public static final String PU_PREFIX = "viewer-config-";
     public static String databaseProductName = null;
@@ -59,11 +61,12 @@ public class DynamicStripersistInitializer implements InitializeSettings {
         String persistenceUnit = null;
         DataSource ds = null;
         try {
-            InitialContext ctx = new InitialContext();
-        
-            ds = (DataSource)ctx.lookup(DATA_SOURCE_NAME);
-        } catch(Exception e) {
-            log.info("No JNDI DataSource found under " + DATA_SOURCE_NAME + "");
+            InitialContext init = new InitialContext();
+            Context env = (Context) init.lookup("java:comp/env");
+            ds = (DataSource) env.lookup(DATA_SOURCE_NAME);
+        } catch (NamingException e) {
+            log.fatal("No JNDI DataSource found under " + DATA_SOURCE_NAME + "");
+            log.debug(e.getLocalizedMessage(), e);
         }
 
         if(ds != null) {

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -2,39 +2,73 @@
 <Context antiJARLocking="true" disableURLRewriting="true" path="/viewer">
   <Parameter name="componentregistry.path" override="false" value="/viewer-html/components"/>
   <!-- For Tomcat: define datasource in server.xml, for example:
+    NOTE:
+        each version of tomcat comes with it's own version of the pooling library
+        that can have subtle difference so you must check for your version:
+
+        - https://tomcat.apache.org/tomcat-7.0-doc/jndi-datasource-examples-howto.html
+        - https://tomcat.apache.org/tomcat-8.0-doc/jndi-resources-howto.html
+        - https://tomcat.apache.org/tomcat-8.5-doc/jndi-datasource-examples-howto.html
 
     <Server ...>
         ...
+        Oracle:
+
         <GlobalNamingResources>
             <Resource name="jdbc/geo_viewer"
                 auth="Container"
                 type="javax.sql.DataSource"
-                username="geo_viewer"
-                password="geo_viewer"
+                username="flamingo4"
+                password="flamingo4"
                 driverClassName="oracle.jdbc.OracleDriver"
                 url="jdbc:oracle:thin:@localhost:1521:orcl"
                 maxActive="40"
-                validationQuery="select 1 from dual"
-
                 timeBetweenEvictionRunsMillis="30000"
                 minEvictableIdleTimeMillis="5000"
+                validationQuery="select 1 from dual"
             />
         </GlobalNamingResources>
         ...
+
+        PostgreSQL:
+        <Resource auth="Container"
+                  driverClassName="org.postgresql.Driver"
+                  type="javax.sql.DataSource"
+                  name="jdbc/geo_viewer"
+                  url="jdbc:postgresql://localhost:5432/flamingo4"
+                  username="flamingo4"
+                  password="flamingo4"
+                  timeBetweenEvictionRunsMillis="30000"
+                  maxWaitMillis="15000"
+                  minEvictableIdleTimeMillis="5000"
+                  maxTotal="40"
+                  validationQuery="select 1"
+        />
     </Server>
     -->
-  <!-- Tomcat resource link -->
-  <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource"/>
-  <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session"/>
-  <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
-  <Realm className="org.apache.catalina.realm.LockOutRealm">
-    <Realm allRolesMode="authOnly" className="org.apache.catalina.realm.DataSourceRealm" dataSourceName="jdbc/geo_viewer" digest="SHA-1" roleNameCol="group_" userCredCol="password" userNameCol="username" userRoleTable="user_groups" userTable="user_"/>
-    <!-- Use JNDIRealm for authenticating against a LDAP server (such as
+    <!-- Tomcat resource link -->
+    <ResourceLink global="jdbc/geo_viewer" name="jdbc/geo_viewer" type="javax.sql.DataSource" />
+    <ResourceLink global="mail/session" name="mail/session" type="javax.mail.Session" />
+    <!-- use LockoutRealm instead of CombinedRealm to prevent brute-forcing -->
+    <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm allRolesMode="authOnly"
+               className="org.apache.catalina.realm.DataSourceRealm"
+               dataSourceName="jdbc/geo_viewer"
+               roleNameCol="group_"
+               userCredCol="password"
+               userNameCol="username"
+               userRoleTable="user_groups"
+               userTable="user_">
+            <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
+                               algorithm="SHA-1"
+            />
+        </Realm>
+        <!-- Use JNDIRealm for authenticating against a LDAP server (such as
              Active Directory):
              http://tomcat.apache.org/tomcat-8.0-doc/config/realm.html
              http://tomcat.apache.org/tomcat-8.0-doc/realm-howto.html#JNDIRealm
         -->
-    <!--Realm className="org.apache.catalina.realm.JNDIRealm"
+        <!--Realm className="org.apache.catalina.realm.JNDIRealm"
             allRolesMode="authOnly"
             connectionURL="ldap://ldap:389"
             connectionName="cn=ServiceUser,ou=Services,o=MyOrg"
@@ -44,5 +78,5 @@
             userSearch="cn={0}"
             commonRole="ExtendedUser"
         /-->
-  </Realm>
+    </Realm>
 </Context>

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -58,7 +58,8 @@
                userCredCol="password"
                userNameCol="username"
                userRoleTable="user_groups"
-               userTable="user_">
+               userTable="user_"
+               digest="SHA-1">
             <CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
                                algorithm="SHA-1"
             />


### PR DESCRIPTION
Update the `context.xml` files for both viewer and viewer-admin so they provide working configuration for Tomcat 8.5.x (tested with 8.5.23)
The essence is adding the following `CredentialHandler` node to the security `Realm`:
```xml
<CredentialHandler className="org.apache.catalina.realm.MessageDigestCredentialHandler"
                   algorithm="SHA-1"
/>
```

## backwards compatibility
Does it still work with:

  - [x] Tomcat 7.0.81 (will fail if the `digest="SHA-1"` attribute is removed from the DataSourceRealm and will log a warning message about the added CredentialHandler)
  - [x] Tomcat 8.0.47 (will log a message about the unknown  `digest="SHA-1"` attribute)


close #947