### PR TITLE
impr/maintain attribute order

### DIFF
--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -305,6 +305,7 @@
                                 <param>${viewerhtml.path}/common/overrides.js</param>
                                 <param>${viewerhtml.path}/common/ScreenPopup.js</param>
                                 <param>${viewerhtml.path}/common/CQLFilterWrapper.js</param>
+                                <param>${viewerhtml.path}/common/FeatureInfoWrapper.js</param>
                                 <param>${viewerhtml.path}/common/ClearTrigger.js</param>
                                 <param>${viewerhtml.path}/common/LocalStorage.js</param>
                                 <!-- Server side Ajax Wrappers -->

--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintExtraInfo.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintExtraInfo.java
@@ -68,7 +68,7 @@ public class PrintExtraInfo {
 
     public void setInfoArray(JSONArray j) throws Exception {
         JSONObject properties = new JSONObject();
-        properties.put("properties", j);
+        properties.put("attr", j);
         this.setInfoObject(properties);
     }
 

--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintExtraInfo.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintExtraInfo.java
@@ -21,6 +21,8 @@ import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.w3c.dom.Node;
 
@@ -61,12 +63,21 @@ public class PrintExtraInfo {
     }
 
     public void setInfoText(JSONObject j) throws Exception {
+        this.setInfoObject(j);
+    }
+
+    public void setInfoArray(JSONArray j) throws Exception {
+        JSONObject properties = new JSONObject();
+        properties.put("properties", j);
+        this.setInfoObject(properties);
+    }
+
+    private void setInfoObject(JSONObject j) throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         JSONObject root = new JSONObject();
         root.put("root", j);
         String s = org.json.XML.toString( root);
         this.info =dbf.newDocumentBuilder().parse(new ByteArrayInputStream(s.getBytes("UTF-8"))).getDocumentElement();
-        
     }
     
 }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
@@ -100,6 +100,9 @@ public class FeatureInfoActionBean implements ActionBean {
     @Validate
     private boolean graph = false;
 
+    @Validate
+    private boolean ordered = false;
+
     private Layer layer;
 
     //<editor-fold defaultstate="collapsed" desc="getters and setters">
@@ -197,6 +200,14 @@ public class FeatureInfoActionBean implements ActionBean {
 
     public void setGraph(boolean graph) {
         this.graph = graph;
+    }
+
+    public boolean isOrdered() {
+        return ordered;
+    }
+
+    public void setOrdered(boolean ordered) {
+        this.ordered = ordered;
     }
 
     public Layer getLayer() {
@@ -360,7 +371,7 @@ public class FeatureInfoActionBean implements ActionBean {
     protected JSONArray executeQuery(ApplicationLayer al, SimpleFeatureType ft, FeatureSource fs, Query q)
             throws IOException, JSONException, Exception {
 
-        FeatureToJson ftjson = new FeatureToJson(arrays, edit, graph, attributesToInclude);
+        FeatureToJson ftjson = new FeatureToJson(arrays, edit, graph, false, false, attributesToInclude, ordered);
         JSONArray features = ftjson.getJSONFeatures(al, ft, fs, q, null, null);
         return features;
     }

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureReportActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureReportActionBean.java
@@ -224,7 +224,7 @@ public class FeatureReportActionBean implements ActionBean {
                                 // remove FID
                                 JSONArray feat = features.getJSONArray(featureCount);
                                 FeaturePropertiesArrayHelper.removeKey(feat, FID);//.remove(FID);
-                                colCount = features.getJSONArray(featureCount).length();
+                                colCount = feat.length();
                                 jsonFeats.put(feat);
                             }
                             info.put("features", jsonFeats);

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -182,14 +182,17 @@ public class PrintActionBean implements ActionBean {
                 PrintExtraInfo pei = new PrintExtraInfo();
                 String className = extraObj.getString("className");
                 String componentName = extraObj.getString("componentName");
-                JSONObject infoString = extraObj.getJSONObject("info");
-
+                Object infoObject = extraObj.get("info");
                 pei.setClassName(className);
                 if (componentName!=null) {
                     componentName = componentName.replaceAll("_", " ");
                 }
                 pei.setComponentName(componentName);
-                pei.setInfoText(infoString);
+                if(infoObject instanceof JSONArray) {
+                    pei.setInfoArray((JSONArray)infoObject);
+                } else if(infoObject instanceof JSONObject) {
+                    pei.setInfoText((JSONObject)infoObject);
+                }
                 peis.add(pei);
             }
             info.setExtra(peis);

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
@@ -21,7 +21,7 @@ public class FeaturePropertiesArrayHelper {
         for(int i = 0; i < len; i++) {
             JSONObject o = j.optJSONObject(i);
             if(o != null && o.has(key)) {
-                o.get(key);
+                return o.get(key);
             }
         }
         return null;
@@ -30,7 +30,7 @@ public class FeaturePropertiesArrayHelper {
     public static JSONArray removeKey(JSONArray j, String key) {
         int len = j.length();
         int idx = -1;
-        for(int i = 0; i < len; i++) {
+        for(int i = (len - 1); i >= 0; i--) {
             JSONObject o = j.optJSONObject(i);
             if(o != null && o.has(key)) {
                 idx = i;

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2018 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package nl.b3p.viewer.util;
 
 import org.json.JSONArray;

--- a/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FeaturePropertiesArrayHelper.java
@@ -1,0 +1,46 @@
+package nl.b3p.viewer.util;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class FeaturePropertiesArrayHelper {
+
+    public static boolean containsKey(JSONArray j, String key) {
+        int len = j.length();
+        for(int i = 0; i < len; i++) {
+            JSONObject o = j.optJSONObject(i);
+            if(o != null && o.has(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static Object getByKey(JSONArray j, String key) {
+        int len = j.length();
+        for(int i = 0; i < len; i++) {
+            JSONObject o = j.optJSONObject(i);
+            if(o != null && o.has(key)) {
+                o.get(key);
+            }
+        }
+        return null;
+    }
+
+    public static JSONArray removeKey(JSONArray j, String key) {
+        int len = j.length();
+        int idx = -1;
+        for(int i = 0; i < len; i++) {
+            JSONObject o = j.optJSONObject(i);
+            if(o != null && o.has(key)) {
+                idx = i;
+                break;
+            }
+        }
+        if(idx != -1) {
+            j.remove(idx);
+        }
+        return j;
+    }
+
+}

--- a/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
+++ b/viewer/src/main/webapp/WEB-INF/jsp/app.jsp
@@ -120,6 +120,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <script type="text/javascript" src="${contextPath}/viewer-html/common/overrides.js"></script>
                 <script type="text/javascript" src="${contextPath}/viewer-html/common/ScreenPopup.js"></script>
                 <script type="text/javascript" src="${contextPath}/viewer-html/common/CQLFilterWrapper.js"></script>
+                <script type="text/javascript" src="${contextPath}/viewer-html/common/FeatureInfoWrapper.js"></script>
                 <script type="text/javascript" src="${contextPath}/viewer-html/common/ClearTrigger.js"></script>
                 <script type="text/javascript" src="${contextPath}/viewer-html/common/LocalStorage.js"></script>
 

--- a/viewer/src/main/webapp/WEB-INF/xsl/print/FeatureReport.xsl
+++ b/viewer/src/main/webapp/WEB-INF/xsl/print/FeatureReport.xsl
@@ -200,21 +200,22 @@
                 <fo:table-column column-width="{$tWidthRight}mm" />
                 <fo:table-body>
                     <xsl:for-each select="*">
-                        <xsl:sort select="local-name()" data-type="text"/>
-                        <fo:table-row>
-                            <fo:table-cell>
-								<fo:block>
-									<xsl:call-template name="string-remove-underscores">
-										<xsl:with-param name="text" select="local-name()" />
-									</xsl:call-template>
-								</fo:block>
-                            </fo:table-cell>
-                            <fo:table-cell>
-                               <fo:block>
-                                    <xsl:value-of select="normalize-space(.)" />
-                                </fo:block>
-                            </fo:table-cell>
-                        </fo:table-row>
+                        <xsl:for-each select="*">
+                            <fo:table-row>
+                                <fo:table-cell>
+                                    <fo:block>
+                                        <xsl:call-template name="string-remove-underscores">
+                                            <xsl:with-param name="text" select="local-name()" />
+                                        </xsl:call-template>
+                                    </fo:block>
+                                </fo:table-cell>
+                                <fo:table-cell>
+                                   <fo:block>
+                                        <xsl:value-of select="normalize-space(.)" />
+                                    </fo:block>
+                                </fo:table-cell>
+                            </fo:table-row>
+                        </xsl:for-each>
                     </xsl:for-each>
                 </fo:table-body>
             </fo:table>

--- a/viewer/src/main/webapp/WEB-INF/xsl/print/FeatureReport.xsl
+++ b/viewer/src/main/webapp/WEB-INF/xsl/print/FeatureReport.xsl
@@ -234,15 +234,17 @@
                         <fo:table-header xsl:use-attribute-sets="table-header-font">
                             <xsl:comment>header rij</xsl:comment>
                             <fo:table-row>
-                                <xsl:for-each select="features/*">
-                                    <xsl:if test ="true() and not(../following-sibling::features)">
-                                        <fo:table-cell>
-                                            <fo:block>
-                                                <xsl:call-template name="string-remove-underscores">
-                                                    <xsl:with-param name="text" select="local-name()" />
-                                                </xsl:call-template>
-                                            </fo:block>
-                                        </fo:table-cell>
+                                <xsl:for-each select="features">
+                                    <xsl:if test ="position() = last()">
+                                        <xsl:for-each select="array/*">
+                                            <fo:table-cell>
+                                                <fo:block>
+                                                    <xsl:call-template name="string-remove-underscores">
+                                                        <xsl:with-param name="text" select="local-name()" />
+                                                    </xsl:call-template>
+                                                </fo:block>
+                                            </fo:table-cell>
+                                        </xsl:for-each>
                                     </xsl:if>
                                 </xsl:for-each>
                             </fo:table-row>

--- a/viewer/src/main/webapp/viewer-html/common/FeatureInfoWrapper.js
+++ b/viewer/src/main/webapp/viewer-html/common/FeatureInfoWrapper.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2012-2018 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Optional wrapper for FeatureInfo as returned by ajax/FeatureInfo
+ * FeatureInfo attributes can be an array or an object. This wrapper takes care of the differences and provides unified
+ * methods to get the attribute information
+ */
+Ext.define("viewer.FeatureInfoWrapper", {
+    feature: null,
+    indexedAttributes: null,
+    constructor : function (feature){
+        this.feature = feature;
+    },
+    getAttributes: function() {
+        // Backwards compatibility. If the feature is the attributes (old way) use the feature as attribute obj.
+        return this.feature.attributes ? this.feature.attributes : this.feature;
+    },
+    forEachAttribute: function(fn, scope, filteredAttributes) {
+        var attributes = this.getAttributes();
+        var indexedFilteredAttributes = {};
+        for(var i = 0; i < filteredAttributes.length; i++) {
+            indexedFilteredAttributes[filteredAttributes[i]] = true;
+        }
+        if(Ext.isArray(attributes)) {
+            for(var j = 0; j < attributes.length; j++) {
+                this._executeLoop(attributes[j], fn, scope, indexedFilteredAttributes);
+            }
+        } else {
+            this._executeLoop(attributes, fn, scope, indexedFilteredAttributes);
+        }
+    },
+    _executeLoop: function(attributes, fn, scope, filteredAttributes) {
+        for(var key in attributes) if(attributes.hasOwnProperty(key) && !filteredAttributes.hasOwnProperty(key)) {
+            fn.call(scope || this, key, attributes[key]);
+        }
+    },
+    getIndexedAttributes: function() {
+        if(this.indexedAttributes !== null) {
+            return this.indexedAttributes;
+        }
+        var attributes = this.getAttributes();
+        if(Ext.isArray(attributes)) {
+            attributes = this.attributeArrayToObject(attributes);
+        }
+        this.indexedAttributes = attributes;
+        return this.indexedAttributes;
+    },
+    getAttribute: function(key) {
+        var attributes = this.getIndexedAttributes();
+        return attributes[key] || null;
+    },
+    getRelatedFeatureTypes: function() {
+        return this.getAttribute('related_featuretypes');
+    },
+    attributeArrayToObject: function(attributes) {
+        var attr = {};
+        var fa;
+        for(var i = 0; i < attributes.length; i++) {
+            fa = attributes[i];
+            for(var key in fa) if(fa.hasOwnProperty(key)) {
+                attr[key] = fa[key];
+            }
+        }
+        return attr;
+    }
+});

--- a/viewer/src/main/webapp/viewer-html/components/AttributeList.js
+++ b/viewer/src/main/webapp/viewer-html/components/AttributeList.js
@@ -260,10 +260,16 @@ Ext.define ("viewer.components.AttributeList",{
         }
         this.attributeListLinkInFeatureInfoCreated = true;
     },
+    /**
+     * Handle FeatureInfo/Maptip link click
+     * @param {viewer.FeatureInfoWrapper} feature
+     * @param appLayer
+     * @param coords
+     */
     handleFeatureInfoLink: function(feature, appLayer, coords) {
         // Show the window
         this.showWindow();
-        this.filterFeature = feature.__fid;
+        this.filterFeature = feature.getAttribute('__fid');
         // Check if the appLayer is selected already
         // If the layer is already selected, fire layerChanged ourself
         var selectedAppLayer = this.layerSelector.getValue();

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -38,7 +38,7 @@ Ext.define("viewer.components.Edit", {
     schema: null,
     editLinkInFeatureInfoCreated: false,
     afterLoadAttributes: null,
-    filterFeature: null,
+    filterFeatureId: null,
     // Boolean to check if window is hidden temporarily for mobile mode
     mobileHide: false,
     config: {
@@ -344,7 +344,7 @@ Ext.define("viewer.components.Edit", {
         // Add event handler to get features for coordinates
         this.afterLoadAttributes = function () {
             this.afterLoadAttributes = null;
-            this.filterFeature = feature;
+            this.filterFeatureId = feature.getAttribute('__fid');
             this.mode = "edit";
             this.config.viewerController.mapComponent.getMap().setMarker("edit", coords.x, coords.y);
             this.getFeaturesForCoords(coords);
@@ -697,11 +697,11 @@ Ext.define("viewer.components.Edit", {
             return;
         }
         // A feature filter has been set, filter the right feature from the result set
-        if (this.filterFeature !== null) {
+        if (this.filterFeatureId !== null) {
             for (var i = 0; i < features.length; i++) {
-                if (features[i].__fid === this.filterFeature.__fid) {
+                if (features[i].__fid === this.filterFeatureId) {
                     this.handleFeature(this.indexFeatureToNamedFeature(features[i]));
-                    this.filterFeature = null; // Remove filter after first use
+                    this.filterFeatureId = null; // Remove filter after first use
                     return;
                 }
             }

--- a/viewer/src/main/webapp/viewer-html/components/FeatureInfo.js
+++ b/viewer/src/main/webapp/viewer-html/components/FeatureInfo.js
@@ -27,6 +27,7 @@ Ext.define ("viewer.components.FeatureInfo",{
      */
     constructor: function (conf){    
         conf.isPopup=true;
+        conf.useOrderedAttributes = true;
         //don't call maptip constructor but that of super maptip.
         this.initConfig(conf);
         viewer.components.FeatureInfo.superclass.constructor.call(this, this.config);

--- a/viewer/src/main/webapp/viewer-html/components/FeatureReport.js
+++ b/viewer/src/main/webapp/viewer-html/components/FeatureReport.js
@@ -184,28 +184,29 @@ Ext.define("viewer.components.FeatureReport", {
     /**
      * Called from the featureinfo popup that we registered with.
      *
-     * @param {type} feature selected feature
+     * @param {viewer.FeatureInfoWrapper} feature selected feature
      * @param {type} appLayer
      * @returns void
      */
     handleAction: function (feature, appLayer) {
         Ext.getCmp(this.name + 'formappLayer').setValue(appLayer.id);
-        Ext.getCmp(this.name + 'formFid').setValue(feature.__fid);
+        Ext.getCmp(this.name + 'formFid').setValue(feature.getAttribute('__fid'));
         Ext.getCmp(this.name + 'maxFeats').setValue(this.config.numOfRelatedFeatures);
 
         // use the summary title of the featureinfo
         if (appLayer.details['summary.title']) {
             var t = appLayer.details['summary.title'];
-            for (var key in feature) {
-                if (!feature.hasOwnProperty(key)) {
+            var attributes = feature.getIndexedAttributes();
+            for (var key in attributes) {
+                if (!attributes.hasOwnProperty(key)) {
                     continue;
                 }
                 var regex = new RegExp("\\[" + key + "\\]", "g");
-                t = t.replace(regex, String(feature[key]));
+                t = t.replace(regex, String(attributes[key]));
             }
             this.subTitle = this.config.subTitle + ' ' + t;
         } else {
-            this.subTitle = this.config.subTitle + ' feature id:' + feature.__fid;
+            this.subTitle = this.config.subTitle + ' feature id:' + feature.getAttribute('__fid');
         }
 
         var mapvalues = this.getMapValues();

--- a/viewer/src/main/webapp/viewer-html/components/RequestManager.js
+++ b/viewer/src/main/webapp/viewer-html/components/RequestManager.js
@@ -29,7 +29,7 @@ Ext.define ("viewer.components.RequestManager",{
         this.featureInfo = featureInfo;
         this.config.viewerController = viewerController;
     },
-    request: function (id, options, radius, layers, callback, failure, scope) {
+    request: function (id, options, radius, layers, callback, failure, scope, params) {
         var me = this;
         if (!scope) {
             scope = me;
@@ -41,9 +41,9 @@ Ext.define ("viewer.components.RequestManager",{
             this.previousRequests[id].done = 0;
             this.cancelPrevious(id);
         }
-        var extraParams = {
+        var extraParams = Ext.merge({}, params, {
             requestId: id
-        };
+        });
         for(var i = 0 ; i < layers.length;i++){
             var request = this.featureInfo.layersFeatureInfo(options.coord.x, options.coord.y, radius, [layers[i]], extraParams,function(data){
                 me.responseReceived(data[0].requestId);


### PR DESCRIPTION
Use JSONArray instead of JSONObject for attributes to maintain order of the attributes.
Currently used by FeatureInfoReport & FeatureInfo component