### PR TITLE
Update GeoTools & PostgreSQL & Apache  HttpComponents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
   # install without testing
-  - travis_wait 20 mvn install -U -DskipTests -Dtest.skip.integrationtests=true -B -V -fae -q --settings .travis/settings.xml
+  - travis_wait 30 mvn --settings .travis/settings.xml -Ptravis-ci-prebuild install -U -DskipTests -Dtest.skip.integrationtests=true -B -V -fae -T4.2C
 
 script:
   - ulimit -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ before_install:
 
 install:
   # install without testing
-  #- mvn install -U -DskipTests -Dtest.skip.integrationtests=true -pl viewer-config-persistence,viewer-commons,web-commons -B -V -fae -q
-  - mvn install -U -DskipTests -Dtest.skip.integrationtests=true -B -V -fae -q
+  - travis_wait 20 mvn install -U -DskipTests -Dtest.skip.integrationtests=true -B -V -fae -q --settings .travis/settings.xml
 
 script:
   - ulimit -a

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+  <!-- servers>
+    <server>
+      <id>gh-pages</id>
+      <!- - travis encrypt GHSITE_USERNAME=.... en travis encrypt GHSITE_PASSWORD=..... - ->
+      <username>${env.GHSITE_USERNAME}</username>
+      <password>${env.GHSITE_PASSWORD}</password>
+    </server>
+  </servers -->
+  <profiles>
+    <profile>
+      <id>travis-ci</id>
+      <repositories>
+        <repository>
+          <id>osgeo</id>
+          <name>Open Source Geospatial Foundation Repository</name>
+          <url>http://download.osgeo.org/webdav/geotools/</url>
+        </repository>
+        <repository>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <id>boundless</id>
+          <name>Boundless Maven Repository</name>
+          <url>https://repo.boundlessgeo.com/main</url>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+</settings>

--- a/.travis/settings.xml
+++ b/.travis/settings.xml
@@ -10,7 +10,7 @@
   </servers -->
   <profiles>
     <profile>
-      <id>travis-ci</id>
+      <id>travis-ci-prebuild</id>
       <repositories>
         <repository>
           <id>osgeo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.2.0</postgresql.version>
         <apache.poi.version>3.17</apache.poi.version>
-        <apache.httpcomponents.version>4.5.4</apache.httpcomponents.version>
+        <apache.httpcomponents.version>4.5.5</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,11 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>18.1</geotools.version>
+        <geotools.version>18.2</geotools.version>
         <powermock.version>1.7.3</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.1.1</postgresql.version>
+        <postgresql.version>42.2.0</postgresql.version>
         <apache.poi.version>3.17</apache.poi.version>
         <apache.httpcomponents.version>4.5.4</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline


### PR DESCRIPTION
- update GeoTools (18.1 -> 18.2) [release notes](https://osgeo-org.atlassian.net/secure/ReleaseNote.jspa?projectId=10001&version=16708)
- update Postgresql driver (42.1.4 -> 42.2.0) [release notes](https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.0)
- Update org.apache.httpcomponents (4.5.4 -> 4.5.5) [release notes](http://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt)