### PR TITLE
Bugs/svg and featureinfo issues

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/ajax/FeatureInfo.js
+++ b/viewer/src/main/webapp/viewer-html/common/ajax/FeatureInfo.js
@@ -26,18 +26,6 @@ Ext.define("viewer.FeatureInfo", {
             this.config.actionbeanUrl = actionBeans["featureinfo"];
         }
     },
-    getVisibleAppLayers: function() {
-        var visibleLayerIds = this.config.viewerController.getVisibleLayers();
-        var visibleAppLayers = {};
-        for(var i = 0; i < visibleLayerIds.length; i++) {
-            var id=visibleLayerIds[i];
-            var appLayer = this.config.viewerController.getAppLayerById(id);
-            if(appLayer != null) {
-                visibleAppLayers[appLayer.id] = true;
-            }
-        }
-        return visibleAppLayers;
-    },
     featureInfoInternal: function(params, successFunction, failureFunction,scope) {
         var me = this;
         params = Ext.apply(params, { application: this.config.viewerController.app.id });
@@ -67,7 +55,7 @@ Ext.define("viewer.FeatureInfo", {
         });
     },
     featureInfo: function(x, y, distance, successFunction, failureFunction) {
-        var visibleAppLayers = this.getVisibleAppLayers();
+        var visibleAppLayers = this.config.viewerController.getVisibleAppLayers();
 
         var queries = [];
         for(var i = 0; i < visibleAppLayers.length; i++) {
@@ -85,7 +73,7 @@ Ext.define("viewer.FeatureInfo", {
     },
     layersFeatureInfo: function(x, y, distance, appLayers, extraParams, successFunction, failureFunction,scope) {
 
-        var visibleAppLayers = this.getVisibleAppLayers();
+        var visibleAppLayers = this.config.viewerController.getVisibleAppLayers();
 
         var queries = [];
         for(var i = 0; i < appLayers.length; i++) {

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1134,6 +1134,23 @@ Ext.define("viewer.viewercontroller.ViewerController", {
         return layerArray;
     },
     /**
+     * Returns an object with visible applayer ids
+     * @param castToStrings boolean An optional parameter to cast all ID's to strings.
+     * @return a object of Layer id's (same as appLayerIds) objects
+     **/
+    getVisibleAppLayers: function(castToStrings) {
+        var visibleLayerIds = this.getVisibleLayers(castToStrings);
+        var visibleAppLayers = {};
+        for(var i = 0; i < visibleLayerIds.length; i++) {
+            var id=visibleLayerIds[i];
+            var appLayer = this.getAppLayerById(id);
+            if(appLayer != null) {
+                visibleAppLayers[appLayer.id] = true;
+            }
+        }
+        return visibleAppLayers;
+    },
+    /**
      * Gets the layers that have a maptip configured
      * @param layer a mapComponent layer.
      * @return a string of layer names in the given layer that have a maptip configured.

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
@@ -149,6 +149,7 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
                 }
                 var displayClass = control.displayClass.toLowerCase().replace("olcontrolnavigationhistory ", "");
                 buttondiv.innerHTML = [
+                    '<div class="svg-click-area"></div>', // An extra transparent DIV is added to fix issue where button could not be clicked in IE
                     '<svg role="img" title=""><use xlink:href="',
                     appSprite,
                     '#icon-',

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
@@ -623,6 +623,7 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
                 me.maps[0].getFrameworkMap().addControl(tool.getFrameworkTool());
                 me.getPanel().addControls([tool.getFrameworkTool().previous,tool.getFrameworkTool().next]);
                 me.getMap().removeListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
+                me.repaintTools();
             };
             this.getMap().addListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
         }else if (tool.getType() == viewer.viewercontroller.controller.Tool.CLICK){
@@ -648,6 +649,7 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
                 }
                 me.getPanel().addControls([navControl.previous]);
                 me.getMap().removeListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
+                me.repaintTools();
             };
             this.getMap().addListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
         }else if (tool.getType()==viewer.viewercontroller.controller.Tool.NEXT_EXTENT){//19,
@@ -663,6 +665,7 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
                 }
                 me.getPanel().addControls([navControl.next]);
                 me.getMap().removeListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
+                me.repaintTools();
             };
             this.getMap().addListener(viewer.viewercontroller.controller.Event.ON_LAYER_ADDED,handler,handler);
         }else {
@@ -686,6 +689,19 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
             }
         }
 
+    },
+    /**
+     * IE does not render tools propertly when tools are added later, which is the case for next/prev extent
+     * Code below modifies the <use> tag inside the SVG which seems to fix the issue.
+     */
+    repaintTools: function() {
+        if(!Ext.browser.is.IE) {
+            return;
+        }
+    ﻿   var tools = document.querySelectorAll('.svg-tool svg use');
+        for(var i = 0; i < tools.length; i++) {
+            tools[i].setAttribute('href', tools[i].getAttribute('xlink:href'));
+        }
     },
     removeToolById : function (id){
         var tool = this.getTool(id);

--- a/viewer/src/main/webapp/viewer-html/components/Maptip.js
+++ b/viewer/src/main/webapp/viewer-html/components/Maptip.js
@@ -188,17 +188,18 @@ Ext.define ("viewer.components.Maptip",{
         var radius=this.config.clickRadius*map.getResolution();
         var me=this;
         var currentScale = this.config.viewerController.mapComponent.getMap().getScale();
+        var visibleAppLayers = this.config.viewerController.getVisibleAppLayers();
         var inScaleLayers = new Array();
-        this.disableSpinner = true;
         if (this.serverRequestLayers){
             for (var i=0; i < this.serverRequestLayers.length; i++){
-                if (this.config.viewerController.isWithinScale(this.serverRequestLayers[i],currentScale)){
+                if (this.config.viewerController.isWithinScale(this.serverRequestLayers[i],currentScale)
+                    && visibleAppLayers.hasOwnProperty(this.serverRequestLayers[i].id)) {
                     inScaleLayers.push(this.serverRequestLayers[i]);
-                    if (this.serverRequestLayers[i].checked) {
-                        this.disableSpinner = false;
-                    }
                 }
             }
+        }
+        if(inScaleLayers.length === 0) {
+            return;
         }
         if(this.config.spinnerWhileIdentify){
             var coords = options.coord;
@@ -262,7 +263,7 @@ Ext.define ("viewer.components.Maptip",{
             }
             var data=options.data;
             var components=[];
-            if (!data){
+            if (!data) {
                 return;
             }
             
@@ -281,10 +282,6 @@ Ext.define ("viewer.components.Maptip",{
             this.lastPosition.x = options.x;
             this.lastPosition.y = options.y;
             this.worldPosition = options.coord;
-
-            if (this.disableSpinner) {
-                this.viewerController.mapComponent.getMap().removeMarker("edit");
-            }
        
             components = this.createInfoHtmlElements(data, options);
             if (!Ext.isEmpty(components)){

--- a/viewer/src/main/webapp/viewer-html/svg/svgsprite.css
+++ b/viewer/src/main/webapp/viewer-html/svg/svgsprite.css
@@ -7,7 +7,8 @@
     z-index: 10;
 }
 
-.svg-button .svg-click-area {
+.svg-button .svg-click-area,
+.svg-tool .svg-click-area {
     position: absolute;
     left: -1px;
     top: -1px;
@@ -18,11 +19,16 @@
 }
 
 .svg-tool svg {
+    position: absolute;
+    left: 0;
+    top: 0;
     width: 28px;
     height: 28px;
+    z-index: 10;
 }
 
 .svg-tool {
+    position: relative;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes 3 issues:
- Clicking tool buttons was difficult in IE with SVG icons enabled. You had to click within the button area but outside the icon itself
- When SVG was enabled and there where multiple tools configured and also Next/Previous extent tools, the other tools would not show up in IE
- In FeatureInfo/Maptip, when all layers are off when starting the viewer a spinner would occur when clicking the map but the spinner would never be removed because no request was done.