### PR TITLE
add sessionid to url when printing

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintUtil.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintUtil.java
@@ -81,7 +81,10 @@ public class PrintUtil {
     public static String getImageUrl(String param, String url, String sessionID) throws Exception {
         RedirectResolution cia = new RedirectResolution(CombineImageActionBean.class);
         RedirectResolution pa = new RedirectResolution(PrintActionBean.class);
+        // url van print actionbean naar combineimage action bean, kopieer de sessionid naar de url
+        // tomcat specifiek gedrag
         url = url.replace(pa.getUrl(new Locale("NL")), cia.getUrl(new Locale("NL")));
+        url += ";jsessionid=" + sessionID;
 
         HttpClient client = new HttpClient();
         PostMethod method = null;


### PR DESCRIPTION
because the sessionid gets lost the lookup for the remote user fails when passing around the request, as a result the wms proxy cannot authenticate when requesting the image for printing.

close #994 