### PR TITLE
GeoTools 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,12 +66,15 @@ after_success:
 jdk:
   - oraclejdk8
   - openjdk8
+  - oraclejdk9
 
 os:
   - linux
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - oraclejdk9
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ os:
 matrix:
   fast_finish: true
   allow_failures:
-    - oraclejdk9
+    - jdk: oraclejdk9
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>19-beta</geotools.version>
+        <geotools.version>19.0</geotools.version>
         <powermock.version>1.7.3</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>18.2</geotools.version>
+        <geotools.version>19-beta</geotools.version>
         <powermock.version>1.7.3</powermock.version>
         <hsqldb.version>2.4.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
GeoTools 19 provides the option to start using Java 9, blogposts: 
- http://geotoolsnews.blogspot.nl/2018/02/geotools-19-beta-released.html
- http://geotoolsnews.blogspot.nl/2018/03/geotools-19-rc1-released.html

### versions
- [x] GeoTools 19-beta
- [x] GeoTools 19-RC1
- [x] GeoTools 19.0