### PR TITLE
Update nl.b3p:b3p-commons-csw (5.0.2 -> 5.0.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>5.0.2</version>
+                <version>5.0.3</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.persistence</groupId>


### PR DESCRIPTION
b3p-commons-csw now uses geotools 19.0 as well, while here also update mockito-core lib.