### PR TITLE
Only retrieve bufferable layers if no layers were configured for snapping component

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Snapping.js
+++ b/viewer/src/main/webapp/viewer-html/components/Snapping.js
@@ -68,6 +68,9 @@ Ext.define("viewer.components.Snapping", {
             requestParams["layers"] = this.config.layers;
             requestParams["hasConfiguredLayers"] = true;
             requestParams["bufferable"] = true;
+        } else {
+            requestParams["hasConfiguredLayers"] = false;
+            requestParams["bufferable"] = true;
         }
 
         Ext.Ajax.request({


### PR DESCRIPTION
If the snapping component was not configured (not limited to specific layers) all layers are shown, even those without underlying vector data such as aerial imagery

resolves [mantis-10688](http://mantis.b3p.nl/view.php?id=10688)