### PR TITLE
Give the connection scheme to the proxy http client

### DIFF
--- a/viewer-admin/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/viewer-admin/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -16,10 +16,10 @@ log4j.logger.org.apache.solr=ERROR
 # Geotools log level
 log4j.logger.org.geotools=ERROR
 
-org.apache..commons.httpclient=INFO
-org.apache.http=INFO
-org.apache.http.wire=INFO
-httpclient.wire=INFO
+log4j.logger.org.apache.commons.httpclient=INFO
+log4j.logger.org.apache.http=INFO
+log4j.logger.org.apache.http.wire=INFO
+log4j.logger.httpclient.wire=INFO
 
 #log4j.logger.org.stripesstuff.stripersist=TRACE
 #log4j.logger.org.hibernate.SQL=DEBUG

--- a/viewer-commons/src/main/java/nl/b3p/commons/HttpClientConfigured.java
+++ b/viewer-commons/src/main/java/nl/b3p/commons/HttpClientConfigured.java
@@ -11,7 +11,6 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
@@ -99,21 +98,21 @@ public class HttpClientConfigured {
             String hostname = null; //any
             int port = -1; //any
             URL aURL;
+            String scheme = null;
             try {
                 aURL = new URL(url);
                 hostname = aURL.getHost();
                 port = aURL.getPort();
+                scheme = aURL.getProtocol();
             } catch (MalformedURLException ex) {
                 // ignore
             }
 
-            CredentialsProvider credentialsProvider
-                    =                    new BasicCredentialsProvider();
-            Credentials defaultcreds =
-                    new UsernamePasswordCredentials(username, password);
-            AuthScope authScope =
-                    new AuthScope(hostname, port);
-            credentialsProvider.setCredentials(authScope, defaultcreds);
+            CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+            credentialsProvider.setCredentials(
+                    new AuthScope(hostname, port),
+                    new UsernamePasswordCredentials(username, password)
+            );
 
             hcb = hcb.setDefaultCredentialsProvider(credentialsProvider);
 
@@ -122,13 +121,14 @@ public class HttpClientConfigured {
                 // Create AuthCache instance for preemptive authentication
                 AuthCache authCache = new BasicAuthCache();
                 BasicScheme basicAuth = new BasicScheme();
-                HttpHost targetHost = new HttpHost(hostname, port);
+                HttpHost targetHost = new HttpHost(hostname, port, scheme);
                 authCache.put(targetHost, basicAuth);
                 // Add AuthCache to the execution context
                 context.setCredentialsProvider(credentialsProvider);
                 context.setAuthCache(authCache);
                 log.debug("Preemptive credentials: hostname: " + hostname
                         + ", port: " + port
+                        + ", proto: " + scheme
                         + ", username: " + username
                         + ", password: ****.");
             }


### PR DESCRIPTION
Give the connection scheme to the proxy http client to make preemptive authentication work for https sites.

fixes [mantis 10740](http://mantis.b3p.nl/view.php?id=10740)