### PR TITLE
Remove ‘removed’ flag from appLayers when adding

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/SelectionModule.js
+++ b/viewer/src/main/webapp/viewer-html/components/SelectionModule.js
@@ -1617,6 +1617,9 @@ Ext.define ("viewer.components.SelectionModule",{
                 var service = me.services[recordOrigData.service];
                 serviceId = service.id;
             }
+            if(me.appLayers[recordOrigData.id] && me.appLayers[recordOrigData.id].removed) {
+                me.appLayers[recordOrigData.id].removed = false;
+            }
             me.addedLayers.push({
                 background: false,
                 checked: this.autoCheck(),


### PR DESCRIPTION
Fixes issue when adding 'removed' layers to the selected content through the SelectionModule