### PR TITLE
Fix for Mantis#10820: checkbox CQL must be surrounded by parentheses …

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/SimpleFilterFilters.js
+++ b/viewer/src/main/webapp/viewer-html/components/SimpleFilterFilters.js
@@ -374,6 +374,9 @@ Ext.define("viewer.components.sf.Checkbox", {
                 cql += this.config.attributeName +  operator + (mustEscape ? "'" : "")  + this.sanitizeValue(name,mustEscape) + (mustEscape ? "'" : "");
             }
         }
+        if(cql.length > 0 && this.options.length > 1){
+            cql = "(" + cql + ")";
+        }
         return cql;
     },
     reset : function(){


### PR DESCRIPTION
…to prevent incorrect cql when using it with other filters