### PR TITLE
Bug/fix click pan

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersMapComponent.js
@@ -83,6 +83,9 @@ Ext.define("viewer.viewercontroller.OpenLayersMapComponent",{
             defaultTool.setVisible(false);
             defaultTool.activate();
         }
+
+        var dummyVector = this.createVectorLayer({name:"DUMMYVECTOR_FOR_STUPID_PANIDENTIFYBUG", viewerController:this.viewerController});
+        this.getMap().addLayer(dummyVector);
     },
 
     /**

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/Utils.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/Utils.js
@@ -309,6 +309,7 @@ OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control,{
     defaultHandlerOptions: {
         'single': true,
         'double': false,
+        pixelTolerance: 10,
         'stopSingle': false,
         'stopDouble': false
     },
@@ -337,6 +338,7 @@ OpenLayers.Control.Click = OpenLayers.Class(OpenLayers.Control,{
         this.handler = new OpenLayers.Handler.Click(
             this, {
                 'click': this.onClick,
+                pixelTolerance: 10,
                 'dblclick': this.onDblclick
             }, this.handlerOptions
         );

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/tools/OpenLayersDefaultTool.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/tools/OpenLayersDefaultTool.js
@@ -51,7 +51,10 @@ Ext.define("viewer.viewercontroller.openlayers.tools.OpenLayersDefaultTool",{
             handler: {
                     fn: this.handleClick,
                     scope: this
-                }
+                },
+            handlerOptions:{
+                pixelTolerance: 10
+            }
         });
         /* The default tool can be added by the mapcomponent.checkTools. It's added
          * when there is no other tool added. The layers are already added then, so 

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/tools/OpenLayersIdentifyTool.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/tools/OpenLayersIdentifyTool.js
@@ -213,7 +213,7 @@ Ext.define("viewer.viewercontroller.openlayers.tools.OpenLayersIdentifyTool",{
             this.wmsGetFeatureInfoControl.deactivate();
         }
     },
-    handleClick: function(tool,options){                
+    handleClick: function(tool,options){
         this.map.fire(viewer.viewercontroller.controller.Event.ON_GET_FEATURE_INFO,options);
     }, 
     //called when wms layers return data.           


### PR DESCRIPTION
Fixes mantis 10471.
I think this is because of https://gis.stackexchange.com/questions/20859/will-mousedown-events-fire-with-touch-events-on-openlayers-mobile: click event is never thrown when a clickhandler is registered. Mouseup and mousedown are, but with a drag this never results in a click. Adding a vectorlayer fixes this. I know it's ugly, but after 8/10 hours, I give up.