### PR TITLE
Bump xercesImpl from 2.11.0 to 2.12.0  [v5.2.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.11.0</version>
+                <version>2.12.0</version>
             </dependency>
             <dependency>
                 <groupId>org.flamingo-mc</groupId>


### PR DESCRIPTION
Bumps xercesImpl from 2.11.0 to 2.12.0.

Signed-off-by: dependabot[bot] <support@dependabot.com>

backport of #1108 