### PR TITLE
Bug/oracle drop if exists dont work

### DIFF
--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -157,7 +157,7 @@ public class DatabaseSynchronizer implements Servlet {
         // 5.1.5 / 5.2.0-rc1 / 5.3.0
         updates.put("30", new UpdateElement(Collections.singletonList("emptySql.sql"), String.class));
         // 5.3.1 / 5.2.0
-        updates.put("31", new UpdateElement(Collections.singletonList("fileupload.sql"), String.class));
+        updates.put("31", new UpdateElement(Collections.singletonList("fileupload.sql"), String.class, true));
         // NB when adding an update also update the metadata version in the testdata.sql file around line 343
     }
 
@@ -367,7 +367,7 @@ public class DatabaseSynchronizer implements Servlet {
                                 throw new Exception("Update script '"+script+"' nor '"+databaseProductName.toLowerCase()+"-"+script+"' can be found");
                             }
                             log.info("Running database upgrade script: " + scriptName);
-                            runner.runScript(new InputStreamReader(is));
+                            runner.runScript(new InputStreamReader(is), element.canFail());
                             if (!this.errored){
                                 this.successVersion = entry.getKey();
                             }

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -157,7 +157,9 @@ public class DatabaseSynchronizer implements Servlet {
         // 5.1.5 / 5.2.0-rc1 / 5.3.0
         updates.put("30", new UpdateElement(Collections.singletonList("emptySql.sql"), String.class));
         // 5.3.1 / 5.2.0
-        updates.put("31", new UpdateElement(Collections.singletonList("fileupload.sql"), String.class, true));
+        updates.put("31", new UpdateElement(Collections.singletonList("emptySql.sql"), String.class));
+        updates.put("32", new UpdateElement(Collections.singletonList("dropfileupload.sql"), String.class, true));
+        updates.put("33", new UpdateElement(Collections.singletonList("fileupload.sql"), String.class, true));
         // NB when adding an update also update the metadata version in the testdata.sql file around line 343
     }
 

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/UpdateElement.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/UpdateElement.java
@@ -26,10 +26,16 @@ public class UpdateElement {
 
     private List<String> elements;
     private Class clazz;
+    private boolean canFail = false;
 
     public UpdateElement(List<String> elements, Class clazz) {
+        this(elements, clazz, false);
+    }
+
+    public UpdateElement(List<String> elements, Class clazz, boolean canFail) {
         this.elements = elements;
         this.clazz = clazz;
+        this.canFail = canFail;
     }
 
     public void add(String element) {
@@ -52,5 +58,12 @@ public class UpdateElement {
         this.clazz = clazz;
     }
 
+    public boolean canFail() {
+        return canFail;
+    }
+
+    public void setCanFail(boolean canFail) {
+        this.canFail = canFail;
+    }
     
 }

--- a/viewer-config-persistence/src/main/resources/scripts/oracle-dropfileupload.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/oracle-dropfileupload.sql
@@ -1,0 +1,1 @@
+DROP TABLE file_upload;

--- a/viewer-config-persistence/src/main/resources/scripts/oracle-fileupload.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/oracle-fileupload.sql
@@ -1,14 +1,3 @@
-
--- drop table if exists
-    BEGIN
-       EXECUTE IMMEDIATE 'DROP TABLE file_upload';
-    EXCEPTION
-       WHEN OTHERS THEN
-          IF SQLCODE != -942 THEN
-             RAISE;
-          END IF;
-    END;
-
     create table file_upload (
         id number(19,0) not null,
         created_at timestamp,

--- a/viewer-config-persistence/src/main/resources/scripts/postgresql-dropfileupload.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/postgresql-dropfileupload.sql
@@ -1,0 +1,2 @@
+
+    drop table if exists file_upload;

--- a/viewer-config-persistence/src/main/resources/scripts/postgresql-fileupload.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/postgresql-fileupload.sql
@@ -1,6 +1,4 @@
 
-    drop table if exists file_upload;
-
     create table file_upload (
         id  bigserial not null,
         created_at timestamp,

--- a/viewer-config-persistence/src/test/java/nl/b3p/viewer/util/TestUtil.java
+++ b/viewer-config-persistence/src/test/java/nl/b3p/viewer/util/TestUtil.java
@@ -151,7 +151,7 @@ public abstract class TestUtil extends LoggingTestUtil {
             Session session = (Session) entityManager.getDelegate();
             conn = (Connection) session.connection();
             ScriptRunner sr = new ScriptRunner(conn, true, true);
-            sr.runScript(f);
+            sr.runScript(f, false);
             conn.commit();
             entityManager.flush();
         } finally {

--- a/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
+++ b/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
@@ -340,7 +340,7 @@ INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_L
 INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_LAYER, REMOVED) VALUES (27, false, null, 1, 4, false);
 INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_LAYER, REMOVED) VALUES (28, false, null, 1, 5, false);
 
-INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '31');
+INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '33');
 
 INSERT INTO user_ (username, password) VALUES ('admin', '14c06474bec5e7def0304925d09f2b977af3146a');
 INSERT INTO user_ (username, password) VALUES ('pietje', '14c06474bec5e7def0304925d09f2b977af3146a');


### PR DESCRIPTION
ScriptRunner parses the statements by a delimiter ";". So the BEGIN construct doesn't work.
Expanded the scriptrunner capabilities in #1151, and allowed the drop table script to fail.