### PR TITLE
Allow JS to be executed when checkbox is set

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/HTML.js
+++ b/viewer/src/main/webapp/viewer-html/components/HTML.js
@@ -44,7 +44,7 @@ Ext.define ("viewer.components.HTML",{
             autoScroll: true
         });
         
-        this.container.update(this.config.html, this.config.loadScripts);
+        this.container.getEl().setHtml(this.config.html, this.config.loadScripts, function(){}, null);
     },
     getExtComponents: function() {
         return [ this.container.getId() ];


### PR DESCRIPTION
Ext changed the way Javascript is allowed in HTML. We have to explicitly set the scope to null to prevent code to be added to container scope instead of global, which is required to define functions inside HTML block