### PR TITLE
Properly set/restore color after loading file

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Drawing.js
+++ b/viewer/src/main/webapp/viewer-html/components/Drawing.js
@@ -478,8 +478,8 @@ Ext.define ("viewer.components.Drawing",{
      **/
     activeFeatureChanged : function (vectorLayer,feature){
         this.toggleSelectForm(true);
-        if(this.features[feature.config.id] == undefined){
-            feature.color = this.config.color;
+        if(!this.features.hasOwnProperty(feature.config.id)) {
+            feature.color = feature.color || (feature.style || {}).color || this.config.color;
             this.features[feature.config.id] = feature;
         }else{
             var color = this.features[feature.config.id].color;


### PR DESCRIPTION
When a file is saved the color in the file is correct. When loading the file, the feature that is drawn is properly colored, but the color property on the Feature object is not properly set after the feature is drawn. For new features this is automatically the default color which is incorrect for loaded features