### PR TITLE
Bugs/mantis#11570 duplicate layers in legend

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/CoordinateLinkWindow.js
+++ b/viewer/src/main/webapp/viewer-html/components/CoordinateLinkWindow.js
@@ -53,6 +53,9 @@ Ext.define("viewer.components.CoordinateLinkWindow", {
         return this;
     },
     initComp: function () {
+        if(this.toolMapClick !== null) {
+            return;
+        }
         this.toolMapClick = this.viewerController.mapComponent.createTool({
             type: viewer.viewercontroller.controller.Tool.MAP_CLICK,
             id: this.name + "toolMapClick",

--- a/viewer/src/main/webapp/viewer-html/components/Cyclorama.js
+++ b/viewer/src/main/webapp/viewer-html/components/Cyclorama.js
@@ -60,6 +60,9 @@ Ext.define ("viewer.components.Cyclorama",{
         if(!this.config.layers) {
             return;
         }
+        if(this.toolMapClick !== null) {
+            return;
+        }
         this.toolMapClick =  this.viewerController.mapComponent.createTool({
             type: viewer.viewercontroller.controller.Tool.MAP_CLICK,
             id: this.name + "toolMapClick",

--- a/viewer/src/main/webapp/viewer-html/components/Legend.js
+++ b/viewer/src/main/webapp/viewer-html/components/Legend.js
@@ -174,6 +174,7 @@ Ext.define("viewer.components.Legend", {
     },
     
     onLayersInitialized: function() {
+        this.resetLegend();
         this.initLegend();
     },
     


### PR DESCRIPTION
When loading a bookmark the event ON_LAYERS_INITIALIZED gets fired twice. The legend should be reset before re-creating to prevent duplicate legends.

Also changed this in 2 other components where duplication could also occur