### PR TITLE
Make attribute printing more robust

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -185,8 +185,9 @@ public class PrintActionBean implements ActionBean {
             if(!jRequest.has("extra")){
                 jRequest.put("extra", new JSONArray());
             }
-
-            processAttributes(jRequest, em, jRequest, app, context.getRequest());
+            if (jRequest.has("attributesObject")) {
+                processAttributes(jRequest, em, jRequest, app, context.getRequest());
+            }
         }
         if (jRequest.has("angle")){
             int angle = jRequest.getInt("angle");

--- a/viewer/src/main/webapp/viewer-html/components/Print.js
+++ b/viewer/src/main/webapp/viewer-html/components/Print.js
@@ -212,6 +212,13 @@ Ext.define ("viewer.components.Print",{
             this.createLegendSelector();
             Ext.ComponentQuery.query('#scale')[0].setValue(this.config.viewerController.mapComponent.getMap().getActualScale());
         }
+        // enable attributes checkbox if attr list is available
+        var attributeLists = this.viewerController.getComponentsByClassName("viewer.components.AttributeList");
+        if (attributeLists && attributeLists.length > 0) {
+            Ext.ComponentQuery.query('#includeAttributes')[0].setDisabled(false);
+        } else {
+            Ext.ComponentQuery.query('#includeAttributes')[0].setDisabled(true);
+        }
     },
     /**
      * Create the print form.
@@ -432,10 +439,12 @@ Ext.define ("viewer.components.Print",{
                             },{
                                 xtype: 'checkbox',
                                 name: 'includeAttributes',
+                                itemId: 'includeAttributes',
                                 inputValue: true,
-                                checked:false,
+                                checked: false,
+                                disabled: true,
                                 boxLabel: 'Attributen toevoegen'
-                            },{
+                            }, {
                                 name: 'scale',
                                 itemId: 'scale',
                                 fieldLabel: 'Schaal',
@@ -1103,4 +1112,3 @@ Ext.define ("viewer.components.Print",{
         return [ (this.panel !== null) ? this.panel.getId() : '' ];
     }
 });
-


### PR DESCRIPTION
- disable the "Attributen toevoegen" checkbox by default and enable it only when an Attributelist component is configured
- check in the backed if ther actually is an "attributesObject" in the printrequest json before trying to parse that

see also [mantis 11531](http://mantis.b3p.nl/view.php?id=11531) and #1171 