### PR TITLE
Improvements for Edit/ExtendedEdit/ExtendedFeatureInfo

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Edit-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit-config.js
@@ -30,6 +30,16 @@ Ext.define("viewer.components.CustomConfiguration", {
 
         this.form.add([
             {
+                xtype: 'numberfield',
+                fieldLabel: 'Klik nauwkeurigheid',
+                name: 'clickRadius',
+                value: this.configObject.clickRadius !== undefined ? this.configObject.clickRadius : 4,
+                labelWidth: this.labelWidth,
+                style: {
+                    marginRight: "70px"
+                }
+            },
+            {
                 xtype: 'checkbox',
                 fieldLabel: 'Bewerken toestaan',
                 name: 'allowEdit',

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -49,6 +49,7 @@ Ext.define("viewer.components.Edit", {
         tooltip: "",
         layers: null,
         label: "",
+        clickRadius: 4,
         allowDelete: false,
         allowCopy: false,
         allowNew: true,
@@ -756,7 +757,7 @@ Ext.define("viewer.components.Edit", {
             viewerController: this.config.viewerController
         });
         var me = this;
-        featureInfo.editFeatureInfo(coords.x, coords.y, this.config.viewerController.mapComponent.getMap().getResolution() * 4, layer, function (features) {
+        featureInfo.editFeatureInfo(coords.x, coords.y, this.config.viewerController.mapComponent.getMap().getResolution() * (this.config.clickRadius || 4), layer, function (features) {
             me.featuresReceived(features);
         }, function (msg) {
             me.failed(msg);

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -1157,13 +1157,10 @@ Ext.define("viewer.components.Edit", {
         }
     },
     resetForm: function () {
-        this.setButtonDisabled("editButton", true);
-        this.setButtonDisabled("newButton", true);
         this.savebutton.setText("Opslaan");
         this.mode = null;
-        this.layerSelector.clearSelection();
         this.geomlabel.setHtml("");
-        this.inputContainer.removeAll();
+        this.setFormVisible(false);
         this.config.viewerController.mapComponent.getMap().removeMarker("edit");
         if (this.vectorLayer) {
             // vector layer may be null when cancel() is called

--- a/viewer/src/main/webapp/viewer-html/components/ExtendedEdit.js
+++ b/viewer/src/main/webapp/viewer-html/components/ExtendedEdit.js
@@ -150,7 +150,7 @@ Ext.define ("viewer.components.ExtendedEdit",{
         });
         var me = this;
         this.currentCoords = options.coord;
-        featureInfo.editFeatureInfo(options.coord.x, options.coord.y, this.config.viewerController.mapComponent.getMap().getResolution() * 4, layer, function (features) {
+        featureInfo.editFeatureInfo(options.coord.x, options.coord.y, this.config.viewerController.mapComponent.getMap().getResolution() * (this.config.clickRadius || 4), layer, function (features) {
             me.featuresReceived(features);
         }, function (msg) {
             // me.failed(msg);

--- a/viewer/src/main/webapp/viewer-html/components/ExtendedEdit.js
+++ b/viewer/src/main/webapp/viewer-html/components/ExtendedEdit.js
@@ -112,7 +112,9 @@ Ext.define ("viewer.components.ExtendedEdit",{
         this.callParent(arguments);
         if(!this.initialLoad) {
             this.initialLoad = true;
-            this.edit();
+            if(this.config.allowEdit) {
+                this.edit();
+            }
         }
     },
     selectedLayerChanged: function(layer) {
@@ -134,6 +136,9 @@ Ext.define ("viewer.components.ExtendedEdit",{
      * When a feature info starts.
      */
     startEdit: function(map, options) {
+        if(!this.config.allowEdit) {
+            return;
+        }
         this.totalPages = 0;
         this.feature_data = [];
         var layer = this.layerSelector.getValue();
@@ -281,6 +286,8 @@ Ext.define ("viewer.components.ExtendedEdit",{
         this.savebutton.setText("Opslaan");
         this.config.viewerController.mapComponent.getMap().removeMarker("edit");
         this.vectorLayer.removeAllFeatures();
-        this.edit();
+        if(this.config.allowEdit) {
+            this.edit();
+        }
     }
 });

--- a/viewer/src/main/webapp/viewer-html/components/ExtendedFeatureInfo.js
+++ b/viewer/src/main/webapp/viewer-html/components/ExtendedFeatureInfo.js
@@ -56,7 +56,8 @@ Ext.define ("viewer.components.ExtendedFeatureInfo",{
         this.panel = Ext.create('Ext.panel.Panel', {
             title: title,
             items: [],
-            autoScroll: true,
+            scrollable: true,
+            layout: 'fit',
             dockedItems: [this.buttons],
             listeners: {
                 render: function(panel) {
@@ -143,7 +144,7 @@ Ext.define ("viewer.components.ExtendedFeatureInfo",{
     },
     setRefreshing: function(isRefreshing) {
         if(isRefreshing) {
-            var pages = this.panel.query('container');
+            var pages = this.panel.query('[cls=feature-info-page]');
             this.currentFeatureId = pages[this.currentIndex] ? pages[this.currentIndex].config.featureId : null;
             this.panel.removeAll(true);
             this.totalPages = 0;
@@ -171,6 +172,7 @@ Ext.define ("viewer.components.ExtendedFeatureInfo",{
         }
         var container = Ext.create('Ext.container.Container', {
             contentEl: contentEl,
+            cls: 'feature-info-page',
             hidden: false,
             featureId: featureId,
             listeners: {
@@ -184,7 +186,7 @@ Ext.define ("viewer.components.ExtendedFeatureInfo",{
         this.panel.add(container);
     },
     showPage: function(index, currentFeatureId){
-        var pages = this.panel.query('container');
+        var pages = this.panel.query('[cls=feature-info-page]');
         if(currentFeatureId) {
             for(var j = 0; j < pages.length; j++) {
                 if(pages[j].config.featureId === currentFeatureId) {


### PR DESCRIPTION
- Allow click radius to be configured for Edit and ExtendedEdit
- Fixes an issue where the title would disappear on next/previous in ExtendedFeatureInfo
- Apply 'Allow edit' configuration in ExtendedEdit component
- Improved Edit component, after editing, keep selection of Layer
