### PR TITLE
fix 'Application null not found' error using IE opening index.jsp

### DIFF
--- a/viewer/src/main/webapp/index.jsp
+++ b/viewer/src/main/webapp/index.jsp
@@ -23,10 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <stripes:url var="url" beanclass="nl.b3p.viewer.stripes.ApplicationActionBean">
-            <stripes:param name="unknown" value="true"/>
-        </stripes:url>
-        <meta http-equiv="Refresh" content="0;url=${url}">
+        <meta http-equiv="Refresh" content="0;url=${contextPath}/app?unknown=true">
         <title>Geo viewer</title>
     </head>
     <body>


### PR DESCRIPTION
When opening index.jsp without a session, the Refresh header has a ;jsessionid=... appended and Internet Explorer drops this after the timeout and semicolon; this means that the unknown=true parameter is also dropped leading to this error.

Instead of URL encoding the Refresh header or changing ApplicationActionBean this just uses a hardcoded URL to the ApplicationActionBean, it's not going to change anyway.