### PR TITLE
update maven plugins to current release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,15 +66,12 @@ after_success:
 jdk:
   - oraclejdk8
   - openjdk8
-  - oraclejdk9
 
 os:
   - linux
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - jdk: oraclejdk9
 
 cache:
   directories:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ timestamps {
             }
 
             stage('OWASP Dependency Check') {
-                sh "mvn org.owasp:dependency-check-maven:aggregate -Dformat=XML -DsuppressionFile=./.mvn/owasp-suppression.xml"
+                sh "mvn org.owasp:dependency-check-maven:aggregate -DskipSystemScope=true -DnodeAuditAnalyzerEnabled=false -DnodeAnalyzerEnabled=false -Dformat=XML -DsuppressionFile=./.mvn/owasp-suppression.xml"
 
                 dependencyCheckPublisher canComputeNew: false, defaultEncoding: '', healthy: '85', pattern: '**/dependency-check-report.xml', shouldDetectModules: true, unHealthy: ''
             }

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,6 @@
     <packaging>pom</packaging>
     <name>flamingo-mc</name>
     <url>http://github.com/flamingo-mc</url>
-    <prerequisites>
-        <maven>3.2.5</maven>
-    </prerequisites>
     <scm>
         <connection>scm:git:git@github.com:flamingo-mc/flamingo.git</connection>
         <developerConnection>scm:git:git@github.com:flamingo-mc/flamingo.git</developerConnection>
@@ -20,12 +17,12 @@
         <repository>
             <id>repo.b3p.nl</id>
             <name>B3Partners releases repository</name>
-            <url>http://repo.b3p.nl/nexus/content/repositories/releases/</url>
+            <url>https://repo.b3p.nl/nexus/repository/releases/</url>
         </repository>
         <snapshotRepository>
             <id>repo.b3p.nl</id>
             <name>B3Partners snapshots repository</name>
-            <url>http://repo.b3p.nl/nexus/content/repositories/snapshots/</url>
+            <url>https://repo.b3p.nl/nexus/repository/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
     <licenses>
@@ -495,7 +492,7 @@
         <repository>
             <id>B3Partners</id>
             <name>Releases hosted by B3Partners</name>
-            <url>http://repo.b3p.nl/nexus/content/groups/public/</url>
+            <url>https://repo.b3p.nl/nexus/repository/public/</url>
         </repository>
     </repositories>
     <build>
@@ -805,25 +802,25 @@
             <name>Matthijs Laan</name>
             <email>matthijslaan@b3partners.nl</email>
             <organization>B3Partners B.V.</organization>
-            <organizationUrl>http://www.b3partners.nl</organizationUrl>
+            <organizationUrl>https://www.b3partners.nl</organizationUrl>
         </developer>
         <developer>
             <name>Meine Toonen</name>
             <email>meinetoonen@b3partners.nl</email>
             <organization>B3Partners B.V.</organization>
-            <organizationUrl>http://www.b3partners.nl</organizationUrl>
+            <organizationUrl>https://www.b3partners.nl</organizationUrl>
         </developer>
         <developer>
             <name>Roy Braam</name>
             <email>roybraam@b3partners.nl</email>
             <organization>B3Partners B.V.</organization>
-            <organizationUrl>http://www.b3partners.nl</organizationUrl>
+            <organizationUrl>https://www.b3partners.nl</organizationUrl>
         </developer>
         <developer>
             <name>Mark Prins</name>
             <email>markprins@b3partners.nl</email>
             <organization>B3Partners B.V.</organization>
-            <organizationUrl>http://www.b3partners.nl</organizationUrl>
+            <organizationUrl>https://www.b3partners.nl</organizationUrl>
         </developer>
     </developers>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,18 +45,18 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <geotools.version>19.2</geotools.version>
+        <geotools.version>19.3</geotools.version>
         <powermock.version>1.7.4</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.2.4</postgresql.version>
+        <postgresql.version>42.2.5</postgresql.version>
         <apache.poi.version>3.17</apache.poi.version>
         <apache.httpcomponents.version>4.5.6</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
-        <tomcat.version>7.0.88</tomcat.version>
+        <tomcat.version>7.0.91</tomcat.version>
     </properties>
     <dependencyManagement>
         <!--
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
-                <version>20180130</version>
+                <version>20180813</version>
             </dependency>
             <!-- Stripes -->
             <dependency>
@@ -239,7 +239,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.20.1</version>
+                <version>2.23.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -420,7 +420,7 @@
             <dependency>
                 <groupId>javax.mail</groupId>
                 <artifactId>javax.mail-api</artifactId>
-                <version>1.6.1</version>
+                <version>1.6.2</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
-        <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <tomcat.version>7.0.88</tomcat.version>
     </properties>
     <dependencyManagement>
         <!--
             To check for dependency updates use the following command:
-            mvn -U org.codehaus.mojo:versions-maven-plugin:2.5:display-dependency-updates > dependency-updates.log
+            mvn -U org.codehaus.mojo:versions-maven-plugin:2.7:display-dependency-updates > dependency-updates.log
             and check the output for any available updates.
             
             To check for vulnarabilities in dependencies use the following command:
@@ -503,7 +503,7 @@
             <plugins>
                 <!--
                     To check for plugin updates use the following command:
-                    mvn -U org.codehaus.mojo:versions-maven-plugin:2.5:display-plugin-updates -T1 > plugin-updates.log
+                    mvn -U org.codehaus.mojo:versions-maven-plugin:2.7:display-plugin-updates -T1 > plugin-updates.log
                     and check the output for any available updates
                 -->
                 <plugin>
@@ -569,7 +569,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>2.2.4</version>
+                    <version>2.2.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -584,12 +584,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
@@ -598,7 +598,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.tomcat.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <!--
+            when upgrading geotools also check b3p-commons-csw which has some
+            geotools transitive dependencies
+        -->
         <geotools.version>19.3</geotools.version>
         <powermock.version>1.7.4</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
@@ -86,6 +90,7 @@
                 <artifactId>gt-render</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.json</groupId>
                 <artifactId>json</artifactId>
@@ -150,7 +155,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>5.0.5</version>
+                <version>5.0.6</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.persistence</groupId>
@@ -595,7 +600,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.tomcat.maven</groupId>


### PR DESCRIPTION
- [x] update maven plugins to current versions
- [x] update dependencies to current patch levels
  Update to current patch release:
  - tomcat libs 7.0.88 -> 7.0.91
  - geotools 19.2 -> 19.3
  - json 20180130 -> 20180813
  - postgres driver 42.2.4 -> 42.2.5
  - mockito-core  2.20.1 -> 2.23.0
  - javax.mail-api 1.6.1 -> 1.6.2
- [x] upgrade b3p-commons-csw to match geotools 19.3