### PR TITLE
various bugfixes in FeatureStyle

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
@@ -29,7 +29,7 @@ public class FeatureStyle {
     private String labelOutlineColor = null;
     private String labelOutlineWidth = null;
     private String labelAlign = null;
-    private int fontSize = 0;
+    private float fontSize = 0;
     private String fontColor = null;
     private Double rotation = 0.0;
     private Double labelXOffset = 0.0;
@@ -39,7 +39,7 @@ public class FeatureStyle {
     private String strokeColor = null;
     private Double strokeOpacity = 0.0;
     private Double strokeWidth = 0.0;
-    private String strokeDashstyle = null;
+    private String strokeDashstyle = "solid";
     private String graphicName = null;
     private Double pointRadius = 0.0;
 
@@ -57,7 +57,7 @@ public class FeatureStyle {
         labelOutlineColor = sanitizeColorString(style.optString("labelOutlineColor"));
         labelOutlineWidth = style.optString("labelOutlineWidth");
         labelAlign = style.optString("labelAlign");
-        fontSize = style.optInt("fontSize", 12);
+        fontSize = style.optFloat("fontSize", 12);
         fontColor = sanitizeColorString(style.optString("fontColor"));
         rotation = style.optDouble("rotation", 0.0);
         labelXOffset = style.optDouble("labelXOffset", 0.0);
@@ -108,11 +108,12 @@ public class FeatureStyle {
         this.labelAlign = labelAlign;
     }
 
-    public int getFontSize() {
+    // return a float because https://docs.oracle.com/javase/8/docs/api/java/awt/Font.html#deriveFont-float-
+    public float getFontSize() {
         return fontSize;
     }
 
-    public void setFontSize(int fontSize) {
+    public void setFontSize(float fontSize) {
         this.fontSize = fontSize;
     }
 

--- a/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
@@ -26,11 +26,11 @@ import org.json.JSONObject;
 public class FeatureStyle {
 
     private String label = "";
-    private String labelOutlineColor = null;
-    private String labelOutlineWidth = null;
+    private String labelOutlineColor = "FFFFFF";
+    private Integer labelOutlineWidth = 1;
     private String labelAlign = null;
-    private float fontSize = 0;
-    private String fontColor = null;
+    private Float fontSize = 12f;
+    private String fontColor = "000000";
     private Double rotation = 0.0;
     private Double labelXOffset = 0.0;
     private Double labelYOffset = 0.0;
@@ -43,6 +43,12 @@ public class FeatureStyle {
     private String graphicName = null;
     private Double pointRadius = 0.0;
 
+    /**
+     *
+     * @deprecated use {@link FeatureStyle(JSONObject)} instead, as this sets up
+     * the style with aberrant properties.
+     */
+    @Deprecated
     public FeatureStyle(){
         fillColor = "ff0000";
         fillOpacity = 0.3;
@@ -54,11 +60,11 @@ public class FeatureStyle {
     
     public FeatureStyle(JSONObject style) {
         label = style.optString("label");
-        labelOutlineColor = sanitizeColorString(style.optString("labelOutlineColor"));
-        labelOutlineWidth = style.optString("labelOutlineWidth");
+        labelOutlineColor = sanitizeColorString(style.optString("labelOutlineColor", "#FFFFFF"));
+        labelOutlineWidth = style.optInt("labelOutlineWidth", 1);
         labelAlign = style.optString("labelAlign");
-        fontSize = style.optFloat("fontSize", 12);
-        fontColor = sanitizeColorString(style.optString("fontColor"));
+        fontSize = style.optFloat("fontSize", 12f);
+        fontColor = sanitizeColorString(style.optString("fontColor", "#000000"));
         rotation = style.optDouble("rotation", 0.0);
         labelXOffset = style.optDouble("labelXOffset", 0.0);
         labelYOffset = style.optDouble("labelYOffset", 0.0);
@@ -70,7 +76,7 @@ public class FeatureStyle {
         fillOpacity = transparentFillColor ? 0.0 : style.optDouble("fillOpacity", 0.0);
         strokeColor = sanitizeColorString(style.optString("strokeColor"));
         strokeOpacity = style.optDouble("strokeOpacity", 0.0);
-        strokeDashstyle = style.optString("strokeDashstyle");
+        strokeDashstyle = style.optString("strokeDashstyle", "solid");
         strokeWidth = style.optDouble("strokeWidth", 3.0);
         graphicName = style.optString("graphicName");
         pointRadius = style.optDouble("pointRadius", 0.0);
@@ -92,11 +98,11 @@ public class FeatureStyle {
         this.labelOutlineColor = labelOutlineColor;
     }
 
-    public String getLabelOutlineWidth() {
+    public Integer getLabelOutlineWidth() {
         return labelOutlineWidth;
     }
 
-    public void setLabelOutlineWidth(String labelOutlineWidth) {
+    public void setLabelOutlineWidth(Integer labelOutlineWidth) {
         this.labelOutlineWidth = labelOutlineWidth;
     }
 
@@ -109,11 +115,11 @@ public class FeatureStyle {
     }
 
     // return a float because https://docs.oracle.com/javase/8/docs/api/java/awt/Font.html#deriveFont-float-
-    public float getFontSize() {
+    public Float getFontSize() {
         return fontSize;
     }
 
-    public void setFontSize(float fontSize) {
+    public void setFontSize(Float fontSize) {
         this.fontSize = fontSize;
     }
 
@@ -223,6 +229,11 @@ public class FeatureStyle {
             color = color.substring(index+1);
         }
         return color;
-        
     }
+
+    @Override
+    public String toString() {
+        return "FeatureStyle{" + "label=" + label + ", labelOutlineColor=" + labelOutlineColor + ", labelOutlineWidth=" + labelOutlineWidth + ", labelAlign=" + labelAlign + ", fontSize=" + fontSize + ", fontColor=" + fontColor + ", rotation=" + rotation + ", labelXOffset=" + labelXOffset + ", labelYOffset=" + labelYOffset + ", fillColor=" + fillColor + ", fillOpacity=" + fillOpacity + ", strokeColor=" + strokeColor + ", strokeOpacity=" + strokeOpacity + ", strokeWidth=" + strokeWidth + ", strokeDashstyle=" + strokeDashstyle + ", graphicName=" + graphicName + ", pointRadius=" + pointRadius + '}';
+    }
+
 }

--- a/viewer/src/main/java/nl/b3p/viewer/image/ImageTool.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/ImageTool.java
@@ -34,7 +34,6 @@ import java.awt.AlphaComposite;
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -50,7 +49,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -233,7 +231,9 @@ public class ImageTool {
             gbi.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.5f));
             CombineImageWkt ciw = (CombineImageWkt) wktGeoms.get(i);
             FeatureStyle fs = ciw.getStyle();
+            log.debug("draw geomentry: " + ciw + " using style: " + fs);
             font = font.deriveFont(fs.getFontSize());
+            gbi.setFont(font);
             float strokeWidth = fs.getStrokeWidth().floatValue();
             double pointRadius = fs.getPointRadius();
             gbi.setStroke(new BasicStroke(strokeWidth));
@@ -294,7 +294,6 @@ public class ImageTool {
                 gbi.setStroke(stroke);
                 gbi.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, fs.getStrokeOpacity().floatValue()));
                 gbi.draw(shape);
-                
             }
             if (ciw.getLabel() != null && !ciw.getLabel().isEmpty()) {
                 gbi.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1.0f));
@@ -312,7 +311,7 @@ public class ImageTool {
                 centerPoint.translate(xoffset+(int)labelXOffset, yoffset-(int)labelYOffset);
 
                 gbi.setColor(fs.getFontColor());
-                BufferedImage b = createStringImage(gbi, ciw.getLabel());
+                BufferedImage b = createStringImage(gbi, ciw.getLabel(), fs);
                 rot.translate(centerPoint.getX(), centerPoint.getY());
                 gbi.drawImage(b, rot, null);
                 gbi.setTransform(t);
@@ -322,24 +321,24 @@ public class ImageTool {
         return newBufIm;
     }
 
-    private static BufferedImage createStringImage(Graphics g, String s) {
+    private static BufferedImage createStringImage(Graphics2D g, String s, FeatureStyle fs) {
         int w = g.getFontMetrics().stringWidth(s) + 8;
         int h = g.getFontMetrics().getHeight();
 
         BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
         Graphics2D gbi = image.createGraphics();
-       
-        gbi.setFont(gbi.getFont());
-        gbi.setColor(Color.WHITE);
-        
-        int halosize= 1;
-        
-        gbi.drawString(s, 0, h - g.getFontMetrics().getDescent()-halosize);
-        gbi.drawString(s, 0, h - g.getFontMetrics().getDescent()+halosize);
+
+        gbi.setFont(g.getFont().deriveFont(fs.getFontSize()));
+        gbi.setColor(fs.getLabelOutlineColor());
+
+        int halosize = fs.getLabelOutlineWidth();
+
+        gbi.drawString(s, 0, h - g.getFontMetrics().getDescent() - halosize);
+        gbi.drawString(s, 0, h - g.getFontMetrics().getDescent() + halosize);
         gbi.drawString(s, -halosize, h - g.getFontMetrics().getDescent());
         gbi.drawString(s, halosize, h - g.getFontMetrics().getDescent());
-        
-        gbi.setColor(Color.BLACK);
+
+        gbi.setColor(fs.getFontColor());
         gbi.drawString(s, 0, h - g.getFontMetrics().getDescent());
         gbi.dispose();
 


### PR DESCRIPTION
This ports changes from #1295 forward to the master branch

- Prevent a possible NPE in ImageTool when a stroke style has not been set by supplying a default value for strokeDashstyle
- Font size should be a float because that is what the awt takes (not an int because int's are for font style)
- pass FeatureStyle to `createStringImage(...)` so that it picks up the label colours

see #1295 
close #1294 
close #1296 