### PR TITLE
CombineImageWkt refactoring

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineImageWkt.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineImageWkt.java
@@ -104,7 +104,7 @@ public class CombineImageWkt {
     }
 
     /**
-     * @param color the color to set
+     * @param color the color to set eg {@code 00ffff}
      * @deprecated set color on the {@link #getStyle() featurestyle} instead
      */
     @Deprecated

--- a/viewer/src/main/java/nl/b3p/viewer/image/CombineImageWkt.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/CombineImageWkt.java
@@ -2,7 +2,6 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-
 package nl.b3p.viewer.image;
 
 import java.awt.Color;
@@ -10,43 +9,76 @@ import java.awt.Color;
 /**
  *
  * @author Roy
+ * @author mprins
  */
 public class CombineImageWkt {
-    private String wktGeom="";
-    private Color color = null;
-    private String label=null;
-    private Float strokeWidth = null;
+    private String wktGeom = "";
     private FeatureStyle style = new FeatureStyle();
-    
-    public CombineImageWkt(String wktGeomString){
-        int colorIndex=wktGeomString.indexOf("#");
-        int labelIndex=wktGeomString.indexOf("|");
-        int wktEnd= wktGeomString.length();
-        if (colorIndex > 0)
-            wktEnd=colorIndex;
-        if (labelIndex > 0 && labelIndex < wktEnd){
-            wktEnd=labelIndex;
-        }
-        this.setWktGeom(wktGeomString.substring(0,wktEnd));
-        if (colorIndex>0){
-            int colorEnd= labelIndex!=-1&& labelIndex>colorIndex?labelIndex:wktGeomString.length();            
-            this.setColor(wktGeomString.substring(colorIndex+1,colorEnd));
-        }
-        if (labelIndex>0){
-            int labelEnd= colorIndex!=-1&& colorIndex>labelIndex?colorIndex:wktGeomString.length();
-            this.setLabel(wktGeomString.substring(labelIndex+1,labelEnd));
-        }
-    }
-    public CombineImageWkt(String wktGeomString, String color){
-        setWktGeom(wktGeomString);        
-        setColor(color);
+
+    public CombineImageWkt(String wktGeom, FeatureStyle style) {
+        this.style = style;
+        this.wktGeom = wktGeom;
     }
 
-    public CombineImageWkt(String wktGeomString, String color, Float strokeWidth) {
-        setWktGeom(wktGeomString);
-        setColor(color);
-        setStrokeWidth(strokeWidth);
+    /**
+     *
+     * @param wktGeomString the geometry (with optional color and label)
+     * @deprecated use
+     * {@link CombineImageWkt#CombineImageWkt(java.lang.String, nl.b3p.viewer.image.FeatureStyle)}
+     * if you also want to convey styling information or a label
+     */
+    @Deprecated
+    public CombineImageWkt(String wktGeomString) {
+        int colorIndex = wktGeomString.indexOf("#");
+        int labelIndex = wktGeomString.indexOf("|");
+        int wktEnd = wktGeomString.length();
+        if (colorIndex > 0) {
+            wktEnd = colorIndex;
+        }
+        if (labelIndex > 0 && labelIndex < wktEnd) {
+            wktEnd = labelIndex;
+        }
+        this.setWktGeom(wktGeomString.substring(0, wktEnd));
+        if (colorIndex > 0) {
+            int colorEnd = labelIndex != -1 && labelIndex > colorIndex ? labelIndex : wktGeomString.length();
+            this.setColor(wktGeomString.substring(colorIndex + 1, colorEnd));
+        }
+        if (labelIndex > 0) {
+            int labelEnd = colorIndex != -1 && colorIndex > labelIndex ? colorIndex : wktGeomString.length();
+            this.setLabel(wktGeomString.substring(labelIndex + 1, labelEnd));
+        }
     }
+
+    /**
+     *
+     * @param wktGeomString the geometry
+     * @param color stroke and fill colour
+     * @deprecated using
+     * {@link CombineImageWkt#CombineImageWkt(java.lang.String, nl.b3p.viewer.image.FeatureStyle)}
+     * is preferred
+     */
+    @Deprecated
+    public CombineImageWkt(String wktGeomString, String color) {
+        this.setWktGeom(wktGeomString);
+        this.setColor(color);
+    }
+
+    /**
+     *
+     * @param wktGeomString the geometry
+     * @param color stroke and fill colour
+     * @param strokeWidth stroke width
+     * @deprecated using
+     * {@link CombineImageWkt#CombineImageWkt(java.lang.String, nl.b3p.viewer.image.FeatureStyle)}
+     * is preferred
+     */
+    @Deprecated
+    public CombineImageWkt(String wktGeomString, String color, Float strokeWidth) {
+        this.setWktGeom(wktGeomString);
+        this.setColor(color);
+        this.setStrokeWidth(strokeWidth);
+    }
+
     /**
      * @return the wktGeom
      */
@@ -62,46 +94,76 @@ public class CombineImageWkt {
     }
 
     /**
+     *
      * @return the color
+     * @deprecated get the color from the {@link #getStyle() featurestyle}
+     * instead
      */
     public Color getColor() {
-        return color;
+        return this.style.getFillColor();
     }
 
     /**
      * @param color the color to set
+     * @deprecated set color on the {@link #getStyle() featurestyle} instead
      */
+    @Deprecated
     public void setColor(Color color) {
-        this.color = color;
+        this.style.setFillColor(String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue()));
+        this.style.setFillOpacity((double) (color.getAlpha() & 0xff));
     }
+
+    /**
+     * @deprecated set color on the {@link #getStyle() featurestyle} instead
+     */
+    @Deprecated
     public void setColor(String hexrgb) {
-        if (hexrgb==null || hexrgb.equals("transparent")){
+        if (hexrgb == null || hexrgb.equals("transparent")) {
             return;
         }
-        if (hexrgb.length()>0)
-            this.color = new Color( Integer.parseInt(( hexrgb ), 16) );
+        if (hexrgb.length() > 0) {
+            this.style.setFillColor(hexrgb);
+        }
     }
 
     /**
      * @return the label
+     * @deprecated get the label from the {@link #getStyle() featurestyle}
+     * instead
      */
     public String getLabel() {
-        return label;
+        return this.style.getLabel();
     }
 
     /**
      * @param label the label to set
+     * @deprecated set the label on the {@link #getStyle() featurestyle} instead
      */
+    @Deprecated
     public void setLabel(String label) {
-        this.label = label;
+        this.style.setLabel(label);
     }
 
+    /**
+     *
+     * @return stroke width
+     * @deprecated use the value from the {@link #getStyle() featurestyle}
+     * instead
+     */
+    @Deprecated
     public Float getStrokeWidth() {
-        return strokeWidth;
+        return this.style.getStrokeWidth().floatValue();
     }
 
+    /**
+     *
+     * @param strokeWidth stroke width
+     * @deprecated set the value on the the {@link #getStyle() featurestyle}
+     * instead
+     */
+    @Deprecated
     public void setStrokeWidth(Float strokeWidth) {
-        this.strokeWidth = strokeWidth;
+        this.style.setStrokeWidth(strokeWidth.doubleValue());
     }
 
     public FeatureStyle getStyle() {
@@ -111,5 +173,5 @@ public class CombineImageWkt {
     public void setStyle(FeatureStyle style) {
         this.style = style;
     }
-    
+
 }

--- a/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
+++ b/viewer/src/main/java/nl/b3p/viewer/image/FeatureStyle.java
@@ -95,7 +95,7 @@ public class FeatureStyle {
     }
 
     public void setLabelOutlineColor(String labelOutlineColor) {
-        this.labelOutlineColor = labelOutlineColor;
+        this.labelOutlineColor = this.sanitizeColorString(labelOutlineColor);
     }
 
     public Integer getLabelOutlineWidth() {
@@ -128,7 +128,7 @@ public class FeatureStyle {
     }
 
     public void setFontColor(String fontColor) {
-        this.fontColor = fontColor;
+        this.fontColor = this.sanitizeColorString(fontColor);
     }
 
     public Double getRotation() {
@@ -160,7 +160,7 @@ public class FeatureStyle {
     }
 
     public void setFillColor(String fillColor) {
-        this.fillColor = fillColor;
+        this.fillColor = this.sanitizeColorString(fillColor);
     }
 
     public Double getFillOpacity() {
@@ -176,7 +176,7 @@ public class FeatureStyle {
     }
 
     public void setStrokeColor(String strokeColor) {
-        this.strokeColor = strokeColor;
+        this.strokeColor = this.sanitizeColorString(strokeColor);
     }
 
     public Double getStrokeOpacity() {

--- a/viewer/src/test/java/nl/b3p/viewer/image/CombineImageWktTest.java
+++ b/viewer/src/test/java/nl/b3p/viewer/image/CombineImageWktTest.java
@@ -1,0 +1,97 @@
+package nl.b3p.viewer.image;
+
+import java.awt.Color;
+import org.json.JSONObject;
+import org.junit.After;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author mprins
+ */
+public class CombineImageWktTest {
+
+    private CombineImageWkt c = null;
+    private final String WKT = "POINT(167465.36 464237.2)";
+    private final String LABEL = "my label";
+    // cyan
+    private final String COLORSTRING = "00FFFF";
+    private final Color COLOR = Color.CYAN;
+    private final Float STROKEWIDTH = 1.1f;
+
+    @After
+    public void tearDown() {
+        c = null;
+    }
+
+    @Test
+    public void testCombineImageWktString() {
+        c = new CombineImageWkt(WKT);
+        assertEquals("wkt is niet gelijk", WKT, c.getWktGeom());
+    }
+
+    @Test
+    public void testCombineImageWktString2() {
+        c = new CombineImageWkt(WKT + "#" + COLORSTRING);
+        assertEquals(WKT, c.getWktGeom());
+        assertEquals(COLOR, c.getColor());
+    }
+
+    @Test
+    public void testCombineImageWktString3() {
+        c = new CombineImageWkt(WKT + "#" + COLORSTRING + "|" + LABEL);
+        assertEquals(WKT, c.getWktGeom());
+        assertEquals(COLOR, c.getColor());
+        assertEquals(LABEL, c.getLabel());
+    }
+
+    @Test
+    public void testCombineImageWktStringString() {
+        c = new CombineImageWkt(WKT, COLORSTRING);
+        assertEquals(WKT, c.getWktGeom());
+        assertEquals(COLOR, c.getColor());
+    }
+
+    @Test
+    public void testCombineImageWktStringStringFloat() {
+        c = new CombineImageWkt(WKT, COLORSTRING, STROKEWIDTH);
+        assertEquals(WKT, c.getWktGeom());
+        assertEquals(COLOR, c.getColor());
+        assertTrue(Math.abs(STROKEWIDTH - c.getStrokeWidth()) < .01);
+    }
+
+    @Test
+    public void testCombineImageWktStringFeatureStyle() {
+        c = new CombineImageWkt(WKT);
+
+        // issue #1297: the label is not set from the style
+        c.setLabel(LABEL);
+        assertEquals(LABEL, c.getLabel());
+
+        FeatureStyle style = new FeatureStyle(
+                new JSONObject("{label: '" + COLORSTRING + LABEL // to illustrate bug #1297
+                        + "',labelOutlineColor: '#FFFFFF', strokeColor: '" + COLORSTRING
+                        + "', strokeOpacity: 1, strokeDashstyle: 'solid', strokeWidth: 2, pointRadius: 2, transparent: true, fontSize: 32}")
+        );
+        c.setStyle(style);
+        assertEquals(COLORSTRING + LABEL, c.getLabel());
+    }
+
+    @Test
+    public void testSetters() {
+        c = new CombineImageWkt(WKT);
+
+        c.setWktGeom(WKT);
+        c.setColor(COLORSTRING);
+        c.setLabel(LABEL);
+        c.setStrokeWidth(STROKEWIDTH);
+
+        assertEquals(WKT, c.getWktGeom());
+        assertEquals(LABEL, c.getLabel());
+        assertEquals(COLOR, c.getColor());
+        assertTrue(Math.abs(STROKEWIDTH - c.getStrokeWidth()) < .01);
+    }
+
+}

--- a/viewer/src/test/java/nl/b3p/viewer/image/CombineImageWktTest.java
+++ b/viewer/src/test/java/nl/b3p/viewer/image/CombineImageWktTest.java
@@ -92,6 +92,9 @@ public class CombineImageWktTest {
         assertEquals(LABEL, c.getLabel());
         assertEquals(COLOR, c.getColor());
         assertTrue(Math.abs(STROKEWIDTH - c.getStrokeWidth()) < .01);
+
+        c.setColor(COLOR);
+        assertEquals(COLOR, c.getColor());
     }
 
 }


### PR DESCRIPTION
This refactors CombineImageWkt to use the internal FeatureStyle object for storing all styling attributes as well as the label. 
It resolves not being able to read the label from the CombineImageWkt when set using a style.

Any constructor not using the FeatureStyle is marked deprecated

check:

- [x] printing of a drawing [Kaart_17-12-2018 (11).pdf](https://github.com/flamingo-geocms/flamingo/files/2686909/Kaart_17-12-2018.11.pdf)
- [x] buffer tool [Kaart_17-12-2018 (12).pdf](https://github.com/flamingo-geocms/flamingo/files/2686926/Kaart_17-12-2018.12.pdf)

close #1297 