### PR TITLE
Bump GeoTools 19.3 to 19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
             when upgrading geotools also check b3p-commons-csw which has some
             geotools transitive dependencies
         -->
-        <geotools.version>19.3</geotools.version>
+        <geotools.version>19.4</geotools.version>
         <powermock.version>1.7.4</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
contains a possibly important fix for Oracle databases: https://osgeo-org.atlassian.net/browse/GEOT-6174