### PR TITLE
Check if the docs array is not empty

### DIFF
--- a/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
+++ b/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrUpdateJob.java
@@ -250,9 +250,11 @@ public class SolrUpdateJob implements Job {
             } finally {
                 iterator.close();
             }
-
-            solrServer.add(docs);
-            solrServer.commit();
+            
+            if(!docs.isEmpty()){
+                solrServer.add(docs);
+                solrServer.commit();
+            }
         }   catch (SolrServerException ex) {
             log.error("Cannot add configuration to index", ex);
         } catch (IOException ex) {


### PR DESCRIPTION
It can happen that 1 or more of the requiredfields is empty.
If this is the case for the whole collection(batch), the docs array will be empty.
