### PR TITLE
check if createDefaultCheckboxes is true

### DIFF
--- a/viewer-admin/src/main/webapp/resources/js/ux/b3p/FilterableCheckboxes.js
+++ b/viewer-admin/src/main/webapp/resources/js/ux/b3p/FilterableCheckboxes.js
@@ -225,10 +225,12 @@ Ext.define('Ext.ux.b3p.FilterableCheckboxes', {
             } else {
                 document.getElementById('checkbox-' + item.htmlId).checked = false;
             }
-            if(Ext.Array.contains(me.checkedDefaultOn, item[me.valueField])) {
-                document.getElementById('checkbox-' + item.htmlDefaultId).checked = true;
-            } else {
-                document.getElementById('checkbox-' + item.htmlDefaultId).checked = false;
+            if(me.createDefaultCheckboxes){
+                if(Ext.Array.contains(me.checkedDefaultOn, item[me.valueField])) {
+                    document.getElementById('checkbox-' + item.htmlDefaultId).checked = true;
+                } else {
+                    document.getElementById('checkbox-' + item.htmlDefaultId).checked = false;
+                }
             }
         });
     },


### PR DESCRIPTION
if checkedDefaultOn is undefined the loop will only run once.
`Ext.Array.contains(me.checkedDefaultOn, item[me.valueField]) ` generates an error when checkedDefault is undefined. The loop will stop then.