### PR TITLE
Bump GeoTools from 20.1 to 20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in trabnsitive dependency hell -->
-        <geotools.version>20.1</geotools.version>
+        <geotools.version>20.2</geotools.version>
         <powermock.version>2.0.0</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>5.1.1</version>
+                <version>5.1.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.persistence</groupId>


### PR DESCRIPTION
Release notes - GeoTools - Version 20.2

### Bug
- [GEOT-6025] - Shapefile data store tries to validate HTTP URL but fails with a NULL pointer exception
- [GEOT-6141] - Faulty reprojection mercator -> other crs for small areas
- [GEOT-6175] - CSVDataStore doesn't clean up temp file when writing out
- [GEOT-6183] - GeoTIFF reader attaches nodata to the coverage, but not to the underlying image
- [GEOT-6184] - MongoDB complex store iterator enters in an infinite loop if no ID is defined
- [GEOT-6185] - ClassBreaksOpImage causes NPE when missing property is requested in getProperty
- [GEOT-6199] - ImageMosaic harvesting does not scale up
- [GEOT-6200] - Reproject fitler tries to reproject non geometry properties
- [GEOT-6201] - BBox function crashes when passed GML
- [GEOT-6206] - GeoPackage reader fails to report the number of overviews available
- [GEOT-6207] - ImageUtilities image disposal methods may not access inner fields of (Writable)RenderedImageAdapter.
- [GEOT-6212] - Complex MongoDB generated properties are not correctly handlded in SLDs

### Improvement
- [GEOT-6182] - Add the possibility to specify the target CRS for the ReprojectingFilterVisitor
- [GEOT-6189] - Allow FilterDOMParser to handle filters with expression in the "value" element
- [GEOT-6198] - Do not set ROIs in image mosaic when not strictly necessary

see: https://geotoolsnews.blogspot.com/2019/01/geotools-202-released.html

Also update b3p-commons-csw 5.1.1 -> 5.1.2, to match the GeoTools version, see: https://github.com/B3Partners/b3p-commons-csw/releases/tag/b3p-commons-csw-5.1.2

