### PR TITLE
Adjusted the arbitrary values for the scaleCorrection

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1342,10 +1342,10 @@ Ext.define("viewer.viewercontroller.ViewerController", {
             //scale * (dpi / ratio dpi to dpm)
             return 96/0.0254;
         }
-        //Chose arbitrary values 750 minscale and 5000 maxscale
+        //Chose arbitrary values 50 minscale and 5000 maxscale
         //return correction for scaledenominator
-        else if (minScale > 750 ||
-                ((minScale === undefined || minScale ===0 )&& maxScale > 5000)){
+        else if (minScale >= 50 ||
+                ((minScale === undefined || minScale ===0 )&& maxScale >= 5000)){
             scaleCorrection = 1 / 0.00028;
         }
         // magic multiply


### PR DESCRIPTION
The following service: 
"https://geodata.nationaalgeoregister.nl/kadastralekaartv3/wms?SERVICE=WMS&request=getcapabilities"

Uses scaleDenominators between 50 and 5000.