### PR TITLE
load pki-overheid G2/G3 certificates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,11 @@ before_install:
   - ls -la ~
 
 install:
+  # load pki-overheid G2/G3 certificates
+  - wget http://cert.pkioverheid.nl/RootCA-G3.cer
+  - sudo keytool -importcert -file ./RootCA-G3.cer -alias G3 -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass 'changeit' -v -noprompt -trustcacerts
+  - wget http://cert.pkioverheid.nl/RootCA-G2.cer
+  - sudo keytool -importcert -file ./RootCA-G2.cer -alias G2 -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass 'changeit' -v -noprompt -trustcacerts
   # install without testing
   - travis_wait 40 mvn --settings .travis/settings.xml -Ptravis-ci-prebuild install -U -DskipTests -Dtest.skip.integrationtests=true -B -V -fae
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,11 @@ install:
   - cmd: echo %PATH%
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-http-proxy.ps1'))
   - ps: .\.appveyor\set-maven-proxy.ps1
+  # load pki-overheid G2/G3 certificates
+  - ps: Invoke-WebRequest http://cert.pkioverheid.nl/RootCA-G2.cer -OutFile .\RootCA-G2.cer
+  - cmd: keytool -importcert -file .\RootCA-G2.cer -alias G2 -keystore "%JAVA_HOME%\jre\lib\security\cacerts" -storepass changeit -v -noprompt -trustcacerts
+  - ps: Invoke-WebRequest http://cert.pkioverheid.nl/RootCA-G3.cer -OutFile .\RootCA-G3.cer
+  - cmd: keytool -importcert -file .\RootCA-G3.cer -alias G3 -keystore "%JAVA_HOME%\jre\lib\security\cacerts" -storepass changeit -v -noprompt -trustcacerts
   - mvn install -U -DskipTests -pl "web-commons,viewer-commons,viewer-config-persistence" -B -V -fae -q
   
 cache:


### PR DESCRIPTION
which we need to communicate with some servers used in the integration tests while running on AppVeyor and Travis-CI