### PR TITLE
Add MS SQL Server 2017 as an attribute source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,11 @@
                 <artifactId>gt-jdbc-postgis</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.geotools.jdbc</groupId>
+                <artifactId>gt-jdbc-sqlserver</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
 
             <!-- web-commons -->
             <dependency>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/editattributesource.jsp
@@ -125,14 +125,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     var dbType = Ext.query("select[name='dbtype']")[0].value;
                                     var port = Ext.query("input[name='port']")[0];
                                     if(dbType == "oracle") {
-                                        if(port.value == "" || port.value == "5432") {
+                                        if(port.value == "" || port.value == "5432" || port.value == "1433") {
                                             port.value = "1521";
                                         }
                                     } else if(dbType == "postgis") {
-                                        if(port.value == "" || port.value == "1521") {
+                                        if(port.value == "" || port.value == "1521" || port.value == "1433") {
                                             port.value = "5432";
                                         }
+                                    } else if(dbType == "sqlserver") {
+                                        if(port.value == "" || port.value == "1521" || port.value == "5432") {
+                                            port.value = "1433";
+                                        }
                                     }
+
                                 }
                                 Ext.onReady(checkProtocol);
                             </script>
@@ -160,6 +165,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         <stripes:select name="dbtype" onchange="checkDefaults()" onkeyup="checkDefaults()">
                                             <stripes:option value="oracle">Oracle</stripes:option>
                                             <stripes:option value="postgis">PostGIS</stripes:option>
+                                            <stripes:option value="sqlserver">SQL Server</stripes:option>
                                         </stripes:select>
                                     </td>
                                 </tr>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -218,6 +218,16 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-sqlserver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.sourceforge.jtds</groupId>
+                    <artifactId>jtds</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>


### PR DESCRIPTION
### ToDo
- [x] Add gt-jdbc-sqlserver, make it possible to enter a sql server url as an attribute source

### Done
I've successfully made an application using a SQL server 2017 database with some BGT data and featureinfo and editing geometry works.




close #1337 