### PR TITLE
WIP Split LineString bugs

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
@@ -362,7 +362,7 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
         for (int i = 0; i < lines.getNumGeometries(); i++) {
             LineString l = (LineString) lines.getGeometryN(i);
             // TODO to be tested
-            if (toSplit.contains(l.getInteriorPoint())) {
+            if (toSplit.intersects(l.getInteriorPoint())) {
                 output.add(l);
             }
         }


### PR DESCRIPTION
- [x] linestring.contains(other) doesn't make sense for LineStrings
- [ ] Both splitstrategies don't create two features. Any ideas?

I think splitting lines have never worked. Possibly implement it based on: https://github.com/omar711/JUMP-Mapping-Platform/blob/master/src/main/java/com/vividsolutions/jump/workbench/ui/cursortool/SplitLineStringsOp.java