### PR TITLE
Resolve usage of `sun.security.rsa.RSAPrivateCrtKeyImpl`

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/CycloramaConfigurationActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/CycloramaConfigurationActionBean.java
@@ -27,14 +27,13 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import javax.annotation.security.RolesAllowed;
 import javax.persistence.EntityManager;
-import net.sourceforge.stripes.action.ActionBean;
 import net.sourceforge.stripes.action.ActionBeanContext;
-import net.sourceforge.stripes.action.Before;
 import net.sourceforge.stripes.action.DefaultHandler;
 import net.sourceforge.stripes.action.FileBean;
 import net.sourceforge.stripes.action.ForwardResolution;
@@ -56,7 +55,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.stripesstuff.stripersist.Stripersist;
-import sun.security.rsa.RSAPrivateCrtKeyImpl;
 
 /**
  *
@@ -189,7 +187,7 @@ public class CycloramaConfigurationActionBean extends LocalizableActionBean {
             Key ksKey = ks.getKey(alias, password.toCharArray());
             String keyFormat = ksKey.getFormat();
 
-            if ((ksKey instanceof RSAPrivateCrtKeyImpl) && keyFormat.equals(KEY_FORMAT)) {
+            if ((ksKey instanceof RSAPrivateCrtKey) && keyFormat.equals(KEY_FORMAT)) {
                 privateKey = (PrivateKey) ksKey;
             }
         }


### PR DESCRIPTION
Resolve the usage of `sun.security.rsa.RSAPrivateCrtKeyImpl` by using the direct interface that it implements (`java.security.interfaces.RSAPrivateCrtKey`) instead.

This resolves java11 compiler issues with proprietary `com.sun` packages asl listed in #1367 

**note** java 11 build of this PR are expected to fail on `nl.b3p.viewer.image.ImageTool` because that uses the proprietary `com.sun.imageio.plugins.png` package