### PR TITLE
[5.4.x] Bump GeoTools 20.2 -> 20.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in trabnsitive dependency hell -->
-        <geotools.version>20.2</geotools.version>
+        <geotools.version>20.3</geotools.version>
         <powermock.version>2.0.0</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBeanTest.java
+++ b/viewer-admin/src/test/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBeanTest.java
@@ -38,7 +38,7 @@ public class GeoServiceActionBeanTest extends TestUtil{
     public GeoServiceActionBeanTest() {
     }
 
-    @Test
+    //@Test
     public void addWMSService(){
         try {
             String url = "http://geodata.nationaalgeoregister.nl/rwsgeluidskaarten/wms?SERVICE=WMS&";


### PR DESCRIPTION
backport of #1389 

I've also cherry-picked b7a9e7e0a863e89ec5fae573482c352a0c2fb2a6 which reduces test coverage