### PR TITLE
Prevent solr server init when no url configured

### DIFF
--- a/solr-commons/pom.xml
+++ b/solr-commons/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
@@ -40,10 +41,6 @@
         <dependency>
             <groupId>org.flamingo-mc</groupId>
             <artifactId>viewer-config-persistence</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrInitializer.java
+++ b/solr-commons/src/main/java/nl/b3p/viewer/solr/SolrInitializer.java
@@ -85,6 +85,10 @@ public class SolrInitializer implements ServletContextListener {
 
     private void inializeSolr(File solrDir) {
         log.debug("Initialize the Solr Server instance");
+        if (solrUrl != null && solrUrl.length() < 1) {
+            log.info("Skip initializing Solr Server instance, no url");
+            return;
+        }
         if(solrUrl.charAt(solrUrl.length() -1 ) != '/'){
             solrUrl += "/";
         }


### PR DESCRIPTION
prevent a NPE when flamingo.solr.url is set to an empty value and skip initializing the HttpSolrServer in that case as well.