### PR TITLE
Audit framework for actionbeans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vuln-check.log
 /viewer/nbproject/
 /.idea/
 *.iml
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,11 @@
                 <artifactId>stripersist</artifactId>
                 <version>1.0.3</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.flamingo-mc</groupId>
+                <artifactId>viewer-audit</artifactId>
+                <version>${flamingo.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.flamingo-mc</groupId>
                 <artifactId>viewer-config-persistence</artifactId>
@@ -900,6 +904,7 @@
         <module>tomcat-lib</module>
         <module>web-commons</module>
         <module>viewer-audit</module>
+        <module>viewer-audit-noplogger</module>
         <module>viewer-commons</module>
         <module>viewer-config-persistence</module>
         <module>solr-commons</module>

--- a/pom.xml
+++ b/pom.xml
@@ -899,6 +899,7 @@
     <modules>
         <module>tomcat-lib</module>
         <module>web-commons</module>
+        <module>viewer-audit</module>
         <module>viewer-commons</module>
         <module>viewer-config-persistence</module>
         <module>solr-commons</module>

--- a/viewer-audit-noplogger/pom.xml
+++ b/viewer-audit-noplogger/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.flamingo-mc</groupId>
+    <artifactId>viewer-audit-noplogger</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.flamingo-mc</groupId>
+        <artifactId>flamingo-mc</artifactId>
+        <version>5.5.1-SNAPSHOT</version>
+    </parent>
+    <name>viewer auditing NOP logger module</name>
+    <description>This module primarily serves the testcase of having multiple
+        LoggingService proviers on the classpath
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.flamingo-mc</groupId>
+            <artifactId>viewer-audit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/viewer-audit-noplogger/src/main/java/nl/b3p/viewer/audit/impl/NOPLoggingService.java
+++ b/viewer-audit-noplogger/src/main/java/nl/b3p/viewer/audit/impl/NOPLoggingService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.impl;
+
+import nl.b3p.viewer.audit.LoggingService;
+
+/**
+ * No-Op audit log provider.
+ *
+ * @author mprins
+ * @see LoggingService
+ */
+public final class NOPLoggingService implements LoggingService {
+    /**
+     * Logs nothing.
+     *
+     * @param user    username, ignored
+     * @param message message, ignored
+     */
+    @Override
+    public void logMessage(String user, String message) {
+        // do nothing
+    }
+}

--- a/viewer-audit-noplogger/src/main/resources/META-INF/services/nl.b3p.viewer.audit.LoggingService
+++ b/viewer-audit-noplogger/src/main/resources/META-INF/services/nl.b3p.viewer.audit.LoggingService
@@ -1,0 +1,1 @@
+nl.b3p.viewer.audit.impl.NOPLoggingService

--- a/viewer-audit-noplogger/src/test/java/nl/b3p/viewer/audit/impl/NOPLoggingServiceTest.java
+++ b/viewer-audit-noplogger/src/test/java/nl/b3p/viewer/audit/impl/NOPLoggingServiceTest.java
@@ -1,0 +1,13 @@
+package nl.b3p.viewer.audit.impl;
+
+import nl.b3p.viewer.audit.LoggingServiceFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class NOPLoggingServiceTest {
+    @Test
+    public void testInstance() {
+        assertEquals("We should have gotten the NOP logging implementation", NOPLoggingService.class, LoggingServiceFactory.getInstance().getClass());
+    }
+}

--- a/viewer-audit-noplogger/src/test/resources/log4j.xml
+++ b/viewer-audit-noplogger/src/test/resources/log4j.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <!-- this is the audit log-->
+    <appender name="auditlog" class="org.apache.log4j.RollingFileAppender">
+        <param name="Threshold" value="info"/>
+        <param name="file" value="target/test-classes/audit.log"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss} - %m%n"/>
+        </layout>
+    </appender>
+    <!-- default log, receiving other logging which goes to the console in this case -->
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="debug"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{HH:mm:ss} viewer-audit-test: %5p (%C#%M:%L) - %m%n"/>
+        </layout>
+    </appender>
+    <logger name="nl.b3p.viewer.audit.impl.DefaultLoggingService" additivity="false">
+        <level value="info"/>
+        <appender-ref ref="auditlog"/>
+    </logger>
+    <root>
+        <level value="debug"/>
+        <appender-ref ref="consoleAppender"/>
+    </root>
+</log4j:configuration>

--- a/viewer-audit/pom.xml
+++ b/viewer-audit/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.flamingo-mc</groupId>
+            <artifactId>viewer-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/viewer-audit/pom.xml
+++ b/viewer-audit/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.flamingo-mc</groupId>
+    <artifactId>viewer-audit</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>org.flamingo-mc</groupId>
+        <artifactId>flamingo-mc</artifactId>
+        <version>5.5.1-SNAPSHOT</version>
+    </parent>
+    <name>viewer auditing module</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/LoggingService.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/LoggingService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit;
+
+/**
+ * SPI voor {@link LoggingService}.
+ *
+ * @author mprins
+ */
+public interface LoggingService {
+
+    /**
+     * Logs the given message and username.
+     *
+     * @param user    username to log
+     * @param message message to log
+     */
+    void logMessage(String user, String message);
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/LoggingServiceFactory.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/LoggingServiceFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Factory interface for {@link LoggingService} instances.
+ *
+ * @author mprins
+ */
+public interface LoggingServiceFactory {
+    Log LOG = LogFactory.getLog(LoggingServiceFactory.class);
+
+    /**
+     * returns a list of known implementations of {@link LoggingService}.
+     *
+     * @return List of available logging service providers.
+     */
+    static List<LoggingService> getInstances() {
+        ServiceLoader<LoggingService> services = ServiceLoader.load(LoggingService.class);
+        List<LoggingService> loggingServices = new ArrayList<>();
+        services.iterator().forEachRemaining(loggingServices::add);
+        return loggingServices;
+    }
+
+    /**
+     * Get the current {@link LoggingService}.
+     *
+     * @return current logging service provider
+     */
+    static LoggingService getInstance() {
+        List<LoggingService> loggingServices = LoggingServiceFactory.getInstances();
+        LoggingService service = null;
+        if (loggingServices.size() == 1) {
+            service = loggingServices.get(0);
+        } else {
+            while (loggingServices.iterator().hasNext()) {
+                service = loggingServices.iterator().next();
+                LOG.debug("found audit log provider: " + service);
+                if (service instanceof nl.b3p.viewer.audit.impl.DefaultLoggingService) {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+        LOG.debug("using audit log provider: " + service);
+        return service;
+    }
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/impl/DefaultLoggingService.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/impl/DefaultLoggingService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.impl;
+
+import nl.b3p.viewer.audit.LoggingService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Default implementation of {@link LoggingService}.
+ * Uses the configured logging framework to write audit logging.
+ * eg. for log4j:
+ * <pre>
+ *     <appender name="auditlog" class="org.apache.log4j.RollingFileAppender">
+ *         <param name="Threshold" value="info"/>
+ *         <param name="file" value="target/auditlog.log"/>
+ *         <param name="MaxFileSize" value="10MB"/>
+ *         <param name="MaxBackupIndex" value="10"/>
+ *         <layout class="org.apache.log4j.PatternLayout">
+ *             <param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss} - %m%n"/>
+ *         </layout>
+ *     </appender>
+ *
+ *     <logger name="nl.b3p.viewer.audit.impl.DefaultLoggingService" additivity="false">
+ *         <level value="info"/>
+ *         <appender-ref ref="auditlog"/>
+ *     </logger>
+ * </pre>
+ * 
+ * @author mprins
+ * @see LoggingService
+ */
+public final class DefaultLoggingService implements LoggingService {
+
+    private static final Log LOG = LogFactory.getLog(DefaultLoggingService.class);
+
+    /**
+     * Log the given message and username.
+     *
+     * @param user    username to log
+     * @param message message to log
+     */
+    @Override
+    public void logMessage(String user, String message) {
+        LOG.info(user + " - " + message);
+    }
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/impl/DefaultLoggingService.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/impl/DefaultLoggingService.java
@@ -23,8 +23,9 @@ import org.apache.commons.logging.LogFactory;
 /**
  * Default implementation of {@link LoggingService}.
  * Uses the configured logging framework to write audit logging.
- * eg. for log4j:
+ * eg. for log4j something like below:
  * <pre>
+ * {@code
  *     <appender name="auditlog" class="org.apache.log4j.RollingFileAppender">
  *         <param name="Threshold" value="info"/>
  *         <param name="file" value="target/auditlog.log"/>
@@ -39,6 +40,7 @@ import org.apache.commons.logging.LogFactory;
  *         <level value="info"/>
  *         <appender-ref ref="auditlog"/>
  *     </logger>
+ * }
  * </pre>
  * 
  * @author mprins

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/DefaultLogging.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/DefaultLogging.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.strategy;
+
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
+import nl.b3p.viewer.audit.LoggingServiceFactory;
+
+/**
+ *
+ * @author Meine Toonen
+ */
+public class DefaultLogging implements LoggingStrategy{
+
+    @Override
+    public void log(Auditable ab, AuditMessageObject amo) {
+        LoggingServiceFactory.getInstance().logMessage(amo.getUsername(), amo.getMessagesAsString());
+    }
+    
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/EditLogging.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/EditLogging.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.strategy;
+
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
+
+/**
+ *
+ * @author Meine Toonen
+ */
+public class EditLogging implements LoggingStrategy{
+
+    @Override
+    public void log(Auditable ab, AuditMessageObject amo) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/LoggingStrategy.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/LoggingStrategy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.strategy;
+
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
+/**
+ *
+ * @author Meine Toonen
+ */
+public interface LoggingStrategy {
+    
+    public void log(Auditable ab, AuditMessageObject amo);
+    
+}

--- a/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/LoggingStrategyFactory.java
+++ b/viewer-audit/src/main/java/nl/b3p/viewer/audit/strategy/LoggingStrategyFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit.strategy;
+
+import net.sourceforge.stripes.action.ActionBean;
+import nl.b3p.viewer.audit.Auditable;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ *
+ * @author Meine Toonen
+ */
+public class LoggingStrategyFactory {
+
+    private static final Log LOG = LogFactory.getLog(LoggingStrategyFactory.class);
+
+    public static LoggingStrategy getStrategy(ActionBean ab) {
+        if (ab == null) {
+            LOG.debug("Auditing with null actionbean not possible");
+            return null;
+        }
+        if (ab instanceof Auditable) {
+            if (ab.getClass().getSimpleName().equals("EditFeatureActionBean")) {
+                return new EditLogging();
+            } else {
+                return new DefaultLogging();
+            }
+        } else {
+            LOG.debug("No strategy for class found: " + ab.getClass().getCanonicalName());
+            return null;
+        }
+    }
+}

--- a/viewer-audit/src/main/resources/META-INF/services/nl.b3p.viewer.audit.LoggingService
+++ b/viewer-audit/src/main/resources/META-INF/services/nl.b3p.viewer.audit.LoggingService
@@ -1,0 +1,1 @@
+nl.b3p.viewer.audit.impl.DefaultLoggingService

--- a/viewer-audit/src/test/java/nl/b3p/viewer/audit/impl/DefaultLoggingServiceTest.java
+++ b/viewer-audit/src/test/java/nl/b3p/viewer/audit/impl/DefaultLoggingServiceTest.java
@@ -1,0 +1,56 @@
+package nl.b3p.viewer.audit.impl;
+
+import nl.b3p.viewer.audit.LoggingServiceFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.RandomAccessFile;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.*;
+
+
+public class DefaultLoggingServiceTest {
+
+    @Test
+    public void testDefaultInstance() {
+        assertEquals("We should have gotten the default logging implementation", DefaultLoggingService.class, LoggingServiceFactory.getInstance().getClass());
+    }
+
+    @Test
+    public void testLogMessage() throws Exception {
+        LoggingServiceFactory.getInstance().logMessage("some user", "Something we want in the audit trail");
+
+        File auditLog = Paths.get(getClass().getClassLoader().getResource("audit.log").toURI()).toFile();
+        assertNotNull("The logfile must exist", auditLog);
+        assertTrue("Audit rule not as expected.", tail(auditLog).endsWith("some user - Something we want in the audit trail"));
+    }
+
+    private String tail(File file) {
+        try (RandomAccessFile fileHandler = new RandomAccessFile(file, "r")) {
+            long fileLength = fileHandler.length() - 1;
+            StringBuilder sb = new StringBuilder();
+            for (long filePointer = fileLength; filePointer != -1; filePointer--) {
+                fileHandler.seek(filePointer);
+                int readByte = fileHandler.readByte();
+                if (readByte == 0xA) {
+                    if (filePointer == fileLength) {
+                        continue;
+                    }
+                    break;
+                } else if (readByte == 0xD) {
+                    if (filePointer == fileLength - 1) {
+                        continue;
+                    }
+                    break;
+                }
+                sb.append((char) readByte);
+            }
+
+            return sb.reverse().toString();
+        } catch (java.io.IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/viewer-audit/src/test/resources/log4j.xml
+++ b/viewer-audit/src/test/resources/log4j.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <!-- this is the audit log-->
+    <appender name="auditlog" class="org.apache.log4j.RollingFileAppender">
+        <param name="Threshold" value="info"/>
+        <param name="file" value="target/test-classes/audit.log"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{dd MMM yyyy HH:mm:ss} - %m%n"/>
+        </layout>
+    </appender>
+    <!-- default log, receiving other logging which goes to the console in this case -->
+    <appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+        <param name="Threshold" value="debug"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%d{HH:mm:ss} viewer-audit-test: %5p (%C#%M:%L) - %m%n"/>
+        </layout>
+    </appender>
+    <logger name="nl.b3p.viewer.audit.impl.DefaultLoggingService" additivity="false">
+        <level value="info"/>
+        <appender-ref ref="auditlog"/>
+    </logger>
+    <root>
+        <level value="debug"/>
+        <appender-ref ref="consoleAppender"/>
+    </root>
+</log4j:configuration>

--- a/viewer-commons/src/main/java/nl/b3p/viewer/audit/AuditMessageObject.java
+++ b/viewer-commons/src/main/java/nl/b3p/viewer/audit/AuditMessageObject.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An object to hold audit information.
+ *
+ * @author Mark Prins
+ */
+public class AuditMessageObject {
+
+    private String username;
+    private String event;
+    private final List<Object> messages = Stream.of(new Object[]{}).collect(Collectors.toList());
+
+    public String getEvent() {
+        return event;
+    }
+
+    /**
+     * Set the event (class#method) for this AuditMessageObject.
+     *
+     * @param event describes event
+     */
+    public void setEvent(String event) {
+        this.event = event;
+    }
+
+    /**
+     * get the username for this audit trail.
+     *
+     * @return the username for this audit trail
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * Set the username for this audit trail.
+     *
+     * @param username the username for this audit trail
+     */
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    /**
+     * add autdit information to this object
+     *
+     * @param message audit information
+     */
+    public void addMessage(Object message) {
+        messages.add(message);
+    }
+
+    /**
+     * This will provide any objects holding audit information, the list cannot
+     * be modified.
+     *
+     * @return list of objects describing auditing information.
+     */
+    public List<Object> getMessages() {
+        return Collections.unmodifiableList(messages);
+    }
+
+    /**
+     * This will provide a string representation of the objects holding audit
+     * information, the list cannot be modified.
+     *
+     * @return the messages describing auditing information separated with a
+     * komma
+     */
+    public String getMessagesAsString() {
+        return messages.stream().map(Object::toString).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public String toString() {
+        return "AuditMessageObject{ event=" + event + ", user=" + username + ", messages=" + this.getMessagesAsString() + '}';
+    }
+}

--- a/viewer-commons/src/main/java/nl/b3p/viewer/audit/Auditable.java
+++ b/viewer-commons/src/main/java/nl/b3p/viewer/audit/Auditable.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.viewer.audit;
+
+/**
+ * Provides a machanism to obtain audit information from implementing classes.
+ *
+ * @author Mark Prins
+ */
+public interface Auditable {
+
+    /**
+     * Accessor to get the auditing information that has been provided by the
+     * implementeing class.
+     *
+     * @return the audit information
+     * @see AuditMessageObject
+     */
+    AuditMessageObject getAuditMessageObject();
+}

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/DownloadFeaturesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/DownloadFeaturesActionBean.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import javax.activation.MimetypesFileTypeMap;
 import javax.persistence.EntityManager;
 import javax.servlet.http.HttpServletResponse;
-import net.sourceforge.stripes.action.ActionBean;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import net.sourceforge.stripes.action.After;
 import net.sourceforge.stripes.action.Before;
@@ -41,6 +40,8 @@ import net.sourceforge.stripes.action.UrlBinding;
 import net.sourceforge.stripes.controller.LifecycleStage;
 import net.sourceforge.stripes.validation.Validate;
 import nl.b3p.geotools.filter.visitor.RemoveDistanceUnit;
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
 import nl.b3p.viewer.config.app.Application;
 import nl.b3p.viewer.config.app.ApplicationLayer;
 import nl.b3p.viewer.config.app.ConfiguredAttribute;
@@ -86,7 +87,7 @@ import org.stripesstuff.stripersist.Stripersist;
  */
 @UrlBinding("/action/downloadfeatures")
 @StrictBinding
-public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean implements ActionBean {
+public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean implements Auditable {
 
     private static final Log log = LogFactory.getLog(DownloadFeaturesActionBean.class);
 
@@ -115,6 +116,8 @@ public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean
 
     @Validate
     private String params;
+
+    private AuditMessageObject auditMessageObject;
 
     //<editor-fold defaultstate="collapsed" desc="getters and setters">
     @Override
@@ -198,6 +201,10 @@ public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean
     public void setParams(String params) {
         this.params = params;
     }
+
+    public AuditMessageObject getAuditMessageObject() {
+        return this.auditMessageObject;
+    }
     // </editor-fold>
 
     @After(stages=LifecycleStage.BindingAndValidation)
@@ -211,6 +218,7 @@ public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean
                 || !Authorizations.isAppLayerReadAuthorized(application, appLayer, context.getRequest(),Stripersist.getEntityManager())) {
             unauthorized = true;
         }
+        auditMessageObject = new AuditMessageObject();
     }
 
     public Resolution download() throws JSONException, FileNotFoundException {
@@ -253,6 +261,11 @@ public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean
                 output = convert(ft, fs, q, type, attributes,featureTypeAttributes);
 
                 json.put("success", true);
+
+                // TODO see what is useful
+                this.auditMessageObject.addMessage(ft);
+                this.auditMessageObject.addMessage(q);
+                this.auditMessageObject.addMessage(fs);
             }
         } catch (Exception e) {
             log.error("Error loading features", e);

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
@@ -16,6 +16,7 @@
  */
 package nl.b3p.viewer.stripes;
 
+import net.sourceforge.stripes.controller.LifecycleStage;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
@@ -29,6 +30,8 @@ import javax.persistence.EntityManager;
 import net.sourceforge.stripes.action.*;
 import net.sourceforge.stripes.validation.Validate;
 import nl.b3p.geotools.filter.visitor.RemoveDistanceUnit;
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
 import nl.b3p.viewer.config.ClobElement;
 import nl.b3p.viewer.config.app.Application;
 import nl.b3p.viewer.config.app.ApplicationLayer;
@@ -62,7 +65,7 @@ import org.stripesstuff.stripersist.Stripersist;
  */
 @UrlBinding("/action/featureinfo")
 @StrictBinding
-public class FeatureInfoActionBean extends LocalizableApplicationActionBean implements ActionBean {
+public class FeatureInfoActionBean extends LocalizableApplicationActionBean implements Auditable {
     private static final Log log = LogFactory.getLog(FeatureInfoActionBean.class);
 
     public static final String FID = "__fid";
@@ -108,6 +111,8 @@ public class FeatureInfoActionBean extends LocalizableApplicationActionBean impl
     private boolean ordered = false;
 
     private Layer layer;
+
+    private AuditMessageObject auditMessageObject;
 
     //<editor-fold defaultstate="collapsed" desc="getters and setters">
     public ActionBeanContext getContext() {
@@ -217,7 +222,16 @@ public class FeatureInfoActionBean extends LocalizableApplicationActionBean impl
     public Layer getLayer() {
         return this.layer;
     }
+
+    public AuditMessageObject getAuditMessageObject() {
+        return this.auditMessageObject;
+    }
     //</editor-fold>
+
+    @Before(stages = LifecycleStage.EventHandling)
+    public void initAudit(){
+        auditMessageObject = new AuditMessageObject();
+    }
 
     @DefaultHandler
     public Resolution info() throws JSONException {
@@ -356,7 +370,7 @@ public class FeatureInfoActionBean extends LocalizableApplicationActionBean impl
                 }
             }
         }
-
+        this.auditMessageObject.addMessage(responses);
         return new StreamingResolution("application/json", new StringReader(responses.toString(4)));
     }
     
@@ -532,6 +546,7 @@ public class FeatureInfoActionBean extends LocalizableApplicationActionBean impl
                 }
             }
         }
+        this.auditMessageObject.addMessage(responses);
         return new StreamingResolution("application/json", new StringReader(responses.toString(4)));
     }
     

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/SplitFeatureActionBean.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import net.sourceforge.stripes.action.ActionBean;
 import net.sourceforge.stripes.action.ActionBeanContext;
 import net.sourceforge.stripes.action.After;
 import net.sourceforge.stripes.action.Before;
@@ -40,6 +39,8 @@ import net.sourceforge.stripes.action.StrictBinding;
 import net.sourceforge.stripes.action.UrlBinding;
 import net.sourceforge.stripes.controller.LifecycleStage;
 import net.sourceforge.stripes.validation.Validate;
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
 import nl.b3p.viewer.config.app.Application;
 import nl.b3p.viewer.config.app.ApplicationLayer;
 import nl.b3p.viewer.config.security.Authorizations;
@@ -76,7 +77,7 @@ import org.stripesstuff.stripersist.Stripersist;
  */
 @UrlBinding("/action/feature/split")
 @StrictBinding
-public class SplitFeatureActionBean extends LocalizableApplicationActionBean implements ActionBean {
+public class SplitFeatureActionBean extends LocalizableApplicationActionBean implements Auditable {
 
     private static final Log log = LogFactory.getLog(SplitFeatureActionBean.class);
 
@@ -113,6 +114,8 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
 
     private boolean unauthorized;
 
+    private AuditMessageObject auditMessageObject;
+
     @After(stages = LifecycleStage.BindingAndValidation)
     public void loadLayer() {
         this.layer = appLayer.getService().getSingleLayer(appLayer.getLayerName(), Stripersist.getEntityManager());
@@ -124,6 +127,7 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
                 || !Authorizations.isLayerGeomWriteAuthorized(layer, context.getRequest(), Stripersist.getEntityManager())) {
             unauthorized = true;
         }
+        auditMessageObject = new AuditMessageObject();
     }
 
     public Resolution split() throws JSONException {
@@ -179,6 +183,7 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
         if (error != null) {
             json.put("error", error);
         }
+        this.auditMessageObject.addMessage(json);
         return new StreamingResolution("application/json", new StringReader(json.toString()));
     }
 
@@ -462,6 +467,10 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
 
     public Layer getLayer() {
         return this.layer;
+    }
+
+    public AuditMessageObject getAuditMessageObject() {
+        return this.auditMessageObject;
     }
     //</editor-fold>
 }

--- a/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
+++ b/viewer/src/main/webapp/WEB-INF/classes/log4j.properties
@@ -1,27 +1,28 @@
 logFilePath=${catalina.base}/logs
 logFile=geo-viewer.log
+auditFile=audit.log
 
 log4j.rootLogger=INFO,file
 
+# audit logging with default logging provider
+log4j.logger.nl.b3p.viewer.audit.impl.DefaultLoggingService=INFO,audit
+log4j.additivity.nl.b3p.viewer.audit.impl.DefaultLoggingService=false
+
+# default logging
 log4j.logger.nl.b3p=INFO
-
-log4j.logger.nl.b3p.viewer.util.databaseupdate=INFO
-
-log4j.logger.nl.b3p.web.filter.HeaderAuthenticationFilter=INFO
-
-# Set to INFO or DEBUG to view more information about loading components
-log4j.logger.nl.b3p.viewer.components=INFO
-
-log4j.logger.nl.b3p.csw.client.CswClient=INFO
-
-log4j.logger.nl.b3p.viewer.stripes.DataStoreSpinupActionBean=INFO
-
 # IP authentication filter
 log4j.logger.nl.b3p.viewer.util.IPAuthenticationFilter=ERROR
 log4j.logger.nl.b3p.viewer.print.PrintGenerator=DEBUG
+log4j.logger.nl.b3p.viewer.util.databaseupdate=INFO
+# Set to INFO or DEBUG to view more information about loading components
+log4j.logger.nl.b3p.viewer.components=INFO
+log4j.logger.nl.b3p.viewer.stripes.DataStoreSpinupActionBean=INFO
+log4j.logger.nl.b3p.web.filter.HeaderAuthenticationFilter=INFO
+log4j.logger.nl.b3p.csw.client.CswClient=INFO
 
 # Geotools log level
 log4j.logger.org.geotools=ERROR
+# http traffic
 log4j.logger.org.apache.commons.httpclient=INFO
 log4j.logger.org.apache.http=INFO
 log4j.logger.org.apache.http.wire=INFO
@@ -44,10 +45,20 @@ log4j.logger.org.hibernate=INFO
 # https://docs.microsoft.com/en-us/sql/connect/jdbc/tracing-driver-operation?view=sql-server-2017
 log4j.logger.com.microsoft.sqlserver.jdbc=INFO
 
+# normal log file
 log4j.appender.file=org.apache.log4j.RollingFileAppender
 log4j.appender.file.file=${logFilePath}/${logFile}
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %l - %m%n
 #log4j.appender.file.layout.conversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p (%C{1}#%M:%L) - %m%n
-log4j.appender.file.append = true
-log4j.appender.file.maxBackupIndex = 5
+log4j.appender.file.append=true
+log4j.appender.file.maxBackupIndex=5
+
+# audit log file
+log4j.appender.audit=org.apache.log4j.RollingFileAppender
+log4j.appender.audit.file=${logFilePath}/${auditFile}
+log4j.appender.audit.layout=org.apache.log4j.PatternLayout
+log4j.appender.audit.layout.conversionPattern=%d{dd MMM yyyy HH:mm:ss} - %m%n
+log4j.appender.audit.append=true
+log4j.appender.audit.maxBackupIndex=10
+log4j.appender.audit.MaxFileSize=10MB

--- a/viewer/src/main/webapp/WEB-INF/web.xml
+++ b/viewer/src/main/webapp/WEB-INF/web.xml
@@ -36,6 +36,10 @@
         <listener-class>nl.b3p.viewer.components.ComponentRegistryInitializer</listener-class>
     </listener>
     <listener>
+        <description>scan for audit logging providers</description>
+        <listener-class>nl.b3p.web.stripes.AuditLogginingInitializer</listener-class>
+    </listener>
+    <listener>
         <listener-class>nl.b3p.web.stripes.StripersistCleanupListener</listener-class>
     </listener>
     <listener>
@@ -102,7 +106,7 @@
         </init-param>
         <init-param>
             <param-name>Extension.Packages</param-name>
-            <param-value>org.stripesstuff.stripersist</param-value>
+            <param-value>org.stripesstuff.stripersist, nl.b3p.web.stripes</param-value>
         </init-param>
         <init-param>
             <param-name>MultipartWrapper.Class</param-name>

--- a/web-commons/pom.xml
+++ b/web-commons/pom.xml
@@ -15,6 +15,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.flamingo-mc</groupId>
+            <artifactId>viewer-audit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flamingo-mc</groupId>
+            <artifactId>viewer-commons</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/web-commons/src/main/java/nl/b3p/web/stripes/AuditLoggingInterceptor.java
+++ b/web-commons/src/main/java/nl/b3p/web/stripes/AuditLoggingInterceptor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.web.stripes;
+
+import net.sourceforge.stripes.action.ActionBean;
+import net.sourceforge.stripes.action.ActionBeanContext;
+import net.sourceforge.stripes.action.Resolution;
+import net.sourceforge.stripes.controller.ExecutionContext;
+import net.sourceforge.stripes.controller.Interceptor;
+import net.sourceforge.stripes.controller.Intercepts;
+import net.sourceforge.stripes.controller.LifecycleStage;
+import nl.b3p.viewer.audit.AuditMessageObject;
+import nl.b3p.viewer.audit.Auditable;
+import nl.b3p.viewer.audit.LoggingServiceFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ *
+ * @author Mark Prins
+ */
+@Intercepts(LifecycleStage.ResolutionExecution)
+public class AuditLoggingInterceptor implements Interceptor {
+
+    private static final Log LOG = LogFactory.getLog(AuditLoggingInterceptor.class);
+
+    @Override
+    public Resolution intercept(ExecutionContext context) throws Exception {
+        Resolution resolution = context.proceed();
+
+        ActionBean actionbean = context.getActionBean();
+        ActionBeanContext actionbeancontext = context.getActionBeanContext();
+        String event = actionbeancontext.getEventName();
+        String user = actionbeancontext.getRequest().getRemoteUser();
+
+        LOG.debug("actionbean: " + actionbean);
+        LOG.debug("actionbeancontext: " + actionbeancontext);
+        LOG.debug("event: " + event);
+        LOG.debug("user: " + user);
+
+        if (actionbean instanceof Auditable) {
+            LOG.debug("user: " + user + " hit: Auditable " + actionbean.getClass().getName() + "#" + event);
+
+            AuditMessageObject o = ((Auditable) actionbean).getAuditMessageObject();
+            o.setEvent(actionbean.getClass().getSimpleName() + "#" + event);
+            o.setUsername(user);
+
+            LOG.debug("audit msg obj: " + o);
+            LoggingServiceFactory.getInstance().logMessage(o.getUsername(), o.getMessagesAsString());
+        }
+
+        return resolution;
+    }
+
+}

--- a/web-commons/src/main/java/nl/b3p/web/stripes/AuditLogginingInitializer.java
+++ b/web-commons/src/main/java/nl/b3p/web/stripes/AuditLogginingInitializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 B3Partners B.V.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package nl.b3p.web.stripes;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import nl.b3p.viewer.audit.LoggingServiceFactory;
+
+/**
+ * Scan the classpath for audit logging providers on startup of the webapp.
+ *
+ * @author Mark Prins
+ */
+public class AuditLogginingInitializer implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        LoggingServiceFactory.getInstances();
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+    }
+}


### PR DESCRIPTION
With a default implementation using the configured logging framework (log4j) and a No-Op logging provider in a separate module.
Strategies can be added using the `Strategy` added in 41aceefbde731013f4c3d181a425da8d3a53f8d3

### todo
- [x] pluggable logging provider
- [x] stripes interceptor to get the auditing object from an actionbean
- [x] determine which data to add to the auditing object for each actionbean. We will need to tune this along the way. Currently the following actionbeans produce audit information, mostly by providing the json response:
  - DownloadFeaturesActionBean
  - EditFeatureActionBean
  - FeatureInfoActionBean
  - FileUploadActionBean
  - MergeFeaturesActionBean
  - SplitFeatureActionBean
- [x] document how to create a custom pluggable logging provider: https://github.com/flamingo-geocms/flamingo/wiki/Creating-a-pluggable-audit-logger
- [x] create pluggable strategies to handle specific data from specific beans (@mtoonen ?)


close #1342