### PR TITLE
don't set currentSearchID when there are more searchconfigs than 1

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Search.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search.js
@@ -805,7 +805,9 @@ Ext.define ("viewer.components.Search",{
             url: null,
             urlOnly: false
         });
-        this.currentSeachId = component.name;
+        if (this.searchconfigs.length === 1) {
+            this.currentSeachId = component.name;
+        }
         this.loadWindow();
     },
     /**


### PR DESCRIPTION
https://mantis.b3p.nl/view.php?id=13594#c30467

/cc @KJLammers We need to know which version this is supposed to go? (previous stable - 5.2.3 or current stable 5.4.2)