### PR TITLE
don't set currentSearchID when there are more searchconfigs than 1 [v5.2.x]

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Search.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search.js
@@ -783,7 +783,9 @@ Ext.define ("viewer.components.Search",{
             url: null,
             urlOnly: false
         });
-        this.currentSeachId = component.name;
+        if (this.searchconfigs.length === 1) {
+            this.currentSeachId = component.name;
+        }
         this.loadWindow();
     },
     /**


### PR DESCRIPTION
backports #1433 to v5.2.x