### PR TITLE
delete java 11 artifacts from local Jenkins repostory after testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,13 @@ timestamps {
                 } finally {
 
                 }
+
+                if (jdkTestName == 'OpenJDK11') {
+                    stage("cleanup Java 11 packages") {
+                        echo "Removing Java 11 built artifacts from local repository"
+                        sh "mvn build-helper:remove-project-artifact"
+                    }
+                }
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -555,6 +555,11 @@
                     <version>2.7</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>


### PR DESCRIPTION
so downstream projects don't get these by accident and run into java compatibility problems