### PR TITLE
Use correct cql parser

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/FeatureInfoActionBean.java
@@ -51,7 +51,6 @@ import org.apache.commons.logging.LogFactory;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
-import org.geotools.filter.text.cql2.CQL;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -327,7 +326,7 @@ public class FeatureInfoActionBean extends LocalizableApplicationActionBean impl
                         spatialFilter = ff.intersects(ff.property(geomAttribute), ff.literal(p));
                     }
 
-                    Filter currentFilter = filter != null && filter.trim().length() > 0 ? CQL.toFilter(filter) : null;
+                    Filter currentFilter = filter != null && filter.trim().length() > 0 ? FlamingoCQL.toFilter(filter,em) : null;
 
                     if (currentFilter!=null){
                         currentFilter = (Filter) currentFilter.accept(new ChangeMatchCase(false), null);


### PR DESCRIPTION
CQL.toFilter doesn't recognize ilike. 
ECQL does.

FlamingoCQL parses possible APPLAYER filters, and then delegates this to ECQL, so ilike will be supported.