### PR TITLE
Bump GeoTools 21.1 -> 21.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>21.1</geotools.version>
+        <geotools.version>21.2</geotools.version>
         <powermock.version>2.0.2</powermock.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>6.0.1</version>
+                <version>6.0.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.persistence</groupId>


### PR DESCRIPTION
Also needs upgrade of b3p-commons-csw to make sure transitive dependencies don't conflict

see: https://github.com/B3Partners/b3p-commons-csw/pull/21