### PR TITLE
Bump dependency-check-maven from 4.0.2 to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>4.0.2</version>
+                    <version>5.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.tomcat.maven</groupId>


### PR DESCRIPTION
backport of #1487