### PR TITLE
fix getLayerLegendInfo call in FeatureReport

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/FeatureReport.js
+++ b/viewer/src/main/webapp/viewer-html/components/FeatureReport.js
@@ -114,10 +114,10 @@ Ext.define("viewer.components.FeatureReport", {
                     me.legendLayerList[l],
                     function (a, b) {
                         legendsToPrint.push(b);
-                    }),
+                    },
                     function () {
                         Ext.MessageBox.alert(i18next.t('viewer_components_featurereport_5'), i18next.t('viewer_components_featurereport_6'));
-                    };
+                    });
         }
         return legendsToPrint;
     },


### PR DESCRIPTION
Should fix [mantis 13807](https://mantis.b3p.nl/view.php?id=13807)