### PR TITLE
Bump postgresql and sqlserver jdbc drivers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <powermock.version>2.0.0</powermock.version>
         <hsqldb.version>2.4.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.2.5</postgresql.version>
-        <mssql.version>7.2.1.jre8</mssql.version>
+        <postgresql.version>42.2.6</postgresql.version>
+        <mssql.version>7.2.2.jre8</mssql.version>
         <apache.poi.version>4.0.1</apache.poi.version>
         <javax.mail.version>1.6.2</javax.mail.version>
         <apache.httpcomponents.version>4.5.7</apache.httpcomponents.version>


### PR DESCRIPTION
backports #1481 

fixes a MITM attack vector in the PG driver, see [CVE-2018-10936](https://nvd.nist.gov/vuln/detail/CVE-2018-10936)