### PR TITLE
Method access changes in DownloadFeaturesActionBean and AttributesActionBean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
         <!--<jacoco.it.execution.data.file>${project.build.directory}/jacoco-it.exec</jacoco.it.execution.data.file>-->
         <!--<jacoco.ut.execution.data.file>${project.build.directory}/jacoco-ut.exec</jacoco.ut.execution.data.file>-->
+        <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
     <dependencyManagement>
         <!--

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/AttributesActionBean.java
@@ -421,7 +421,7 @@ public class AttributesActionBean extends LocalizableApplicationActionBean imple
         }
     }
 
-    private void setFilter(Query q,SimpleFeatureType ft, ApplicationLayer al, EntityManager em) throws Exception {
+    protected void setFilter(Query q, SimpleFeatureType ft, ApplicationLayer al, EntityManager em) throws Exception {
         if(filter != null && filter.trim().length() > 0) {
             Filter f = FlamingoCQL.toFilter(filter, em);
             f = (Filter)f.accept(new RemoveDistanceUnit(), null);
@@ -429,8 +429,6 @@ public class AttributesActionBean extends LocalizableApplicationActionBean imple
             f = FeatureToJson.reformatFilter(f, ft, includeRelations);
             q.setFilter(f);
         }
-
-        setAttributesNotNullFilters(q, al, ft, em);
     }
 
     private static final int MAX_CACHE_SIZE = 50;
@@ -512,7 +510,8 @@ public class AttributesActionBean extends LocalizableApplicationActionBean imple
                 final Query q = new Query(fs.getName().toString());
                 //List<String> propertyNames = FeatureToJson.setPropertyNames(appLayer,q,ft,false);
 
-                setFilter(q,ft, appLayer, em);
+                setFilter(q, ft, appLayer, em);
+                setAttributesNotNullFilters(q, appLayer, ft, em);
 
                 final FeatureSource fs2 = fs;
                 total = lookupTotalCountCache(new Callable<Integer>() {

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/DownloadFeaturesActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/DownloadFeaturesActionBean.java
@@ -386,7 +386,7 @@ public class DownloadFeaturesActionBean extends LocalizableApplicationActionBean
         return featureTypeAttributes;
     }
 
-    private void setFilter(String filter, Query q, SimpleFeatureType ft, EntityManager em) throws Exception {
+    protected void setFilter(String filter, Query q, SimpleFeatureType ft, EntityManager em) throws Exception {
         if (filter != null && filter.trim().length() > 0) {
             Filter f = FlamingoCQL.toFilter(filter, em);
             f = (Filter) f.accept(new RemoveDistanceUnit(), null);


### PR DESCRIPTION
- change the `DownloadFeaturesActionBean#setFilter(...)` method from private to protected so we can override in extending classes
- change the `AttributesActionBean#setFilter(...)` method from private to protected so we can override in extending classes and move a call to a private method to a higher level



see: https://github.com/B3Partners/OIGS/pull/67