### PR TITLE
Bump commons-beanutils-core 1.8.3 to commons-beanutils 1.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,8 +372,8 @@
             <!-- viewer-config-persistence -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
-                <artifactId>commons-beanutils-core</artifactId>
-                <version>1.8.3</version>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.3</version>
             </dependency>
             <dependency>
                 <groupId>org.flamingo-mc</groupId>

--- a/viewer-config-persistence/pom.xml
+++ b/viewer-config-persistence/pom.xml
@@ -183,7 +183,7 @@
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils-core</artifactId>
+            <artifactId>commons-beanutils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
release notes: https://commons.apache.org/proper/commons-beanutils/javadocs/v1.9.3/RELEASE-NOTES.txt

fixes [CVE-2014-0114](https://nvd.nist.gov/vuln/detail/CVE-2014-0114)

- [x] Need to check the dependency tree; there are no `core` versions after 1.8.3, so this upgrades commons-beanutils-core:1.8.3 to commons-beanutils:1.9.3 (_as it turns out the current master has both `commons-beanutils-1.7.0.jar` as well as `commons-beanutils-core-1.8.3.jar` includes in the viewer .war_)
- [x]  ~~may need to explicitly exclude old versions pulled in as transitive dependencies~~