### PR TITLE
Initialize Auditmessage object upon making ProxyActionBean object

### DIFF
--- a/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
+++ b/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
@@ -108,7 +108,7 @@ public class TileServiceTest extends TestUtil{
         GeoService result = instance.loadFromUrl(url, params, status, entityManager);
         assertEquals("https://geodata.nationaalgeoregister.nl/tiles/service/wmts?",result.getUrl());
         Layer topLayer = result.getTopLayer();
-        assertEquals(45, topLayer.getChildren().size());
+        assertEquals(44, topLayer.getChildren().size());
         
         Layer brt = topLayer.getChildren().get(0);
         assertEquals("brtachtergrondkaart", brt.getName());
@@ -189,7 +189,7 @@ public class TileServiceTest extends TestUtil{
         
         GeoService result = instance.loadFromUrl(url, params, status, entityManager);
         Layer topLayer = result.getTopLayer();
-        assertEquals(45, topLayer.getChildren().size());
+        assertEquals(44, topLayer.getChildren().size());
         assertEquals("https://geodata.nationaalgeoregister.nl/tiles/service/wmts?", result.getUrl());
         
         Layer brt = topLayer.getChildren().get(0);

--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintInfo.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintInfo.java
@@ -225,6 +225,7 @@ public class PrintInfo {
     public void cacheLegendImagesAndReadDimensions(ActionBeanContext context, EntityManager em) {
         
         ProxyActionBean pab = new ProxyActionBean();
+        pab.initAudit();
         pab.setContext(context);
         for(Legend l: legendUrls) {
             for(LegendPart lp: l.getLegendParts()) {


### PR DESCRIPTION
ProxyActionBean gives NPE on line 279 when called from the printInfo class in loadlegend() method.

The ProxyActionBean object that is defined in "cacheLegendImagesAndReadDimensions()" does not initialize a auditmessageobject. Before(stages = LifecycleStage.EventHandling) is not called.