### PR TITLE
Use 'flamingo.version' and not 'project.version' for any flamingo dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
                 <artifactId>viewer-config-persistence</artifactId>
                 <type>test-jar</type>
                 <scope>test</scope>
-                <version>${project.version}</version>
+                <version>${flamingo.version}</version>
             </dependency>
 
             <!-- nl b3p csw-->


### PR DESCRIPTION
this should prevent messages like:
```
[INFO] [INFO] Generating "Dependency Management" report --- maven-project-info-reports-plugin:3.0.0:dependency-management
[INFO] [WARNING] Unable to create Maven project for org.flamingo-mc:viewer-config-persistence:test-jar:tests:0.3 from repository.
[INFO] org.apache.maven.project.ProjectBuildingException: Error resolving project artifact: Failure to transfer org.flamingo-mc:viewer-config-persistence:pom:0.3 from http://www.terracotta.org/download/reflector/releases was cached in the local repository, resolution will not be reattempted until the update interval of terracotta-releases has elapsed or updates are forced. Original error: Could not transfer artifact org.flamingo-mc:viewer-config-persistence:pom:0.3 from/to terracotta-releases (http://www.terracotta.org/download/reflector/releases): Access denied to: http://www.terracotta.org/download/reflector/releases/org/flamingo-mc/viewer-config-persistence/0.3/viewer-config-persistence-0.3.pom for project org.flamingo-mc:viewer-config-persistence:pom:0.3
[INFO]     at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:330)
[INFO]     at org.apache.maven.report.projectinfo.dependencies.RepositoryUtils.getMavenProjectFromRepository (RepositoryUtils.java:125)
[INFO]     at org.apache.maven.report.projectinfo.dependencies.renderer.DependencyManagementRenderer.getDependencyRow (DependencyManagementRenderer.java:253)
```

when building a release of an overlay project that has a different version number than Flamingo