### PR TITLE
[Backport 5.4.x] Bump dependency-check-maven from 5.2.2 to 5.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.2.2</version>
+                    <version>5.2.4</version>
                     <configuration>
                         <skipSystemScope>true</skipSystemScope>
                         <format>ALL</format>


### PR DESCRIPTION
Backport #1599.
Backport #1601.