### PR TITLE
use returnTo from URL param after successful login for direct mellon logins with IsPassive=true

### DIFF
--- a/web-commons/src/main/java/nl/b3p/web/filter/HeaderAuthenticationFilter.java
+++ b/web-commons/src/main/java/nl/b3p/web/filter/HeaderAuthenticationFilter.java
@@ -351,13 +351,22 @@ public class HeaderAuthenticationFilter implements Filter {
                 log.info("Extra headers saved from auth request: " + extraHeaders);
             }
 
-            String returnTo = (String)session.getAttribute(ATTR_RETURN_TO);
+            String returnTo = request.getParameter("returnTo");
             if(returnTo != null) {
-                log.info("Redirecting after successful login to: " + returnTo);
+                // When directly logged in using a redirect to /mellon/login
+                // from outside the filter, accept a returnTo URL parameter.
+                // This can be used for AutnRequests with IsPassive=true.
+                log.info("Redirecting to returnTo from URL parameter: " + returnTo);
                 response.sendRedirect(returnTo);
             } else {
-                log.info("Redirecting to default page after successful login");
-                response.sendRedirect(request.getContextPath());
+                returnTo = (String)session.getAttribute(ATTR_RETURN_TO);
+                if(returnTo != null) {
+                    log.info("Redirecting after successful login to: " + returnTo);
+                    response.sendRedirect(returnTo);
+                } else {
+                    log.info("Redirecting to default page after successful login");
+                    response.sendRedirect(request.getContextPath());
+                }
             }
             return;
         }


### PR DESCRIPTION
For a normal SAML login the app redirects to `/viewer/auth/init?returnTo=/viewer/app?name=myapp`. The `returnTo` parameter is saved in the session and redirected to when mellon redirects to `/viewer/auth/saml` after a succesful login.

When an app directly initiates a SAML login by redirecting to `/mellon/login`, it can supply a `ReturnTo` parameter for mellon to return to `/viewer/auth/saml` which processes the succesful login. However the HeaderAuthenticationFilter used to redirect to the context path as no URL to return to was saved in the session, so the default app was opened and not the Flamingo app the user originally navigated to.

With this fix the `ReturnTo` URL `/viewer/auth/saml` can also include a `returnTo` parameter. Note that it must be correctly URL encoded.

Example passive login script in `login.jsp`, note the `newLocation` variable includes the `returnTo` parameter picked up by this pull request:
```
        <script>
            if(document.cookie.indexOf("saml_login_tried=true") === -1) {
                document.cookie = "saml_login_tried=true; path=${contextPath}/";
                var afterAuthReturnTo = "${absoluteURIPrefix}${contextPath}/app/${param['name']}?version=${param['version']}&debug=${param['debug']}";
                document.cookie = "saml_passive_src=" + afterAuthReturnTo + "; path=${contextPath}/";
                console.log('Login: Redirecting to passive SAML login; return to: ' + afterAuthReturnTo);
                var newLocation = '/mellon/login?ReturnTo=' + encodeURIComponent(window.location.protocol + '//' + window.location.hostname + '/viewer/auth/saml?returnTo=' + encodeURIComponent(afterAuthReturnTo)) + '&IsPassive=true';
                console.log('Login: Set window location to: ' + newLocation);
                window.location = newLocation;
            } else {
                console.log('Login: Passive login already tried');
            }
        </script>

        <c:set scope="session" var="loginReturnTo" value="${contextPath}/auth/init?returnTo=${contextPath}/app?name=${param['name']}&version=${param['version']}&debug=${param['debug']}"/>
        <p>Klik <a href="${loginReturnTo}">hier</a> om in te loggen met uw [organisatie]-account.</p> 
```
For a Flamingo app with no login required, use similar redirect logic in `WEB-INF/jsp/app_overrides.jsp`.