### PR TITLE
Exclude JAI transitive dependencies from FOP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,16 @@
                 <groupId>org.apache.xmlgraphics</groupId>
                 <artifactId>fop</artifactId>
                 <version>2.4</version>
+                <exclusions>
+                    <!-- exclusion>
+                        <groupId>javax.media</groupId>
+                        <artifactId>jai-core</artifactId>
+                    </exclusion -->
+                    <exclusion>
+                        <groupId>com.sun.media</groupId>
+                        <artifactId>jai-codec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
                 <artifactId>fop</artifactId>
                 <version>2.4</version>
                 <exclusions>
+                    <!-- fop-core come with a load of deps we don't want -->
                     <!-- exclusion>
                         <groupId>javax.media</groupId>
                         <artifactId>jai-core</artifactId>
@@ -145,6 +146,10 @@
                     <exclusion>
                         <groupId>com.sun.media</groupId>
                         <artifactId>jai-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
- Exclude com.sun.media:jai-codec transitive dependency from FOP
- Exclude javax.servlet:servlet-api transitive dependency from FOP