### PR TITLE
Implemented/hacked functionality to mail features

### DIFF
--- a/viewer-commons/src/main/java/nl/b3p/mail/Mailer.java
+++ b/viewer-commons/src/main/java/nl/b3p/mail/Mailer.java
@@ -54,7 +54,7 @@ public class Mailer {
      * @throws Exception if any
      */
     public static void sendMail(String fromName, String fromEmail, String email, String subject, String mailContent) throws Exception {
-        sendMail(fromName, fromEmail, email, subject, mailContent, null);
+        sendMail(fromName, fromEmail, email, subject, mailContent, null, "text/plain");
     }
 
     /**
@@ -68,6 +68,10 @@ public class Mailer {
      * @throws Exception if any
      */
     public static void sendMail(String fromName, String fromEmail, String email, String subject, String mailContent, String cc) throws Exception {
+        sendMail(fromName, fromEmail, email, subject, mailContent, cc, "text/plain");
+    }
+    
+    public static void sendMail(String fromName, String fromEmail, String email, String subject, String mailContent, String cc, String mimetype) throws Exception {
 
         Address from = new InternetAddress(fromEmail, fromName);
         MimeMessage msg = new MimeMessage(getMailSession());
@@ -80,7 +84,7 @@ public class Mailer {
         }
         msg.setSubject(subject);
         msg.setSentDate(new Date());
-        msg.setContent(mailContent, "text/plain");
+        msg.setContent(mailContent, mimetype != null ?  mimetype : "text/plain");
 
         Transport.send(msg);
     }
@@ -96,7 +100,7 @@ public class Mailer {
      * @param filename Give that attachment a naem.
      * @throws Exception if any
      */
-    public static void sendMail(String fromName, String fromEmail, String email, String subject, String mailContent, File attachment, String filename) throws Exception {
+    public static void sendMailWithAttachment(String fromName, String fromEmail, String email, String subject, String mailContent, File attachment, String filename) throws Exception {
     
         Address from = new InternetAddress(fromEmail, fromName);
         Message msg = new MimeMessage(getMailSession());

--- a/viewer/nbactions.xml
+++ b/viewer/nbactions.xml
@@ -71,6 +71,7 @@
             <properties>
                 <netbeans.deploy>true</netbeans.deploy>
                 <test.skip.integrationtests>true</test.skip.integrationtests>
+                <skipTests>true</skipTests>
             </properties>
         </action>
         <action>

--- a/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
+++ b/viewer/src/main/java/nl/b3p/viewer/print/PrintGenerator.java
@@ -105,7 +105,7 @@ public class PrintGenerator  implements Runnable{
             ResourceBundle bundle = ResourceBundleProvider.getResourceBundle(locale);
             String subject = bundle.getString("viewer.printgenerator.subject_success");
             String mailContent = bundle.getString("viewer.printgenerator.mailContent_success");
-            Mailer.sendMail(fromName, fromMail, toMail, subject, mailContent, temp, filename);
+            Mailer.sendMailWithAttachment(fromName, fromMail, toMail, subject, mailContent, temp, filename);
         } finally {
             temp.delete();
         }

--- a/viewer/src/main/webapp/META-INF/context.xml
+++ b/viewer/src/main/webapp/META-INF/context.xml
@@ -2,6 +2,7 @@
 <Context antiJARLocking="true" disableURLRewriting="true" path="/viewer">
   <Parameter name="componentregistry.path" override="false" value="/viewer-html/components"/>
   <Parameter name="flamingo.data.dir" override="false" value="/opt/flamingo_data/"/>
+  <Parameter name="flamingo.edit.email.config" override="false" value="<cat>:<mailaddress>,<cat>:<mailaddress>,"/>
   <!-- For Tomcat: define datasource in server.xml, for example:
     NOTE:
         each version of tomcat comes with it's own version of the pooling library


### PR DESCRIPTION
Hacky implementation for mailing a feature to a configured mail address.

Table:
CREATE TABLE public.melding
(
    id serial,
    geom geometry,
    categorie text COLLATE pg_catalog."default",
    shouldmail boolean,
    CONSTRAINT melding_pkey PRIMARY KEY (id),
    CONSTRAINT enforce_srid_geom CHECK (st_srid(geom) = 28992),
    CONSTRAINT enforce_dims_geom CHECK (st_ndims(geom) = 2),
    CONSTRAINT enforce_geotype_geom CHECK (geometrytype(geom) = 'POINT'::text OR geom IS NULL)
)

In viewer context.xml:

        <Parameter name="flamingo.edit.email.config" override="false" value="<cat>:<mailaddress>,<cat>:<mailaddress>,<cat>:<mailaddress>"/>