### PR TITLE
[Backport v5.6.x] Bump geotools.version from 22.1 to 22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>22.1</geotools.version>
+        <geotools.version>22.2</geotools.version>
+        <b3p-commons-csw.version>6.1.2</b3p-commons-csw.version>
         <powermock.version>2.0.4</powermock.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
@@ -169,7 +170,7 @@
             <dependency>
                 <groupId>nl.b3p</groupId>
                 <artifactId>b3p-commons-csw</artifactId>
-                <version>6.1.1</version>
+                <version>${b3p-commons-csw.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.persistence</groupId>


### PR DESCRIPTION
backport #1606

* Bump geotools.version from 22.0 to 22.2

Bumps `geotools.version` from 22.0 to 22.2.

Updates `gt-main` from 22.0 to 22.2

Updates `gt-render` from 22.0 to 22.2

Updates `gt-jdbc` from 22.0 to 22.2

Updates `gt-shapefile` from 22.0 to 22.2

Updates `gt-epsg-wkt` from 22.0 to 22.2

Updates `gt-wmts` from 22.0 to 22.2

Updates `gt-wms` from 22.0 to 22.2

Updates `gt-wfs-ng` from 22.0 to 22.2

Updates `gt-jdbc-oracle` from 22.0 to 22.2

Updates `gt-jdbc-postgis` from 22.0 to 22.2

Updates `gt-jdbc-sqlserver` from 22.0 to 22.2

Updates `gt-xsd-core` from 22.0 to 22.2

Updates `gt-xsd-gml3` from 22.0 to 22.2

Updates `gt-metadata` from 22.0 to 22.2

Updates `gt-referencing` from 22.0 to 22.2

Updates `gt-geojson` from 22.0 to 22.2

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

* Bump b3p-commons-csw 6.1.1 -> 6.1.2

Co-authored-by: Mark Prins <mprins@users.sf.net>