### PR TITLE
Make minimum password length configurable

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/UserActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/UserActionBean.java
@@ -34,6 +34,7 @@ import nl.b3p.viewer.config.security.*;
 import nl.b3p.viewer.config.security.Authorizations.ApplicationCache;
 import nl.b3p.viewer.config.services.GeoService;
 import nl.b3p.viewer.config.services.Layer;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.hibernate.*;
 import org.hibernate.criterion.*;
 import org.json.*;
@@ -267,8 +268,10 @@ public class UserActionBean extends LocalizableActionBean {
         }
 
         if (password != null) {
-            if (password.length() < User.MIN_PASSWORD_LENGTH) {
-                errors.add("password", new SimpleError( MessageFormat.format(getBundle().getString("viewer_admin.useractionbean.pwshort"), User.MIN_PASSWORD_LENGTH)));
+            int passwordLength = NumberUtils.toInt(this.getContext().getServletContext().getInitParameter("password.length"), 0);
+            passwordLength = Math.max(passwordLength, User.MIN_PASSWORD_LENGTH);
+            if (password.length() < passwordLength) {
+                errors.add("password", new SimpleError(MessageFormat.format(getBundle().getString("viewer_admin.useractionbean.pwshort"), passwordLength)));
                 return;
             }
         }

--- a/viewer-admin/src/main/webapp/WEB-INF/web.xml
+++ b/viewer-admin/src/main/webapp/WEB-INF/web.xml
@@ -111,6 +111,11 @@
         <param-name>flamingo.projections.epsgnames</param-name>
         <param-value>RD</param-value>
     </context-param>
+    <context-param>
+        <description>minimum length of password</description>
+        <param-name>password.length</param-name>
+        <param-value>12</param-value>
+    </context-param>
     <listener>
         <listener-class>nl.b3p.viewer.components.ComponentRegistryInitializer</listener-class>
     </listener>


### PR DESCRIPTION
This makes it possible to enforce a certain password length by configuration; the absolute minimum is still 8,  https://github.com/flamingo-geocms/flamingo/blob/a03089878cf2c6fe8ebd80c7792f4bf30065df9e/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/User.java#L36

The new value (by configuration) is 12, which can be changed to a different (larger than 7) value for a deployment.

[KPN RED team people](https://overons.kpn/en/kpn-in-the-netherlands/security/in-practice) recommend the following minimum password length:
- 12 characters for regular users
- 14 characters for user that access sensitive data
- 16 characters for admin users

see also #1656