### PR TITLE
Support for geofenceheader

### DIFF
--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/GeoServiceActionBean.java
@@ -122,7 +122,9 @@ public class GeoServiceActionBean extends LocalizableActionBean {
     private WMSExceptionType exception_type;
     @Validate
     private boolean skipDiscoverWFS = false;
-
+    @Validate
+    private String geofenceHeader;
+    
     private WaitPageStatus status;
     private JSONObject newService;
     private JSONObject updatedService;
@@ -419,6 +421,14 @@ public class GeoServiceActionBean extends LocalizableActionBean {
         this.skipDiscoverWFS = skipDiscoverWFS;
     }
 
+    public String getGeofenceHeader() {
+        return geofenceHeader;
+    }
+
+    public void setGeofenceHeader(String geofenceHeader) {
+        this.geofenceHeader = geofenceHeader;
+    }
+
     //</editor-fold>
 
     private JSONArray layersInApplications = new JSONArray();
@@ -486,7 +496,8 @@ public class GeoServiceActionBean extends LocalizableActionBean {
             if(service.getDetails().containsKey(GeoService.DETAIL_USE_PROXY)){
                 ClobElement ce =service.getDetails().get(GeoService.DETAIL_USE_PROXY);
                 useProxy = Boolean.parseBoolean(ce.getValue());
-            }
+            }            
+            geofenceHeader = service.getGeofenceHeader();
             name = service.getName();
             username = service.getUsername();
             password = service.getPassword();
@@ -603,7 +614,8 @@ public class GeoServiceActionBean extends LocalizableActionBean {
         }
         service.getDetails().put(GeoService.DETAIL_USE_INTERSECT, new ClobElement(""+useIntersect));
         service.getDetails().put(GeoService.DETAIL_USE_PROXY, new ClobElement(""+useProxy));
-
+        
+        service.setGeofenceHeader(geofenceHeader);      
         service.setUsername(username);
         if (password != null) {
             service.setPassword(password);

--- a/viewer-admin/src/main/resources/ViewerResources.properties
+++ b/viewer-admin/src/main/resources/ViewerResources.properties
@@ -502,6 +502,7 @@ viewer_admin.geoservice.48=Weet u zeker dat u deze SLD wilt verwijderen?
 viewer_admin.geoservice.49=Verwijderen
 viewer_admin.geoservice.5=ArcGIS server versie
 viewer_admin.geoservice.50=Toevoegen
+viewer_admin.geoservice.51=Geofence header sleutel
 viewer_admin.geoservice.6=Automatisch
 viewer_admin.geoservice.7=Selecteer een versie indien <i>http://server/ArcGIS/rest/services?f=json</i> is afgeschermd maar de service zelf niet.
 viewer_admin.geoservice.8=Gebruik altijd ingevulde URL in plaats van URLs in GetCapabilities

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
@@ -213,7 +213,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td><stripes-dynattr:password name="password" autocomplete="new-password" maxlength="255" size="30"/></td>
         </tr>
         <tr id="geofenceHeader">
-            <td><fmt:message key="viewer_admin.geoservice.52" />:</td>
+            <td><fmt:message key="viewer_admin.geoservice.51" />:</td>
             <td><stripes-dynattr:text name="geofenceHeader" maxlength="255" size="30">${geofenceHeader}</stripes-dynattr:text></td>
         </tr>
         <tr>

--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/geoservice.jsp
@@ -212,6 +212,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td><fmt:message key="viewer_admin.geoservice.21" />:</td>
             <td><stripes-dynattr:password name="password" autocomplete="new-password" maxlength="255" size="30"/></td>
         </tr>
+        <tr id="geofenceHeader">
+            <td><fmt:message key="viewer_admin.geoservice.52" />:</td>
+            <td><stripes-dynattr:text name="geofenceHeader" maxlength="255" size="30">${geofenceHeader}</stripes-dynattr:text></td>
+        </tr>
         <tr>
             <td colspan="2">
                 <stripes:checkbox name="useIntersect"/> <fmt:message key="viewer_admin.geoservice.22" />
@@ -221,7 +225,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <td colspan="2">
                 <stripes:checkbox name="useProxy"/> <fmt:message key="viewer_admin.geoservice.23" />
             </td>
-        </tr>
+        </tr>        
         <tr>
             <td valign="top">
                 <h1><fmt:message key="viewer_admin.geoservice.24" />:</h1>                           

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/GeoService.java
@@ -59,7 +59,7 @@ public abstract class GeoService implements Serializable {
      * authentication.
      */
     public static final String PARAM_PASSWORD = "password";
-
+    
     @Id
     private Long id;
 
@@ -74,7 +74,9 @@ public abstract class GeoService implements Serializable {
 
     private String username;
     private String password;
-
+    
+    private String geofenceHeader;
+    
     private boolean monitoringEnabled;
     
     private boolean monitoringStatusOK = true;
@@ -222,6 +224,14 @@ public abstract class GeoService implements Serializable {
 
     public void setReaders(Set<String> readers) {
         this.readers = readers;
+    }
+
+    public String getGeofenceHeader() {
+        return geofenceHeader;
+    }
+
+    public void setGeofenceHeader(String geofenceHeader) {
+        this.geofenceHeader = geofenceHeader;
     }
     //</editor-fold>
       

--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/util/databaseupdate/DatabaseSynchronizer.java
@@ -171,6 +171,9 @@ public class DatabaseSynchronizer implements Servlet {
         
         // 5.6.0
         updates.put("38", new UpdateElement(Collections.singletonList("delete_orphan_featuretypes.sql"), String.class, true));
+        
+        // 5.7.3
+        updates.put("39", new UpdateElement(Collections.singletonList("add_geoservice_geofence_header.sql"), String.class, true));
         // 
         // NB when adding an update also update the metadata version in the testdata.sql file around line 348
         // that is: /src/test/resources/nl/b3p/viewer/util/testdata.sql

--- a/viewer-config-persistence/src/main/resources/scripts/hsqldb-add_geoservice_geofence_header.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/hsqldb-add_geoservice_geofence_header.sql
@@ -1,0 +1,2 @@
+ALTER TABLE geo_service
+  ADD COLUMN geofence_header varchar(255);

--- a/viewer-config-persistence/src/main/resources/scripts/microsoft_sql_server-add_geoservice_geofence_header.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/microsoft_sql_server-add_geoservice_geofence_header.sql
@@ -1,0 +1,1 @@
+ALTER TABLE geo_service ADD geofence_header VARCHAR(255) NULL;

--- a/viewer-config-persistence/src/main/resources/scripts/oracle-add_geoservice_geofence_header.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/oracle-add_geoservice_geofence_header.sql
@@ -1,0 +1,2 @@
+alter table geo_service
+  add geofence_header varchar2(255 char);

--- a/viewer-config-persistence/src/main/resources/scripts/postgresql-add_geoservice_geofence_header.sql
+++ b/viewer-config-persistence/src/main/resources/scripts/postgresql-add_geoservice_geofence_header.sql
@@ -1,0 +1,2 @@
+alter table geo_service
+  add column geofence_header varchar(255);

--- a/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
+++ b/viewer-config-persistence/src/test/resources/nl/b3p/viewer/util/testdata.sql
@@ -202,10 +202,10 @@ INSERT INTO feature_type_attributes (feature_type, attribute_descriptor, list_in
 INSERT INTO feature_type_attributes (feature_type, attribute_descriptor, list_index) VALUES (6, 46, 0);
 
 
-INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer) VALUES ('tiled', 1, '2015-09-15 16:33:48.096', false, true, 'Openbasiskaart', NULL, 'http://www.openbasiskaart.nl/mapcache/tms/1.0.0/osm-nb@rd', NULL, 'TMS', NULL, NULL, 1, 1);
-INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer) VALUES ('wms', 2, '2015-09-15 16:34:14.961', false, true, 'Groen', 'w@chtw00rd', 'http://x12.b3p.nl/cgi-bin/mapserv?map=/srv/maps/solparc/groen_productie.map&', 'B3P', NULL, 'Inimage', false, 2, 3);
-INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer) VALUES ('wms', 3, '2015-09-15 16:34:29.301', false, true, 'woonplaatsen', 'w@chtw00rd', 'http://x12.b3p.nl/cgi-bin/mapserv?map=/srv/maps/solparc/woonplaats_productie.map&', 'B3P', NULL, 'Inimage', false, 2, 9);
-INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer) VALUES ('wms', 4, '2018-11-22 13:34:29.301', false, true, 'woonplaatsen', 'w@chtw00rd', 'https://flamingo5.b3p.nl/geoserver/test_omgeving_fla5/wms', 'B3P', NULL, 'Inimage', false, 2, 1);
+INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer, geofence_header) VALUES ('tiled', 1, '2015-09-15 16:33:48.096', false, true, 'Openbasiskaart', NULL, 'http://www.openbasiskaart.nl/mapcache/tms/1.0.0/osm-nb@rd', NULL, 'TMS', NULL, NULL, 1, 1, NULL);
+INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer, geofence_header) VALUES ('wms', 2, '2015-09-15 16:34:14.961', false, true, 'Groen', 'w@chtw00rd', 'http://x12.b3p.nl/cgi-bin/mapserv?map=/srv/maps/solparc/groen_productie.map&', 'B3P', NULL, 'Inimage', false, 2, 3, NULL);
+INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer, geofence_header) VALUES ('wms', 3, '2015-09-15 16:34:29.301', false, true, 'woonplaatsen', 'w@chtw00rd', 'http://x12.b3p.nl/cgi-bin/mapserv?map=/srv/maps/solparc/woonplaats_productie.map&', 'B3P', NULL, 'Inimage', false, 2, 9, NULL);
+INSERT INTO geo_service (protocol, id, authorizations_modified, monitoring_enabled, monitoring_statusok, name, password, url, username, tiling_protocol, exception_type, override_url, category, top_layer, geofence_header) VALUES ('wms', 4, '2018-11-22 13:34:29.301', false, true, 'woonplaatsen', 'w@chtw00rd', 'https://flamingo5.b3p.nl/geoserver/test_omgeving_fla5/wms', 'B3P', NULL, 'Inimage', false, 2, 1, NULL);
 
 insert into geo_service_readers (geo_service, role_name) values (2, 'Admin');
 insert into geo_service_readers (geo_service, role_name) values (4, 'Admin');
@@ -342,7 +342,7 @@ INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_L
 INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_LAYER, REMOVED) VALUES (27, false, null, 1, 4, false);
 INSERT INTO START_LAYER (ID, CHECKED, SELECTED_INDEX, APPLICATION, APPLICATION_LAYER, REMOVED) VALUES (28, false, null, 1, 5, false);
 
-INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '38');
+INSERT INTO metadata (id, config_key, config_value) VALUES (1, 'database_version', '39');
 
 INSERT INTO user_ (username, password) VALUES ('admin', '14c06474bec5e7def0304925d09f2b977af3146a');
 INSERT INTO user_ (username, password) VALUES ('pietje', '14c06474bec5e7def0304925d09f2b977af3146a');


### PR DESCRIPTION
It is now possible to set a geofenceheader key on a geoservice. This is only applied when proxy is used. 
Instructions:
- Set geofenceheader key (this is the key that has been set in geoserver with geofence) on the geoservice and set use proxy.
- Make a group/role in the viewer-admin with description value 'geofence', the group/role name must match a geofence rule.