### PR TITLE
Prevent a possible NPE by checking for a null valued serviceId in the ProxyActionBean

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyActionBean.java
@@ -123,7 +123,7 @@ public class ProxyActionBean implements ActionBean, Auditable {
 
         // Session must exist
         HttpSession sess = request.getSession(false);
-        if (sess == null || url == null) {
+        if (sess == null || url == null || serviceId == null) {
             return new ErrorResolution(HttpServletResponse.SC_FORBIDDEN, "Proxy requests forbidden");
         }
 


### PR DESCRIPTION
related #1692 