### PR TITLE
Bump Tomcat test dependencies 7.0.99 ⇨ 7.0.100

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <tomcat.version>7.0.99</tomcat.version>
+        <tomcat.version>7.0.100</tomcat.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <!--<jacoco.it.execution.data.file>${project.build.directory}/jacoco-it.exec</jacoco.it.execution.data.file>-->
         <!--<jacoco.ut.execution.data.file>${project.build.directory}/jacoco-ut.exec</jacoco.ut.execution.data.file>-->


### PR DESCRIPTION
resolves:
- CVE-2020-1935
- CVE-2020-1938
- CVE-2019-17569

**note** Tomcat is not part of Flamingo, Tomcat is not distributed as part of Flamingo; however Tomcat instances running Flamingo may be vulnerable

We only use some tomcat libraries in our test suite.