### PR TITLE
[Backport v5.4.x] Bump apache.httpcomponents.version from 4.5.10 to 4.5.12 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <mssql.version>7.4.1.jre8</mssql.version>
         <apache.poi.version>4.0.1</apache.poi.version>
         <javax.mail.version>1.6.2</javax.mail.version>
-        <apache.httpcomponents.version>4.5.10</apache.httpcomponents.version>
+        <apache.httpcomponents.version>4.5.12</apache.httpcomponents.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>


### PR DESCRIPTION
Backport #1725