### PR TITLE
Fixed NPE

### DIFF
--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/security/Authorizations.java
@@ -529,6 +529,9 @@ public class Authorizations {
     }
 
     public static boolean isUserExpired(User u, ActionBeanContext context) {
+        if(u == null){
+            return false;
+        }
         Date today = null;
         Date expire = null;
         try {


### PR DESCRIPTION
When opening a viewer without logging in, there is a NullPointerException

Already in 5.6 branch