### PR TITLE
Bump GeoTools 22.2 ➜ 23.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>22.2</geotools.version>
-        <b3p-commons-csw.version>6.1.2</b3p-commons-csw.version>
+        <geotools.version>23-RC</geotools.version>
+        <b3p-commons-csw.version>6.2.0-SNAPSHOT</b3p-commons-csw.version>
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>23-RC</geotools.version>
-        <b3p-commons-csw.version>6.2.0-SNAPSHOT</b3p-commons-csw.version>
+        <geotools.version>23.0</geotools.version>
+        <b3p-commons-csw.version>6.2.0</b3p-commons-csw.version>
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
- [x] upgrade GeoTools 22.2 ➜ 23-RC
- [x] upgrade b3p-commons-csw 6.1.2 ➜ 6.2.0-SNAPSHOT
- [x] upgrade GeoTools 23-RC ➜ 23.0
- [x] upgrade b3p-commons-csw 6.2.0-SNAPSHOT ➜ 6.2.0

depends on https://github.com/B3Partners/b3p-commons-csw/pull/39