### PR TITLE
[Backport v5.4.x] Bump grunt from 1.0.4 to 1.1.0 in /viewer/src/main/webapp/viewer-html…

### DIFF
--- a/viewer/src/main/webapp/viewer-html/package.json
+++ b/viewer/src/main/webapp/viewer-html/package.json
@@ -3,7 +3,14 @@
     "version": "4.5.7",
     "homepage": "https://github.com/flamingo-geocms/flamingo",
     "devDependencies": {
-        "grunt": "1.0.0",
-        "grunt-svgstore": "1.0.0"
+        "grunt": "1.1.0",
+        "grunt-svgstore": "2.0.0",
+        "http-server": "^0.12.1",
+        "jasmine-core": "^3.4.0",
+        "jsdom": "^16.1.0",
+        "karma": "^4.1.0",
+        "karma-chrome-launcher": "^3.1.0",
+        "karma-firefox-launcher": "^1.1.0",
+        "karma-jasmine": "^3.1.0"
     }
 }


### PR DESCRIPTION
Backport #1745

Bumps [grunt](https://github.com/gruntjs/grunt) from 1.0.4 to 1.1.0.
- [Release notes](https://github.com/gruntjs/grunt/releases)
- [Changelog](https://github.com/gruntjs/grunt/blob/master/CHANGELOG)
- [Commits](https://github.com/gruntjs/grunt/compare/v1.0.4...v1.1.0)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>