### PR TITLE
[Backport v5.4.x] Bump mockito-core from 3.3.1 to 3.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>2.24.5</version>
+                <version>3.3.3</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Backport #1743

Bumps [mockito-core](https://github.com/mockito/mockito) from 3.3.1 to 3.3.3.
- [Release notes](https://github.com/mockito/mockito/releases)
- [Commits](https://github.com/mockito/mockito/compare/v3.3.1...v3.3.3)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>