### PR TITLE
isAlternative = true from appLayer legends

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1427,7 +1427,7 @@ Ext.define("viewer.viewercontroller.ViewerController", {
 
             // Check override for appLayer by service admin
             if(appLayer.details != undefined && appLayer.details.legendImageUrl != undefined) {
-                success(appLayer, { parts: [ {url: appLayer.details.legendImageUrl, isAlternative:false, serviceId: appLayer.serviceId, label: appLayer.alias}] });
+                success(appLayer, { parts: [ {url: appLayer.details.legendImageUrl, isAlternative:true, serviceId: appLayer.serviceId, label: appLayer.alias}] });
                 return;
             }
 


### PR DESCRIPTION
[mantis-13539](https://mantis.b3p.nl/view.php?id=13539)

Legend images configured in boomstructuur met kaarten, weren't identified as alternative legends, and were rerouted through the proxy. Which declined the request.