### PR TITLE
[Backport v5.4.x] Bump javassist from 3.26.0-GA to 3.27.0-GA (#1757)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
                 <!-- override the version provided by hibernate -->
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.24.1-GA</version>
+                <version>3.27.0-GA</version>
             </dependency>
             <dependency>
                 <groupId>org.hibernate</groupId>
@@ -364,7 +364,7 @@
                 <exclusions>
                     <exclusion>
                         <!--
-                        exclude old javassist so we can use 3.22.0-CR2, see issue #745
+                        exclude old javassist so we can use 3.27.0-CR2, see issue #745
                         when upgrading hibernate this should be removed
                         -->
                         <groupId>javassist</groupId>


### PR DESCRIPTION
Backport 8870cb3 from #1757

Bumps [javassist](https://github.com/jboss-javassist/javassist) from 3.26.0-GA to 3.27.0-GA.
- [Release notes](https://github.com/jboss-javassist/javassist/releases)
- [Commits](https://github.com/jboss-javassist/javassist/commits)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>