### PR TITLE
bump dependencies & plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ vuln-check.log
 target/
 # GH-issue 1493
 viewer/src/main/webapp/viewer-html/package-lock.json
+package-lock.json
+node_modules

--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,10 @@
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <tomcat.version>7.0.100</tomcat.version>
+        <tomcat.version>7.0.103</tomcat.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
-        <!--<jacoco.it.execution.data.file>${project.build.directory}/jacoco-it.exec</jacoco.it.execution.data.file>-->
-        <!--<jacoco.ut.execution.data.file>${project.build.directory}/jacoco-ut.exec</jacoco.ut.execution.data.file>-->
+        <tomcat7-maven-plugin.version>2.2</tomcat7-maven-plugin.version>
+        <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <netbeans.hint.jdkPlatform>JDK_1.8</netbeans.hint.jdkPlatform>
     </properties>
     <dependencyManagement>
@@ -533,7 +533,7 @@
             <dependency>
                 <groupId>org.apache.tika</groupId>
                 <artifactId>tika-core</artifactId>
-                <version>1.23</version>
+                <version>1.24</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -661,7 +661,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>5.3.1</version>
+                    <version>5.3.2</version>
                     <configuration>
                         <skipSystemScope>true</skipSystemScope>
                         <format>ALL</format>
@@ -672,7 +672,7 @@
                 <plugin>
                     <groupId>org.apache.tomcat.maven</groupId>
                     <artifactId>tomcat7-maven-plugin</artifactId>
-                    <version>2.2</version>
+                    <version>${tomcat7-maven-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.tomcat.embed</groupId>
@@ -769,7 +769,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>properties-maven-plugin</artifactId>
-                    <version>1.0.0</version>
+                    <version>${properties-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -235,6 +235,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -251,6 +252,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
@@ -277,6 +279,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>${project.basedir}/src/test/tomcatconf/context.xml</contextFile>
@@ -350,6 +353,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -366,6 +370,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
@@ -392,6 +397,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>${project.basedir}/src/test/tomcatconf/jenkinscontext.xml</contextFile>
@@ -454,6 +460,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -470,6 +477,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
@@ -482,7 +490,6 @@
                                 <database.properties.file>ms_sql_server.properties</database.properties.file>
                             </systemPropertyVariables>
                             <useFile>false</useFile>
-                            <!--<argLine>${failsafeArgLine}</argLine>-->
                         </configuration>
                         <executions>
                             <execution>
@@ -496,6 +503,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/appveyorcontext.xml</contextFile>
@@ -532,11 +540,6 @@
                                 <artifactId>mssql-jdbc</artifactId>
                                 <version>${mssql.version}</version>
                             </dependency>
-                            <!--dependency>
-                                <groupId>org.jacoco</groupId>
-                                <artifactId>org.jacoco.agent</artifactId>
-                                <version>${jacoco-maven-plugin.version}</version>
-                            </dependency -->
                         </dependencies>
                     </plugin>
                 </plugins>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -519,6 +519,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -535,6 +536,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
@@ -562,6 +564,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/context.xml</contextFile>
@@ -623,6 +626,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -639,6 +643,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
@@ -666,6 +671,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/jenkinscontext.xml</contextFile>
@@ -726,6 +732,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>properties-maven-plugin</artifactId>
+                        <version>${properties-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <phase>initialize</phase>
@@ -742,12 +749,12 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
                         <configuration>
                             <includes>
                                 <include>**/*IntegrationTest.java</include>
                             </includes>
                             <excludes>
-                                <!--<exclude>**/TilingIntegrationTest.java</exclude>-->
                             </excludes>
                             <trimStackTrace>false</trimStackTrace>
                             <testFailureIgnore>!${test.skip.integrationtests}</testFailureIgnore>
@@ -772,6 +779,7 @@
                     <plugin>
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
+                        <version>${tomcat7-maven-plugin.version}</version>
                         <configuration>
                             <port>9090</port>
                             <contextFile>src/test/tomcatconf/appveyorcontext.xml</contextFile>
@@ -808,13 +816,6 @@
                                 <artifactId>mssql-jdbc</artifactId>
                                 <version>${mssql.version}</version>
                             </dependency>
-                            <!--
-                            <dependency>
-                                <groupId>org.jacoco</groupId>
-                                <artifactId>org.jacoco.agent</artifactId>
-                                <version>${jacoco-maven-plugin.version}</version>
-                            </dependency>
-                            -->
                         </dependencies>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
- bump Tomcat development dependencies 7.0.100 ➜ 7.0.103
- bump dependency-check-maven plugin 5.3.1 ➜ 5.3.2
- bump tika-core 1.23 ➜ 1.24

also add some macro's for plugin versions and cleanup some stale comments