### PR TITLE
If dynamic lookup is configured for editing an attribute do not put out (possibly old) editValues

### DIFF
--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredAttribute.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/app/ConfiguredAttribute.java
@@ -280,7 +280,9 @@ public class ConfiguredAttribute {
         o.put("folder_label", label);
         if(editValues != null) {
             try {
-                o.put("editValues", new JSONArray(editValues));
+                if (!valueList.equalsIgnoreCase("dynamic")) {
+                    o.put("editValues", new JSONArray(editValues));
+                }
             } catch(JSONException je) {
             }
         }


### PR DESCRIPTION
close #1799