### PR TITLE
Feature: improve attribution

### DIFF
--- a/viewer-admin/src/main/webapp/WEB-INF/jsp/services/layer.jsp
+++ b/viewer-admin/src/main/webapp/WEB-INF/jsp/services/layer.jsp
@@ -76,9 +76,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <tr id="voorbeelden" style="display: none;">
                         <td colspan="2" style="border: 1px solid #43a4b1">
                             <i><fmt:message key="viewer_admin.layer.12" />:</i><br/>
-                            <span style="font-family: monospace">&amp;copy; &lt;a href="http://www.openstreetmap.nl" target="_blank"&gt;OpenStreetMap contributors&lt;/a&gt;</span><br/>
+                            <span style="font-family: monospace">&amp;copy; &lt;a href="https://www.openstreetmap.org/copyright" target="_blank"&gt;OpenStreetMap&lt;/a&gt; contributors</span><br/>
                             <i><fmt:message key="viewer_admin.layer.13" />:</i></br>
-                            <span style="font-family: monospace">&amp;copy; &lt;a href="http://www.kadaster.nl" target="_blank"&gt;Kadaster&lt;/a&gt;</span><br/>
+                            <span style="font-family: monospace">&amp;copy; &lt;a href="https://www.kadaster.nl" target="_blank"&gt;Kadaster&lt;/a&gt;</span><br/>
                         </td>
                     </tr>
                     <tr>

--- a/viewer/src/main/webapp/viewer-html/common/openlayers/theme/default/style.jsp
+++ b/viewer/src/main/webapp/viewer-html/common/openlayers/theme/default/style.jsp
@@ -46,6 +46,7 @@ div.olLayerDiv {
     bottom: 4.5em;
     position: absolute;
     display: block;
+    background: rgba(255,255,255,0.6);
 }
 .olControlScale {
     left: 3px;

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ol/OpenLayers5Map.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ol/OpenLayers5Map.js
@@ -51,7 +51,14 @@ Ext.define("viewer.viewercontroller.ol.OpenLayers5Map", {
         config.restrictedExtent = maxBounds;
         this.frameworkMap = new ol.Map({
             target: config.domId,
-            controls: ol.control.defaults({zoom: false}),
+            controls: ol.control.defaults({
+                zoom: false,
+                attribution: false
+            }).extend([
+                new ol.control.Attribution({
+                    collapsed: false
+                })
+            ]),
             keyboardEventTarget: document,
             view: new ol.View({
                 projection: config.projection,


### PR DESCRIPTION
- Updated suggested OSM attribution with direct link to copyright page

- Improved legibility of OL2 attribution, before and after:

![image](https://user-images.githubusercontent.com/1926261/82311680-53fec000-99c6-11ea-8149-9e8314fc9743.png)
![image](https://user-images.githubusercontent.com/1926261/82311711-5eb95500-99c6-11ea-9957-44234f995429.png)

- Expanded OL5 attribution by default:

![image](https://user-images.githubusercontent.com/1926261/82311745-6973ea00-99c6-11ea-8f17-96251b02c71b.png)

Previously:
![image](https://user-images.githubusercontent.com/1926261/82311790-7395e880-99c6-11ea-8c40-ab648f7251f1.png)

