### PR TITLE
backport from @mprins. Arrowfunctions not in ie11, so revert this epi…

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Snapping.js
+++ b/viewer/src/main/webapp/viewer-html/components/Snapping.js
@@ -261,7 +261,7 @@ Ext.define("viewer.components.Snapping", {
     },
     enableAllLayers: function(toggle){
         var layers = [];
-        this.layerList.forEach(l =>{
+        this.layerList.forEach(function(l) {
            layers.push(l.id);
         });
         this.setLayersEnabled(layers,toggle);


### PR DESCRIPTION
…c functionality to support pre-historic browsers