### PR TITLE
Bump Tomcat libs 7.0.103 -> 7.0.104

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         or as part of a profile, see eg. 'travis-ci' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <tomcat.version>7.0.103</tomcat.version>
+        <tomcat.version>7.0.104</tomcat.version>
         <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
         <tomcat7-maven-plugin.version>2.2</tomcat7-maven-plugin.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>


### PR DESCRIPTION
resolves CVE-2020-9484 (note this is a test dependency it does not resolve anything for any deployment; that should be done by upgrading the servlet engine of the deployment)