### PR TITLE
Use in-memory hsqldb for unittests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ timestamps {
                 numToKeepStr: '5']
             ]]);
 
-        final def jdks = ['OpenJDK11','JDK8']
+        final def jdks = [/*'OpenJDK11',*/'JDK8']
 
         stage("Prepare") {
              checkout scm

--- a/viewer-config-persistence/src/test/java/nl/b3p/viewer/util/TestUtil.java
+++ b/viewer-config-persistence/src/test/java/nl/b3p/viewer/util/TestUtil.java
@@ -90,7 +90,10 @@ public abstract class TestUtil extends LoggingTestUtil {
         testname = testname.replaceAll(":", "-");
         testname = testname.replaceAll(" ", "");
         String randomizer = RandomStringUtils.randomAlphabetic(8);
-        config.put("javax.persistence.jdbc.url", "jdbc:hsqldb:file:./target/unittest-hsqldb_"+ testname + "_" + randomizer + "/db;shutdown=true");
+        // if you want to keep the database of each test in the target directory use this:
+        // config.put("javax.persistence.jdbc.url", "jdbc:hsqldb:file:./target/unittest-hsqldb_"+ testname + "_" + randomizer + "/db;shutdown=true");
+        // if you want tests to run against in-memory database use:
+        config.put("javax.persistence.jdbc.url", "jdbc:hsqldb:mem:unittest-hsqldb_"+ testname + "_" + randomizer + "/db;shutdown=true");
         entityManager = Persistence.createEntityManagerFactory(persistenceUnit,config).createEntityManager();
         if(!entityManager.getTransaction().isActive()){
             entityManager.getTransaction().begin();


### PR DESCRIPTION
faster is better, if you need to inspect a testcase's data you can always temporarily revert this change