### PR TITLE
[Backport v5.6.x] Bump geotools.version from 23.0 to 23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>22.2</geotools.version>
-        <b3p-commons-csw.version>6.1.2</b3p-commons-csw.version>
+        <geotools.version>23.1</geotools.version>
+        <b3p-commons-csw.version>6.2.1</b3p-commons-csw.version>
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
backports #1832


Bumps `geotools.version` from 23.0 to 23.1.

Updates `gt-main` from 23.0 to 23.1

Updates `gt-render` from 23.0 to 23.1

Updates `gt-jdbc` from 23.0 to 23.1

Updates `gt-shapefile` from 23.0 to 23.1

Updates `gt-epsg-wkt` from 23.0 to 23.1

Updates `gt-wmts` from 23.0 to 23.1

Updates `gt-wms` from 23.0 to 23.1

Updates `gt-wfs-ng` from 23.0 to 23.1

Updates `gt-jdbc-oracle` from 23.0 to 23.1

Updates `gt-jdbc-postgis` from 23.0 to 23.1

Updates `gt-jdbc-sqlserver` from 23.0 to 23.1

Updates `gt-xsd-core` from 23.0 to 23.1

Updates `gt-xsd-gml3` from 23.0 to 23.1

Updates `gt-metadata` from 23.0 to 23.1

Updates `gt-referencing` from 23.0 to 23.1

Updates `gt-geojson` from 23.0 to 23.1

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>