### PR TITLE
fix pdok testcase, revert maven-war-plugin update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -629,7 +629,8 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <!-- 3.3.0 is "broken" see: https://issues.apache.org/jira/browse/MWAR-433  -->
+                    <version>3.2.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>

--- a/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
+++ b/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
@@ -48,7 +48,7 @@ public class TileServiceTest extends TestUtil{
     private TileService instance = new TileService();
 
     private static final String PDOK_WMTS = "http://geodata.nationaalgeoregister.nl/tiles/service/wmts?request=getcapabilities";
-    private static final int PDOK_WMTS_LAYERCOUNT = 43;
+    private static final int PDOK_WMTS_LAYERCOUNT = 42;
 
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = null;


### PR DESCRIPTION
Reverts #1839 (Bump maven-war-plugin from 3.2.3 to 3.3.0) as this breaks the build, see https://issues.apache.org/jira/browse/MWAR-433

also fix broken pdok testcase