### PR TITLE
Allow setting the label width of attribute labels on the edit form

### DIFF
--- a/viewer-admin/src/main/resources/ViewerResources.properties
+++ b/viewer-admin/src/main/resources/ViewerResources.properties
@@ -1686,3 +1686,4 @@ js.general.components.selectionwindowconfig.2 = Tooltip
 js.general.components.selectionwindowconfig.3 = Label
 js.edit.config.showSnappingButton=Laat snappingknop zien
 js.edit.config.useGPSTrace=Gebruik GPS voor lijnen
+js.edit.config.editLabelWidth = Breedte label (100-500)

--- a/viewer-admin/src/main/resources/ViewerResources_en.properties
+++ b/viewer-admin/src/main/resources/ViewerResources_en.properties
@@ -1677,3 +1677,4 @@ js.general.components.selectionwindowconfig.2 = Tooltip
 js.general.components.selectionwindowconfig.3 = Label
 js.edit.config.showSnappingButton=Show snappingbutton
 js.edit.config.useGPSTrace=Use GPS for linestrings
+js.edit.config.editLabelWidth = Label width (100-500)

--- a/viewer/src/main/webapp/viewer-html/components/Edit-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit-config.js
@@ -107,6 +107,19 @@ Ext.define("viewer.components.CustomConfiguration", {
                 labelWidth: this.labelWidth
             },
             {
+                xtype: 'numberfield',
+                fieldLabel: i18next.t('edit_config_editLabelWidth'),
+                minValue: 100,
+                maxValue: 500,
+                step: 10,
+                name: 'editLabelWidth',
+                value: this.configObject.editLabelWidth !== undefined ? this.configObject.editLabelWidth : 100,
+                labelWidth: this.labelWidth,
+                style: {
+                    marginRight: "70px"
+                }
+            },
+            {
                 xtype: 'textarea',
                 fieldLabel: i18next.t('edit_config_6'),
                 name: 'editHelpText',

--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -52,6 +52,7 @@ Ext.define("viewer.components.Edit", {
         tooltip: "",
         layers: null,
         label: "",
+        editLabelWidth: 100,
         clickRadius: 4,
         allowDelete: false,
         allowCopy: false,
@@ -899,6 +900,8 @@ Ext.define("viewer.components.Edit", {
             name: 'files[' + index + "]",
             width: "70%",
             labelClsExtra: this.editLblClass,
+            labelWidth: this.config.editLabelWidth,
+            labelAlign: 'left',
             listeners:{
                 change: function(fld,value){
                     var newValue = value.replace(/C:\\fakepath\\/g, '');
@@ -926,6 +929,8 @@ Ext.define("viewer.components.Edit", {
             disabled: !this.allowedEditable(attribute),
             readOnly:  attribute.automaticValue,
             labelClsExtra: this.editLblClass,
+            labelWidth: this.config.editLabelWidth,
+            labelAlign: 'left',
             allowBlank: !disallowNull,
             listeners: {
                 scope: this,
@@ -1078,6 +1083,8 @@ Ext.define("viewer.components.Edit", {
              (default: false)  */
             forceSelection: (attribute.hasOwnProperty('allowValueListOnly') && attribute.allowValueListOnly),
             labelClsExtra: this.editLblClass,
+            labelWidth: this.config.editLabelWidth,
+            labelAlign: 'left',
             listeners: {
                 scope: this,
                 change: this.validateFormFieldChange


### PR DESCRIPTION
the default value is 100, which is often too small, this will allow setting attribute label width for each instance of the edit component.

alternatively one could add css `.editCmpLbl {width: 250px !important;}` but that would apply applicationwide..