### PR TITLE
make the window that holds the list of edit features wider

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -1748,7 +1748,7 @@ Ext.define("viewer.components.Edit", {
 
         var window = Ext.create("Ext.window.Window", {
             id: this.name + "FeaturesWindow",
-            width: 500,
+            width: '80%',
             height: 300,
             layout: 'fit',
             title: i18next.t('viewer_components_edit_45'),


### PR DESCRIPTION
make the window that holds the list of edit features to choose from 80% wide instead of 500px so it is more useful on a big and/or hi-res screen

(I don't need a backport)