### PR TITLE
use cookie for session tracking

### DIFF
--- a/viewer/src/main/webapp/WEB-INF/web.xml
+++ b/viewer/src/main/webapp/WEB-INF/web.xml
@@ -210,6 +210,7 @@
     </login-config>
     <session-config>
         <session-timeout>240</session-timeout>
+        <tracking-mode>COOKIE</tracking-mode>
     </session-config>
     <welcome-file-list>
         <welcome-file>index.jsp</welcome-file>


### PR DESCRIPTION
This does restrict the very few people who disable first-party cookies from using apps requiring authentication, but public apps should still be useable.