### PR TITLE
Bump git-commit-id-plugin from 4.0.1 to 4.0.2 (#1926)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.0</version>
+                    <version>4.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
+++ b/viewer-config-persistence/src/test/java/nl/b3p/viewer/config/services/TileServiceTest.java
@@ -36,7 +36,7 @@ public class TileServiceTest extends TestUtil{
     private TileService instance = new TileService();
 
     private static final String PDOK_WMTS = "http://geodata.nationaalgeoregister.nl/tiles/service/wmts?request=getcapabilities";
-    private static final int PDOK_WMTS_LAYERCOUNT = 42;
+    private static final int PDOK_WMTS_LAYERCOUNT = 41;
 
     DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
     DocumentBuilder builder = null;


### PR DESCRIPTION
* Bump git-commit-id-plugin from 4.0.1 to 4.0.2

Bumps git-commit-id-plugin from 4.0.1 to 4.0.2.

Signed-off-by: dependabot[bot] <support@github.com>

* fix PDOK_WMTS_LAYERCOUNT test expectation

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Co-authored-by: Mark Prins <mark@b3partners.nl>