### PR TITLE
Bump GeoTools 23.2 ➜ 23.3 and b3p-commons-csw 6.2.2 ➜ 6.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>23.2</geotools.version>
-        <b3p-commons-csw.version>6.2.2</b3p-commons-csw.version>
+        <!-- when updating geotools also check b3p-commons-csw or you will end up in transitive dependency hell -->
+        <geotools.version>23.3</geotools.version>
+        <b3p-commons-csw.version>6.2.3</b3p-commons-csw.version>
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
5.6.x only!

see also https://github.com/B3Partners/b3p-commons-csw/releases/tag/b3p-commons-csw-6.2.3