### PR TITLE
Add the `com.github.eirslett:frontend-maven-plugin` in `dependencyManagment`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,11 @@
                     and check the output for any available updates
                 -->
                 <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <version>1.10.3</version>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.8.1</version>


### PR DESCRIPTION
Add the `com.github.eirslett:frontend-maven-plugin` in `dependencyManagment` so that it gets picked up for automatic update tracking, this is used in the `feat/gbi-component` branch, but feature branches aren't scanned for updatables...