### PR TITLE
[mantis 15294] searchconfig loses its layers sometimes

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Search-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search-config.js
@@ -722,7 +722,7 @@ Ext.define("viewer.components.SearchConfiguration",{
             return;
         }
         // Get old config or create new config object
-        var solrConfig =  {};
+        var solrConfig = searchConfig.solrConfig || {};
         // Check if the solrconfig FilterableCheckboxes object exists
         if(this.solrSearchconfigs.hasOwnProperty(searchconfigId)) {
             // Get the checked solr configs


### PR DESCRIPTION
Old config was not retrieved and saved when it was not opened

Mantis-15294