### PR TITLE
 /viewer/action vervangen door this.tailorMap.getContextPath() + /action

### DIFF
--- a/tailormap-components/projects/core/src/lib/shared/attribute-service/attribute.service.ts
+++ b/tailormap-components/projects/core/src/lib/shared/attribute-service/attribute.service.ts
@@ -10,13 +10,17 @@ import {
   AttributeMetadataResponse,
 } from './attribute-models';
 import { Observable } from 'rxjs';
+import { TailorMapService } from '../../../../../bridge/src/tailor-map.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AttributeService {
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private tailorMap: TailorMapService,
+  ) {
   }
 
   public featureTypeMetadata$(params: AttributeMetadataParameters): Observable<AttributeMetadataResponse> {
@@ -25,7 +29,7 @@ export class AttributeService {
       httpParams = httpParams.set(key, value);
     });
     httpParams = httpParams.set('attributes', 'true');
-    return this.http.get<AttributeMetadataResponse>('/viewer/action/attributes', {params: httpParams});
+    return this.http.get<AttributeMetadataResponse>(this.tailorMap.getContextPath() + '/action/attributes', {params: httpParams});
   }
 
   /**
@@ -42,6 +46,6 @@ export class AttributeService {
       httpParams = httpParams.set(key, value);
     });
     httpParams = httpParams.set('store', '1');
-    return this.http.get<AttributeListResponse>('/viewer/action/attributes', {params: httpParams});
+    return this.http.get<AttributeListResponse>(this.tailorMap.getContextPath() + '/action/attributes', {params: httpParams});
   }
 }

--- a/tailormap-components/projects/core/src/lib/shared/export-service/export.service.ts
+++ b/tailormap-components/projects/core/src/lib/shared/export-service/export.service.ts
@@ -6,13 +6,17 @@ import {
 import {
   ExportFeaturesParameters,
 } from './export-models';
+import { TailorMapService } from '../../../../../bridge/src/tailor-map.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ExportService {
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private tailorMap: TailorMapService,
+  ) {
   }
 
   public exportFeatures (params: ExportFeaturesParameters): any {
@@ -20,7 +24,7 @@ export class ExportService {
     Object.entries(params).forEach(([key, value ]) => {
       httpParams = httpParams.set(key, String(value));
     });
-    return this.http.get ('/viewer/action/downloadfeatures', {params: httpParams, responseType: 'blob', observe: 'response'});
+    return this.http.get (this.tailorMap.getContextPath() + '/action/downloadfeatures', {params: httpParams, responseType: 'blob', observe: 'response'});
   }
 
 }

--- a/tailormap-components/projects/core/src/lib/shared/value-service/value.service.ts
+++ b/tailormap-components/projects/core/src/lib/shared/value-service/value.service.ts
@@ -3,6 +3,7 @@ import {
   HttpClient,
   HttpParams,
 } from '@angular/common/http';
+import { TailorMapService } from '../../../../../bridge/src/tailor-map.service';
 import {
   UniqueValuesResponse,
   ValueParameters,
@@ -14,7 +15,10 @@ import {
 
 export class ValueService {
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private tailorMap: TailorMapService,
+  ) {
   }
 
   public uniqueValues (params: ValueParameters): any {
@@ -22,7 +26,7 @@ export class ValueService {
     Object.entries(params).forEach(([key, value ]) => {
       httpParams = httpParams.set(key, String(value));
     });
-    return this.http.get<UniqueValuesResponse>('/viewer/action/uniquevalues', {params: httpParams});
+    return this.http.get<UniqueValuesResponse>(this.tailorMap.getContextPath() + '/action/uniquevalues', {params: httpParams});
   }
 
 }


### PR DESCRIPTION
In diverse shared services /viewer/action vervangen door this.tailorMap.getContextPath() + /action