### PR TITLE
Feat/gbiw copy adjustments

### DIFF
--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.component.html
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.component.html
@@ -4,13 +4,15 @@
       <mat-expansion-panel>
         <mat-expansion-panel-header>
           <mat-panel-title>
-            Onderliggende features
+            Onderliggende objecten
           </mat-panel-title>
         </mat-expansion-panel-header>
         <div class="tree">
           <tailormap-form-tree
             (nodeClicked)='openForm($event)'
             [features]=[this.data.originalFeature]
+            [isCopy] = true
+            [featuresToCopy] = relatedFeatures
             [feature]=originalFeature></tailormap-form-tree>
         </div>
       </mat-expansion-panel>
@@ -22,23 +24,26 @@
             Instellingen
           </mat-panel-title>
         </mat-expansion-panel-header>
-        <p><mat-checkbox name="deleteRelated" id="deleteRelated" [checked]="false" (change)="setDeleteRelated($event)">Verwijder bestaande gerelateerde features</mat-checkbox></p>
+        <p><mat-checkbox name="deleteRelated" id="deleteRelated" [checked]="false" (change)="setDeleteRelated($event)">Verwijder gerelateerde objecten van alle <br> geselecteerde hoofd objecten</mat-checkbox></p>
+        <p><mat-checkbox name="copyAllRelatedFeatures" id="copyAllRelatedFeatures" [checked]="isAllRelatedFeaturesSet()" (change)="setCopyAllRelatedFeatures($event)">Kopieer alle gerelateerde features</mat-checkbox></p>
       </mat-expansion-panel>
     </mat-accordion>
   </mat-sidenav>
   <mat-sidenav-content>
     <h1 mat-dialog-title cdkDrag cdkDragRootElement=".cdk-overlay-pane">Kopiëren van {{originalFeature.clazz}}</h1>
-    <p>Aantal geselecteerde features: {{this.data.destinationFeatures.length}} </p>
+
+    <p *ngIf="this.data.destinationFeatures.length < 1">Selecteer objecten om naar te kopiëren.</p>
+    <p *ngIf="this.data.destinationFeatures.length > 0">Aantal geselecteerde features: {{this.data.destinationFeatures.length}} </p>
     <mat-divider></mat-divider>
     <div class="container">
       <div class="form">
         <mat-tab-group>
           <mat-tab *ngFor="let tab of formConfig.tabConfig | keyvalue" label="{{tab.value}}">
             <div class="tab">
-              <mat-checkbox name="alles aan/uit" id="toggle" [checked]="true" (change)="toggle($event)">alles aan/uit</mat-checkbox>
+              <mat-checkbox name="alles aan/uit" id="toggle" [checked]="isEverythingChecked(tab.key)" (change)="toggle($event,tab.key)">alles aan/uit</mat-checkbox>
               <mat-divider></mat-divider>
               <div *ngFor="let field of formConfig.fields" class="column">
-                  <span *ngIf="field.column === stringToNumber(tab.key)" class="cellfield">
+                  <span *ngIf="field.tab === stringToNumber(tab.key)" class="cellfield">
                     <mat-checkbox name="{{field.label}}" id="{{field.key}}" [checked]="isFieldChecked(field.key)" (change)="updateFieldToCopy($event)">{{field.label}}</mat-checkbox>
                   </span>
               </div>
@@ -50,7 +55,7 @@
     <div class="actions">
       <button mat-button (click)="settings()">Instellingen</button>
       <button mat-button (click)="cancel()">Annuleren</button>
-      <button mat-button (click)="copy()">Bevestigen</button>
+      <button mat-button [disabled]="this.data.destinationFeatures.length < 1" (click)="copy()"><p matTooltip="Selecteer object(en) om te kopieren">Bevestigen</p></button>
     </div>
   </mat-sidenav-content>
 </mat-sidenav-container>

--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.component.ts
@@ -17,6 +17,7 @@ import { FormActionsService } from '../form-actions/form-actions.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { CopyDialogData } from './form-copy-models';
 import { FeatureInitializerService } from '../../shared/feature-initializer/feature-initializer.service';
+import { FormCopyService } from './form-copy.service';
 
 @Component({
   selector: 'tailormap-form-copy',
@@ -33,41 +34,43 @@ export class FormCopyComponent implements OnInit {
 
   public deleteRelated = false;
 
-  public parentFeature: Feature;
-
   public formConfig: FormConfiguration;
 
-  public featuresToCopy = new Map<number, Map<string, string>>();
+  public relatedFeatures = [];
 
   constructor(public dialogRef: MatDialogRef<FormCopyComponent>,
               @Inject(MAT_DIALOG_DATA) public data: CopyDialogData,
               private configService: FormconfigRepositoryService,
               private actionService: FormActionsService,
               private _snackBar: MatSnackBar,
-              private formConfigRepo: FormconfigRepositoryService,
-              private featureInitializer: FeatureInitializerService) {
+              private featureInitializer: FeatureInitializerService,
+              private formCopyService: FormCopyService) {
   }
 
   public ngOnInit(): void {
+    let fieldsToCopy = new Map<string, string>();
     this.originalFeature = this.data.originalFeature;
-    this.parentFeature = this.data.originalFeature;
-    this.formConfig = this.configService.getFormConfig(this.originalFeature.clazz);
-    const fieldsToCopy = new Map<string, string>();
-    for (const field of this.formConfig.fields) {
-      fieldsToCopy.set(field.key, field.label);
+    if (this.formCopyService.parentFeature != null) {
+      if (this.formCopyService.parentFeature.objecttype === this.data.originalFeature.objecttype) {
+        fieldsToCopy = this.formCopyService.featuresToCopy.get(this.formCopyService.parentFeature['fid']);
+      }
     }
-    this.featuresToCopy.set(this.originalFeature['fid'], fieldsToCopy);
+    this.formCopyService.parentFeature = this.data.originalFeature;
+    this.formConfig = this.configService.getFormConfig(this.originalFeature.clazz);
+    this.formCopyService.featuresToCopy.set(this.originalFeature['fid'], fieldsToCopy);
     if (this.originalFeature.children) {
       for (const child of this.originalFeature.children) {
         const config = this.configService.getFormConfig(child.clazz);
         if (config) {
           // tslint:disable-next-line:no-shadowed-variable
-          const fieldsToCopy = new Map<string, string>();
-          for (const field of config.fields) {
-            fieldsToCopy.set(field.key, field.label);
-          }
+          let fieldsToCopy = new Map<string, string>();
+          this.formCopyService.featuresToCopy.forEach((oldfieldsToCopy, key) => {
+            if (oldfieldsToCopy.get('objecttype') === child.objecttype) {
+                fieldsToCopy = oldfieldsToCopy;
+            }
+          });
           fieldsToCopy.set('objecttype', child.objecttype);
-          this.featuresToCopy.set(child.fid, fieldsToCopy);
+          this.formCopyService.featuresToCopy.set(child.fid, fieldsToCopy);
         }
       }
     }
@@ -133,34 +136,54 @@ export class FormCopyComponent implements OnInit {
   }
 
   public isFieldChecked(event: any) {
-    const fieldsToCopy = this.featuresToCopy.get(this.originalFeature['fid']);
+    const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
     return fieldsToCopy.has(event);
   }
 
-  public toggle(event: any) {
+  public isEverythingChecked(tab: string): boolean {
+    const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
+    for (let i  = 0; i <= this.formConfig.fields.length - 1; i++) {
+      const config = this.formConfig.fields[i];
+      if (config.tab.toString() === tab) {
+        if (!fieldsToCopy.has(config.key)) {
+            return false;
+        }
+      }
+    }
+    return true
+  }
+
+  public toggle(event: any, tab: string) {
     if (!event.checked) {
-      const fieldsToCopy = this.featuresToCopy.get(this.originalFeature['fid']);
-      fieldsToCopy.clear();
-    } else {
-      const fieldsToCopy = this.featuresToCopy.get(this.originalFeature['fid']);
+      const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
       for (let i  = 0; i <= this.formConfig.fields.length - 1; i++) {
         const config = this.formConfig.fields[i];
-        fieldsToCopy.set(config.key, config.label);
+        if (config.tab.toString() === tab) {
+          fieldsToCopy.delete(config.key);
+        }
+      }
+    } else {
+      const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
+      for (let i  = 0; i <= this.formConfig.fields.length - 1; i++) {
+        const config = this.formConfig.fields[i];
+        if (config.tab.toString() === tab) {
+          fieldsToCopy.set(config.key, config.label);
+        }
       }
     }
   }
 
   public updateFieldToCopy(event: any) {
     if (!event.checked) {
-      if (this.featuresToCopy.has(this.originalFeature['fid'])) {
-        const fieldsToCopy = this.featuresToCopy.get(this.originalFeature['fid']);
+      if (this.formCopyService.featuresToCopy.has(this.originalFeature['fid'])) {
+        const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
         if (fieldsToCopy.has(event.source.id)) {
           fieldsToCopy.delete(event.source.id);
         }
       }
     } else {
-      if (this.featuresToCopy.has(this.originalFeature['fid'])) {
-        const fieldsToCopy = this.featuresToCopy.get(this.originalFeature['fid']);
+      if (this.formCopyService.featuresToCopy.has(this.originalFeature['fid'])) {
+        const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.originalFeature['fid']);
         fieldsToCopy.set(event.source.id, event.source.name);
       }
     }
@@ -168,7 +191,7 @@ export class FormCopyComponent implements OnInit {
 
   private getPropertiesToMerge(): any {
     const valuesToCopy = {};
-    const fieldsToCopy = this.featuresToCopy.get(this.parentFeature['fid']);
+    const fieldsToCopy = this.formCopyService.featuresToCopy.get(this.formCopyService.parentFeature['fid']);
     fieldsToCopy.forEach((value, key) => {
       valuesToCopy[key] = this.originalFeature[key];
     })
@@ -177,12 +200,14 @@ export class FormCopyComponent implements OnInit {
 
   private getNewChildFeatures(): Feature[] {
     const newChilds = [];
-    this.featuresToCopy.forEach((fieldsToCopy, key) => {
+    const relatedFeatures = this.relatedFeatures;
+    const parentFeature = this.formCopyService.parentFeature;
+    this.formCopyService.featuresToCopy.forEach((fieldsToCopy, key) => {
       let newChild = {};
-      if (key !== this.parentFeature['fid']) {
+      if (key !== this.formCopyService.parentFeature['fid']) {
         const valuesToCopy = {};
-        for (let i = 0; i <= this.parentFeature.children.length - 1; i++) {
-          const child = this.parentFeature.children[i];
+        for (let i = 0; i <= parentFeature.children.length - 1; i++) {
+          const child = parentFeature.children[i];
           if (child.fid === key) {
             fieldsToCopy.forEach((value, key1) => {
               valuesToCopy[key1] = child[key1];
@@ -190,7 +215,12 @@ export class FormCopyComponent implements OnInit {
           }
         }
         newChild = this.featureInitializer.create(fieldsToCopy.get('objecttype'), valuesToCopy);
-        newChilds.push(newChild);
+        // tslint:disable-next-line:prefer-for-of
+        for (let i = 0; i < relatedFeatures.length; i++) {
+          if (relatedFeatures[i] === key) {
+            newChilds.push(newChild);
+          }
+        }
       }
     });
     return newChilds;
@@ -199,12 +229,30 @@ export class FormCopyComponent implements OnInit {
   public openForm(feature) {
     if (feature) {
         this.originalFeature = feature;
-        this.formConfig = this.formConfigRepo.getFormConfig(this.originalFeature.clazz);
+        this.formConfig = this.configService.getFormConfig(this.originalFeature.clazz);
     }
   }
 
   public setDeleteRelated(event: any) {
     this.deleteRelated = !this.deleteRelated;
+  }
+
+  public setCopyAllRelatedFeatures(event: any) {
+    if (this.formCopyService.parentFeature.children) {
+       this.relatedFeatures = [];
+      // tslint:disable-next-line:prefer-for-of
+       for (let i = 0; i < this.formCopyService.parentFeature.children.length; i++) {
+         this.relatedFeatures.push(this.formCopyService.parentFeature.children[i].fid);
+       }
+    }
+  }
+
+  public isAllRelatedFeaturesSet(): boolean {
+    if (this.formCopyService.parentFeature.children) {
+      return this.formCopyService.parentFeature.children.length === this.relatedFeatures.length;
+    } else {
+      return false;
+    }
   }
 
   public settings() {

--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.spec.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormCopyService } from './form-copy.service';
+
+describe('FormCopyService', () => {
+  let service: FormCopyService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FormCopyService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Feature } from '../../shared/generated';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class FormCopyService {
 

--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
@@ -1,9 +1,15 @@
 import { Injectable } from '@angular/core';
+import { Feature } from '../../shared/generated';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FormCopyService {
 
-  constructor() { }
+  public featuresToCopy = new Map<number, Map<string, string>>();
+
+  public parentFeature: Feature;
+
+  constructor() {
+  }
 }

--- a/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-copy/form-copy.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FormCopyService {
+
+  constructor() { }
+}

--- a/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.html
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.html
@@ -5,7 +5,10 @@
           <mat-icon class="mat-icon-rtl-mirror">
           </mat-icon>
         </button>
-        <span class="{{node.selected ? 'selected' : ''}} {{node?.feature.id ? '' : 'newNode'}}">{{node.name}}</span>
+        <mat-checkbox *ngIf="isCopy" name="{{node?.feature.id}}" id="{{node?.feature.id}}" (change)="addFeatureForCopy($event, node?.feature.id)" [checked]="isFeatureForCopyChecked(node?.feature.id) " ></mat-checkbox>
+        <span class="{{node.selected ? 'selected' : ''}} {{node?.feature.id ? '' : 'newNode'}}">
+
+          {{node.name}}</span>
       </div>
     </mat-tree-node>
 

--- a/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.ts
@@ -41,7 +41,7 @@ export class FormTreeComponent implements OnInit, OnChanges {
   public features: Feature[];
 
   @Input()
-  public isCopy =false;
+  public isCopy = false;
 
   @Input()
   public feature: Feature;
@@ -107,17 +107,18 @@ export class FormTreeComponent implements OnInit, OnChanges {
     return nodes;
   }
 
-  public isFeatureForCopyChecked(featureId: number): boolean{
-    let isIn = false;
-    for (let i = 0; i < this.featuresToCopy.length; i++){
-      if (featureId === this.featuresToCopy[i]){
+  public isFeatureForCopyChecked(featureId: number): boolean {
+    const isIn = false;
+    // tslint:disable-next-line:prefer-for-of
+    for (let i = 0; i < this.featuresToCopy.length; i++) {
+      if (featureId === this.featuresToCopy[i]) {
         return true;
       }
     }
     return isIn;
   }
 
-  public addFeatureForCopy(event: any, featureId: number){
+  public addFeatureForCopy(event: any, featureId: number) {
     if (event.checked) {
       this.featuresToCopy.push(featureId);
     }

--- a/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-tree/form-tree.component.ts
@@ -41,7 +41,13 @@ export class FormTreeComponent implements OnInit, OnChanges {
   public features: Feature[];
 
   @Input()
+  public isCopy =false;
+
+  @Input()
   public feature: Feature;
+
+  @Input()
+  public featuresToCopy = [];
 
   public treeControl = new FlatTreeControl<FlatNode>(node => node.level, node => node.expandable);
 
@@ -99,6 +105,30 @@ export class FormTreeComponent implements OnInit, OnChanges {
       });
     });
     return nodes;
+  }
+
+  public isFeatureForCopyChecked(featureId: number): boolean{
+    let isIn = false;
+    for (let i = 0; i < this.featuresToCopy.length; i++){
+      if (featureId === this.featuresToCopy[i]){
+        return true;
+      }
+    }
+    return isIn;
+  }
+
+  public addFeatureForCopy(event: any, featureId: number){
+    if (event.checked) {
+      this.featuresToCopy.push(featureId);
+    }
+     else {
+      for (let i = 0; i < this.featuresToCopy.length; i++) {
+        if (featureId === this.featuresToCopy[i]) {
+          this.featuresToCopy.splice(i, 1);
+        }
+      }
+    }
+
   }
 
   public getNodeClassName(node: FlatNode) {

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/CopyWorkflow.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/CopyWorkflow.ts
@@ -36,10 +36,16 @@ export class CopyWorkflow extends Workflow {
       (features: Feature[]) => {
         if (features && features.length > 0) {
           const feat = features[0];
-          if (!this.hasDestinationFeature(feat)) {
-            this.destinationFeatures.push(feat);
+          if ( this.feature.clazz === feat.clazz) {
+            if (!this.hasDestinationFeature(feat)) {
+              this.destinationFeatures.push(feat);
+            }
+            this.highlightDestinationFeatures();
+          } else {
+            this.snackBar.open('Geselecteerde feature is niet van hetzelfde type', '', {
+              duration: 5000,
+            });
           }
-          this.highlightDestinationFeatures();
         }
       },
       error => {

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyRESTActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyRESTActionBean.java
@@ -104,9 +104,14 @@ public class ProxyRESTActionBean implements ActionBean, Auditable {
     }
 
     private URL constructURL() throws MalformedURLException {
+        HttpServletRequest request = getContext().getRequest();
+        String parentId = "";
+        if(request.getParameter("parentId") != null) {
+            parentId = "?parentId="+request.getParameter("parentId");
+        }
         URL requestUrl = new URL(context.getRequest().getRequestURL().toString());
         String port = context.getServletContext().getInitParameter("flamingo.restproxy.port");
-        String constructedURL = "http://localhost:" + (port != null ? port : "8084") + "/form-api" + url;
+        String constructedURL = "http://localhost:" + (port != null ? port : "8084") + "/form-api" + url + parentId;
         URL u = new URL(constructedURL);
         return u;
     }


### PR DESCRIPTION
Fixed issues:
- GBIW-237 Onderliggende objecten niet standaard meenemen
- GBIW-213 Onderkant Copyform valt buiten scherm
- GBIW-223 Label "aantal geselecteerde features: 0" aanpassen
- GBIW-225 Attributen standaard uit
- GBIW-236 Label knop "Instellingen" aanpassen --> "Onderliggende objecten"
- GBIW-222 Meerdere featuretypes te selecteren
- GBIW-239 Labels veranderen: features --> objecten
- GBIW-235 Velden paspoort in verkeerde tab
- GBIW-224 Knop bevestigen disablen
- GBIW-238 Extra instelling: neem alle onderliggende objecten mee
- GBIW-195 Onthouden van eerdere input