### PR TITLE
while instead of do while, prevents error when updating empty service

### DIFF
--- a/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
+++ b/viewer-config-persistence/src/main/java/nl/b3p/viewer/config/services/WMSService.java
@@ -582,8 +582,8 @@ public class WMSService extends GeoService implements Updatable {
         }
         
         Set<String> visitedLayerNames = new HashSet();
-        
-        do {
+
+        while(!q.isEmpty()) {
             // Remove from head of queue
             Pair<Layer,Layer> p = q.remove();
             
@@ -620,7 +620,7 @@ public class WMSService extends GeoService implements Updatable {
                 // Add add end of queue
                 q.add(new ImmutablePair(child, thisLayer));
             }
-        } while(!q.isEmpty());
+        }
     }
     
     private void removeOrphanLayersAfterUpdate(UpdateResult result) {


### PR DESCRIPTION
@matthijsln do you know why this was a do-while? Looks like a faulty assumption (a service is never empty), but maybe I'm missing something