### PR TITLE
Allow date fields to have time associated as a editable field

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Edit.js
+++ b/viewer/src/main/webapp/viewer-html/components/Edit.js
@@ -952,7 +952,7 @@ Ext.define("viewer.components.Edit", {
             // Ext uses PHP conventions! see:
             // https://docs.sencha.com/extjs/6.2.1/classic/Ext.Date.html
             options.format = attribute.type === 'date' ? 'd-m-Y' : 'd-m-Y H:i:s';
-            options.altFormats = 'd-m-y|d-M-Y';
+            options.altFormats = 'd-m-y|d-M-Y|d-m-Y H:i:s';
             // ISO 8601 (local time + UTC offset)
             options.submitFormat = 'c';
             input = Ext.create("Ext.form.field.Date", options);


### PR DESCRIPTION
This used to work for old ExtJS versions but now the default Flamingo format of `dd-mm-yyyy hh:mm:ss` fails to parse in ExtJS resulting in an empty date picker.

Adding extra `altFormats` resolves this.

Related: 
- mantis-15562
- mantis-15541