### PR TITLE
GBIW-308 local quickfix for layerids returned as string instead of nu…

### DIFF
--- a/tailormap-components/projects/core/src/lib/user-interface/attributelist/layer.service.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/attributelist/layer.service.ts
@@ -130,11 +130,13 @@ export class LayerService {
     this.layers.splice(0, this.layers.length);
 
     const vc = this.tailorMapService.getViewerController();
-    const layerIds = vc.getVisibleLayers();
+    // NOTE castToStrings false, we want numbers, but still strings are returned (solution is parked, quickfix below).
+    const layerIds = vc.getVisibleLayers(false);
     // console.log(layerIds);
 
     layerIds.forEach(layerId => {
-      this.addLayer(layerId);
+      // NOTE quickfix for vc.getVisibleLayers returning strings instead of numbers
+      this.addLayer(Number(layerId));
     });
 
     this.layersSubject.next(this.layers);


### PR DESCRIPTION
…mber
Ik heb lokaal zo dicht mogelijk bij het probleem de oplossing ingebouwd, Kan daar dan ook weer eenvoudig uitgezet worden als er t.z.t. een wijziging in  vc.getVisibleLayers doorgevoerd wordt.