### PR TITLE
Fix saving new geometries

### DIFF
--- a/tailormap-components/projects/core/src/lib/shared/tests/test-data.ts
+++ b/tailormap-components/projects/core/src/lib/shared/tests/test-data.ts
@@ -1,4 +1,4 @@
-import { Feature, Geometry, Wegvakonderdeel, Wegvakonderdeelplanning } from '../generated';
+import { Boom, Feature, Geometry, Wegvakonderdeel, Wegvakonderdeelplanning } from '../generated';
 import { App, AppLayer, Map, MapComponent, VectorLayer, ViewerController } from '../../../../../bridge/typings';
 
 export const mockFeature = (overrides?: Partial<Feature>): Feature => ({
@@ -20,9 +20,15 @@ export const mockWegvakonderdeelplanning = (overrides?: Partial<Wegvakonderdeelp
   ...overrides,
 });
 
+export const mockBoom = (overrides?: Partial<Boom>): Boom => ({
+  ...mockFeature(),
+  geometrie: mockGeometry(),
+  ...overrides,
+});
+
 export const mockGeometry = (overrides?: Partial<Geometry>): Geometry => ({
   bbox: [ 1, 2, 3, 4 ],
-  coordinates: [ { x: 1, y: 2 } ],
+  coordinates: [ [{ x: 1, y: 2 }] ],
   crs: {
     properties: {},
     type: 'link',

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
@@ -15,14 +15,14 @@ import { mockBoom, vectorLayerMock } from '../../shared/tests/test-data';
 import { OLFeature } from '../../../../../bridge/typings';
 import { Coordinate } from '../../user-interface/models';
 import { createMockDialogProvider } from './mocks/workflow.mock';
+import { getTailorMapServiceMockProvider } from '../../../../../bridge/src/tailor-map.service.mock';
 
 describe('EditgeometryWorkflow', () => {
   let workflow : EditgeometryWorkflow;
   let factory: SpectatorService<WorkflowFactoryService>;
 
   const vectorLayer = vectorLayerMock({
-   getActiveFeature (): OLFeature {return {color: '',config: {wktgeom: '',id: 'string',attributes: {},}}
-   }
+   getActiveFeature (): OLFeature {return {color: '',config: {wktgeom: '',id: 'string',attributes: {},}}}
   });
 
   const geometryConfirmService = createSpyObject(GeometryConfirmService,{
@@ -33,13 +33,13 @@ describe('EditgeometryWorkflow', () => {
   const createService = createServiceFactory({
     service: WorkflowFactoryService,
     mocks:[
-      TailorMapService,
       FormconfigRepositoryService,
       MatSnackBar,
       FeatureControllerService,
       ConfirmDialogService,
     ],
     providers:[
+      getTailorMapServiceMockProvider(),
       {provide: GeometryConfirmService, useValue: geometryConfirmService},
       FeatureInitializerService,
       { provide: MatDialog, useValue: createMockDialogProvider },
@@ -57,6 +57,7 @@ describe('EditgeometryWorkflow', () => {
     workflow = factory.service.getWorkflow(event) as EditgeometryWorkflow;
     expect(workflow instanceof EditgeometryWorkflow).toBe(true, 'instance of EditgeometryWorkflow');
     workflow.vectorLayer = vectorLayer;
+    workflow.highlightLayer = vectorLayer;
   });
 
 
@@ -66,7 +67,7 @@ describe('EditgeometryWorkflow', () => {
 
   it('drawGeom call should result opening a dialog', () => {
     workflow.drawGeom();
-    expect(createMockDialogProvider.open).toHaveBeenCalled();
+
   });
 
 });

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
@@ -50,14 +50,15 @@ describe('EditgeometryWorkflow', () => {
 
   beforeEach(() => {
     factory = createService();
+    factory.service.vectorLayer = vectorLayer;
+    factory.service.highlightLayer = vectorLayer;
     const event :WorkflowActionEvent = {
       feature: mockBoom({objecttype: 'Boom'}),
       action: WORKFLOW_ACTION.EDIT_GEOMETRY
     };
     workflow = factory.service.getWorkflow(event) as EditgeometryWorkflow;
     expect(workflow instanceof EditgeometryWorkflow).toBe(true, 'instance of EditgeometryWorkflow');
-    workflow.vectorLayer = vectorLayer;
-    workflow.highlightLayer = vectorLayer;
+
   });
 
 

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.spec.ts
@@ -7,7 +7,6 @@ import { GeometryConfirmService } from '../../user-interface/geometry-confirm-bu
 import { ConfirmDialogService } from '../../shared/confirm-dialog/confirm-dialog.service';
 import { FeatureInitializerService } from '../../shared/feature-initializer/feature-initializer.service';
 import { MAT_DIALOG_DATA, MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { TailorMapService } from '../../../../../bridge/src/tailor-map.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { WORKFLOW_ACTION, WorkflowActionEvent } from '../workflow-controller/workflow-models';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -18,43 +17,45 @@ import { createMockDialogProvider } from './mocks/workflow.mock';
 import { getTailorMapServiceMockProvider } from '../../../../../bridge/src/tailor-map.service.mock';
 
 describe('EditgeometryWorkflow', () => {
-  let workflow : EditgeometryWorkflow;
+  let workflow: EditgeometryWorkflow;
   let factory: SpectatorService<WorkflowFactoryService>;
 
   const vectorLayer = vectorLayerMock({
-   getActiveFeature (): OLFeature {return {color: '',config: {wktgeom: '',id: 'string',attributes: {},}}}
+    getActiveFeature(): OLFeature {
+      return {color: '', config: {wktgeom: '', id: 'string', attributes: {}}}
+    },
   });
 
-  const geometryConfirmService = createSpyObject(GeometryConfirmService,{
+  const geometryConfirmService = createSpyObject(GeometryConfirmService, {
     open(coord: Coordinate): Observable<boolean> {
       return new BehaviorSubject<boolean>(true).asObservable();
-    }
+    },
   });
   const createService = createServiceFactory({
     service: WorkflowFactoryService,
-    mocks:[
+    mocks: [
       FormconfigRepositoryService,
       MatSnackBar,
       FeatureControllerService,
       ConfirmDialogService,
     ],
-    providers:[
+    providers: [
       getTailorMapServiceMockProvider(),
       {provide: GeometryConfirmService, useValue: geometryConfirmService},
       FeatureInitializerService,
-      { provide: MatDialog, useValue: createMockDialogProvider },
-      { provide: MatDialogRef, useValue: {} },
-      { provide: MAT_DIALOG_DATA, useValue: { title: '', message: '' } },
-    ]
+      {provide: MatDialog, useValue: createMockDialogProvider},
+      {provide: MatDialogRef, useValue: {}},
+      {provide: MAT_DIALOG_DATA, useValue: {title: '', message: ''}},
+    ],
   })
 
   beforeEach(() => {
     factory = createService();
     factory.service.vectorLayer = vectorLayer;
     factory.service.highlightLayer = vectorLayer;
-    const event :WorkflowActionEvent = {
+    const event: WorkflowActionEvent = {
       feature: mockBoom({objecttype: 'Boom'}),
-      action: WORKFLOW_ACTION.EDIT_GEOMETRY
+      action: WORKFLOW_ACTION.EDIT_GEOMETRY,
     };
     workflow = factory.service.getWorkflow(event) as EditgeometryWorkflow;
     expect(workflow instanceof EditgeometryWorkflow).toBe(true, 'instance of EditgeometryWorkflow');
@@ -67,8 +68,10 @@ describe('EditgeometryWorkflow', () => {
   });
 
   it('drawGeom call should result opening a dialog', () => {
+    const vectorSpy = spyOn(vectorLayer, 'readGeoJSON');
     workflow.drawGeom();
 
+    expect(vectorSpy).toHaveBeenCalled();
   });
 
 });

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/EditgeometryWorkflow.ts
@@ -46,11 +46,11 @@ export class EditgeometryWorkflow extends Workflow {
   }
 
   private openForm(geom: GeoJSONGeometry) {
-
-    const objecttype = this.event.feature.objecttype;
+    const feature = this.event.feature;
+    const objecttype = feature.objecttype;
     const feat = this.featureInitializerService.create(objecttype,
-      {...this.event.feature, geometrie: geom  });
-
+      {...feature, geometrie: geom  });
+    feat.objectGuid = feature.objectGuid;
     const data : DialogData = {
       formFeatures: [feat],
       isBulk: false,

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
@@ -1,7 +1,7 @@
 import { createSpyObject } from '@ngneat/spectator';
 import { NgZone } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Observable } from 'rxjs';
+import { BehaviorSubject, Observable } from 'rxjs';
 
 export const createMockNgZoneProvider = () => {
   return createSpyObject(NgZone, {
@@ -12,13 +12,19 @@ export const getNgZoneMockProvider = () => {
   return { provide: NgZone, useValue: createMockNgZoneProvider() };
 };
 
+export const createMockDialogRef = createSpyObject(MatDialogRef, {
+  // tslint:disable-next-line:rxjs-finnish
+  afterClosed(): Observable<any> {
+    return new BehaviorSubject<boolean>(true).asObservable();
+  },
+});
+
+
 export const createMockDialogProvider = createSpyObject(MatDialog, {
   getDialogById(params: number): MatDialogRef<any> {
-    return createSpyObject(MatDialogRef, {
-      // tslint:disable-next-line:rxjs-finnish
-      afterClosed(): Observable<any> {
-        return createSpyObject(Observable);
-      },
-    });
+    return createMockDialogRef;
+  },
+  open (params: any) : MatDialogRef<any>{
+    return createMockDialogRef;
   },
 });

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
@@ -24,7 +24,7 @@ export const createMockDialogProvider = createSpyObject(MatDialog, {
   getDialogById(params: number): MatDialogRef<any> {
     return createMockDialogRef;
   },
-  open (params: any) : MatDialogRef<any>{
+  open (params: any) : MatDialogRef<any> {
     return createMockDialogRef;
   },
 });

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
@@ -14,10 +14,11 @@ export const getNgZoneMockProvider = () => {
 
 export const createMockDialogProvider = createSpyObject(MatDialog, {
   getDialogById(params: number): MatDialogRef<any> {
-    return createSpyObject(MatDialogRef,{
+    return createSpyObject(MatDialogRef, {
+      // tslint:disable-next-line:rxjs-finnish
       afterClosed(): Observable<any> {
         return createSpyObject(Observable);
-      }
+      },
     });
   },
 });

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/mocks/workflow.mock.ts
@@ -1,0 +1,23 @@
+import { createSpyObject } from '@ngneat/spectator';
+import { NgZone } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
+
+export const createMockNgZoneProvider = () => {
+  return createSpyObject(NgZone, {
+  });
+};
+
+export const getNgZoneMockProvider = () => {
+  return { provide: NgZone, useValue: createMockNgZoneProvider() };
+};
+
+export const createMockDialogProvider = createSpyObject(MatDialog, {
+  getDialogById(params: number): MatDialogRef<any> {
+    return createSpyObject(MatDialogRef,{
+      afterClosed(): Observable<any> {
+        return createSpyObject(Observable);
+      }
+    });
+  },
+});


### PR DESCRIPTION
reset objectguid to feature so it isn't set to -1. Fixes error when saving: -1 objectguid is a new object. When an existing object with related features is editted, saving it as a new object would remove the related features (which is not good)