### PR TITLE
Bump geotools.version 24.1 ➜ 24.2 en b3p-commons-csw 6.3.1 ➜ 6.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <!-- when updating geotools also check jts and b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>24.1</geotools.version>
-        <b3p-commons-csw.version>6.3.1</b3p-commons-csw.version>
+        <!-- when updating geotools also check b3p-commons-csw (and maybe jts) or you will end up in transitive dependency hell -->
+        <geotools.version>24.2</geotools.version>
+        <b3p-commons-csw.version>6.3.2</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
- [x] wacht op https://github.com/B3Partners/b3p-commons-csw/pull/67 en release van b3p-commons-csw