### PR TITLE
[Backport v5.4.x] Bump maven-surefire-plugin.version from 3.0.0-M4 to 3.0.0-M5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         or as part of a profile, see eg. 'gh-action' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <tomcat.version>7.0.104</tomcat.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <tomcat.version>7.0.107</tomcat.version>
+        <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
     </properties>
     <dependencyManagement>
         <!--


### PR DESCRIPTION
Bumps `maven-surefire-plugin.version` from 3.0.0-M4 to 3.0.0-M5. Backports #2020

Updates `maven-surefire-plugin` from 3.0.0-M4 to 3.0.0-M5
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.0.0-M4...surefire-3.0.0-M5)

Updates `maven-failsafe-plugin` from 3.0.0-M4 to 3.0.0-M5
- [Release notes](https://github.com/apache/maven-surefire/releases)
- [Commits](https://github.com/apache/maven-surefire/compare/surefire-3.0.0-M4...surefire-3.0.0-M5)

Signed-off-by: dependabot[bot] <support@github.com>