### PR TITLE
Produceer Java 11 artifacts

### DIFF
--- a/.github/workflows/ubuntu-maven.yml
+++ b/.github/workflows/ubuntu-maven.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [ubuntu-20.04]
     strategy:
       matrix:
-        java: [1.8, 11]
+        java: [11]
 
     steps:
       - uses: actions/checkout@v2
@@ -59,7 +59,6 @@ jobs:
           mvn -e verify -B -Pgh-action -pl '!viewer-admin'
           mvn -e verify -B -Pgh-action -pl 'viewer-admin'
       - name: build javadoc
-        if: ${{ matrix.java == '1.8' }}
         run: |
           mvn javadoc:javadoc
           mvn javadoc:test-javadoc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ timestamps {
                 numToKeepStr: '5']
             ]]);
 
-        final def jdks = ['OpenJDK11','OpenJDK8']
+        final def jdks = ['OpenJDK11']
 
         stage("Prepare") {
              checkout scm
@@ -27,9 +27,6 @@ timestamps {
                     try {
                         if (jdkTestName == 'OpenJDK11') {
                             sh "keytool -importcert -file ./EVRootCA.cer -alias EVRootCA -keystore $JAVA_HOME/lib/security/cacerts -storepass 'changeit' -v -noprompt -trustcacerts"
-                        }
-                        if (jdkTestName == 'OpenJDK8') {
-                            sh "keytool -importcert -file ./EVRootCA.cer -alias EVRootCA -keystore $JAVA_HOME/jre/lib/security/cacerts -storepass changeit -v -noprompt -trustcacerts"
                         }
                     } catch (err) {
                         /* possibly already imported cert */
@@ -69,13 +66,6 @@ timestamps {
                         sh "docker stop oracle-flamingo"
                     }
                 }
-
-                if (jdkTestName == 'OpenJDK11') {
-                    stage("cleanup Java 11 packages") {
-                        echo "Removing Java 11 built artifacts from local repository"
-                        sh "mvn build-helper:remove-project-artifact"
-                    }
-                }
             }
         }
 
@@ -87,7 +77,7 @@ timestamps {
             sh "curl -s https://codecov.io/bash | bash"
         }
 
-        withEnv(["JAVA_HOME=${ tool 'OpenJDK8' }", "PATH+MAVEN=${tool 'Maven CURRENT'}/bin:${env.JAVA_HOME}/bin"]) {
+        withEnv(["JAVA_HOME=${ tool 'OpenJDK11' }", "PATH+MAVEN=${tool 'Maven CURRENT'}/bin:${env.JAVA_HOME}/bin"]) {
             if (env.BRANCH_NAME == 'master' && env.NODE_NAME == 'master') {
                 stage("Docker image build & push") {
                     echo "Create a docker image of the master branch when running on the master node"

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>org.flamingo-mc</groupId>
     <artifactId>docker</artifactId>
     <version>5.9.0-SNAPSHOT</version>
     <packaging>docker</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.flamingo-mc</groupId>
@@ -39,7 +39,7 @@
     </licenses>
     <properties>
         <flamingo.version>5.9.0-SNAPSHOT</flamingo.version>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <node.version>v14.15.5</node.version>
         <project.build.sourceVersion>${java.version}</project.build.sourceVersion>
         <project.build.targetVersion>${java.version}</project.build.targetVersion>
@@ -191,6 +191,21 @@
                 <version>2.12.1</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jaxb.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.impl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${activation.api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.flamingo-mc</groupId>
                 <artifactId>viewer-config-persistence</artifactId>
                 <type>test-jar</type>
@@ -264,14 +279,12 @@
                 <artifactId>lucene-core</artifactId>
                 <version>4.6.0</version>
             </dependency>
-
             <dependency>
                 <artifactId>solr-solrj</artifactId>
                 <groupId>org.apache.solr</groupId>
                 <version>4.6.0</version>
                 <scope>compile</scope>
             </dependency>
-
             <!-- viewer-commons -->
             <dependency>
                 <groupId>junit</groupId>
@@ -358,7 +371,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
             <!-- viewer-config-persistence -->
             <dependency>
                 <groupId>commons-beanutils</groupId>
@@ -375,7 +387,6 @@
                 <artifactId>web-commons</artifactId>
                 <version>${flamingo.version} </version>
             </dependency>
-
             <dependency>
                 <groupId>org.geotools</groupId>
                 <artifactId>gt-wms</artifactId>
@@ -452,7 +463,6 @@
                 <artifactId>jakarta.mail</artifactId>
                 <version>${jakarta.mail.version}</version>
             </dependency>
-
             <!-- Flamingo dependencies -->
             <dependency>
                 <groupId>org.apache.poi</groupId>
@@ -853,7 +863,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>[3.3.9,)</version>
+                                    <version>[3.6.0,)</version>
                                 </requireMavenVersion>
                                 <requireJavaVersion>
                                     <version>${java.version}</version>
@@ -953,36 +963,6 @@
                 <test.persistence.unit>viewer-config-microsoft_sql_server</test.persistence.unit>
                 <test.skip.integrationtests>true</test.skip.integrationtests>
             </properties>
-        </profile>
-        <profile>
-            <id>jdk11+</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <properties>
-                <java.version>8</java.version>
-                <!-- project.build.targetVersion>1.8</project.build.targetVersion -->
-                <!-- maven.compiler.target>1.8</maven.compiler.target -->
-            </properties>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>jakarta.xml.bind</groupId>
-                        <artifactId>jakarta.xml.bind-api</artifactId>
-                        <version>${jaxb.api.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.glassfish.jaxb</groupId>
-                        <artifactId>jaxb-runtime</artifactId>
-                        <version>${jaxb.impl.version}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>jakarta.activation</groupId>
-                        <artifactId>jakarta.activation-api</artifactId>
-                        <version>${activation.api.version}</version>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
         </profile>
     </profiles>
     <modules>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -1,23 +1,18 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>org.flamingo-mc</groupId>
     <artifactId>viewer-admin</artifactId>
     <packaging>war</packaging>
-
     <parent>
         <groupId>org.flamingo-mc</groupId>
         <artifactId>flamingo-mc</artifactId>
         <version>5.9.0-SNAPSHOT</version>
     </parent>
     <name>viewer-admin</name>
-
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
     </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/viewer-commons/pom.xml
+++ b/viewer-commons/pom.xml
@@ -1,11 +1,8 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>org.flamingo-mc</groupId>
     <artifactId>viewer-commons</artifactId>
     <packaging>jar</packaging>
-
     <parent>
         <groupId>org.flamingo-mc</groupId>
         <artifactId>flamingo-mc</artifactId>
@@ -89,37 +86,21 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>fluent-hc</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-cache</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
     </dependencies>
-    <profiles>
-        <profile>
-            <id>jdk11+</id>
-            <activation>
-                <jdk>[11,)</jdk>
-            </activation>
-            <properties>
-                <java.version>11</java.version>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.xml.bind</groupId>
-                    <artifactId>jakarta.xml.bind-api</artifactId>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -1,18 +1,14 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <groupId>org.flamingo-mc</groupId>
     <artifactId>viewer</artifactId>
     <packaging>war</packaging>
-
     <parent>
         <groupId>org.flamingo-mc</groupId>
         <artifactId>flamingo-mc</artifactId>
         <version>5.9.0-SNAPSHOT</version>
     </parent>
     <name>viewer</name>
-
     <properties>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <minify.outputdir>${project.name}-${project.version}/viewer-html</minify.outputdir>
@@ -213,7 +209,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
**NB** backwards incompatible

produceer expliciet java 11 artifacts (dat gebeurde de laatste tijd 'per ongeluk' nog al eens omdat verschillende ontwikkelaars geen java 8 meer installeren)


NB deze PR zorgt niet voor het oplossen van zaken als:
- verbod op delen van packages over verschillende jar files
- oplossen van deprecations
- bouwen van jpms modules
- ...