### PR TITLE
Gebruik Node v14.15.5 voor de Maven builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <properties>
         <flamingo.version>5.9.0-SNAPSHOT</flamingo.version>
         <java.version>1.8</java.version>
+        <node.version>v14.15.5</node.version>
         <project.build.sourceVersion>${java.version}</project.build.sourceVersion>
         <project.build.targetVersion>${java.version}</project.build.targetVersion>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -222,6 +222,7 @@
                     <filesets>
                         <fileset>
                             <directory>${tailormap-components.dist.dir}</directory>
+                            <directory>${tailormap-components.dist.dir}/../node_modules</directory>
                         </fileset>
                     </filesets>
                 </configuration>
@@ -261,8 +262,7 @@
                 <configuration>
                     <workingDirectory>${tailormap-components.source.dir}</workingDirectory>
                     <installDirectory>${project.build.directory}/</installDirectory>
-                    <nodeVersion>v13.8.0</nodeVersion>
-                    <npmVersion>6.14.8</npmVersion>
+                    <nodeVersion>${node.version}</nodeVersion>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
gebruik Node 14.15.5 (en de ingebouwde npm) voor builds met Maven