### PR TITLE
[Backport v5.6.x] Bump postgresql from 42.2.18 to 42.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.2.18</postgresql.version>
-        <mssql.version>8.4.1.jre8</mssql.version>
+        <postgresql.version>42.2.19</postgresql.version>
+        <mssql.version>9.2.0.jre8</mssql.version>
         <oracle.version>21.1.0.0</oracle.version>
         <apache.poi.version>4.1.2</apache.poi.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>


### PR DESCRIPTION
backport #2357 naar 5.6.x

Bumps [postgresql](https://github.com/pgjdbc/pgjdbc) from 42.2.18 to 42.2.19.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/REL42.2.19/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/compare/REL42.2.18...REL42.2.19)

Signed-off-by: dependabot[bot] <support@github.com>