### PR TITLE
15935: Fixed always active bug for simple drawing + fixed some layout issues

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/ScreenPopup.js
+++ b/viewer/src/main/webapp/viewer-html/common/ScreenPopup.js
@@ -53,7 +53,8 @@ Ext.define ("viewer.components.ScreenPopup",{
             changeableSize:true,
             items:null,
             position : 'center',
-            useExtLayout: false
+            useExtLayout: false,
+            usePopupScrolling: true
         }
     },
     component: null,
@@ -77,13 +78,13 @@ Ext.define ("viewer.components.ScreenPopup",{
             layout: 'fit',
             modal: false,
             renderTo: Ext.getBody(),
-            scrollable: true,
+            scrollable: this.config.details.usePopupScrolling,
             constrainHeader: true,
             iconCls: this.config.iconCls || "",
             bodyStyle: {},
-            cls: "screen-popup"
+            cls: "screen-popup",
         };
-        
+
         if(this.config.popupIcon) {
             config.header = {
                 xtype: 'svgpanelheader',
@@ -261,16 +262,16 @@ Ext.define ("viewer.components.ScreenPopup",{
         }
         if (updatedZIndex) {
             this.zIndex = updatedZIndex + 1;
-        }  
+        }
     },
     getPosition:function(){
         return this.popupWin.getPosition();
     },
     getWidth: function(){
-        return this.popupWin.getWidth();        
+        return this.popupWin.getWidth();
     },
     getHeight: function(){
-        return this.popupWin.getHeight();        
+        return this.popupWin.getHeight();
     },
     bringToFront: function(){
         this.computeMaxZIndex();

--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersVectorLayer.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/openlayers/OpenLayersVectorLayer.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2012-2017 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -17,7 +17,7 @@
 /* global Ext */
 
 /**
- * @class 
+ * @class
  * @description A drawable vector layer
  */
 Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
@@ -262,7 +262,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         this.setTranslate(false);
     },
 
-    getActiveFeature : function(){        
+    getActiveFeature : function(){
         var olFeature = this.getFrameworkLayer().features[0];
         if (olFeature){
             var feature = this.fromOpenLayersFeature(olFeature);
@@ -277,7 +277,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
     },
 
     /**
-     * Gets a feature by the id. 
+     * Gets a feature by the id.
      *
      */
     getFeatureById : function (id){
@@ -353,7 +353,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         // call superclass method to register keydown events
         this.bringToFront();
         this.superclass.drawFeature.call(this, type);
-        
+
         if (type === "Point") {
             this.activeDrawFeatureControl = this.point;
             this.point.activate();
@@ -390,21 +390,30 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         if (this.point.active){
             this.point.cancel();
             this.point.deactivate();
-        }if (this.line.active){
+        }
+        if (this.line.active){
             this.line.cancel();
             this.line.deactivate();
-        }if (this.polygon.active){
+        }
+        if (this.polygon.active){
             this.polygon.cancel();
             this.polygon.deactivate();
-        }if (this.circle.active){
+        }
+        if (this.circle.active){
             this.circle.cancel();
             this.circle.deactivate();
-        }if (this.box.active){
+        }
+        if (this.box.active){
             this.box.cancel();
             this.box.deactivate();
-        }if (this.freehand.active){
+        }
+        if (this.freehand.active){
             this.freehand.cancel();
             this.freehand.deactivate();
+        }
+        if (this.freehandLine.active){
+            this.freehandLine.cancel();
+            this.freehandLine.deactivate();
         }
         this.activeDrawFeatureControl = null;
     },
@@ -454,7 +463,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         var feature = this.fromOpenLayersFeature (object.feature);
         this.fireEvent(viewer.viewercontroller.controller.Event.ON_ACTIVE_FEATURE_CHANGED,this,feature);
     },
-    
+
     /**
      * Called when a feature is modified.
      */
@@ -483,7 +492,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         }
         this.fireEvent(viewer.viewercontroller.controller.Event.ON_FEATURE_ADDED,this,feature);
     },
-    
+
     /**
      * Puts an openlayersfeature in editmode and fires an event: viewer.viewercontroller.controller.Event.ON_ACTIVE_FEATURE_CHANGED
      * TODO: fix the selecting of a newly added point (after adding another geometry first)
@@ -494,7 +503,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
         var featureObject = this.fromOpenLayersFeature (feature);
         this.fireEvent(viewer.viewercontroller.controller.Event.ON_ACTIVE_FEATURE_CHANGED,this,featureObject);
     },
-    
+
     /**
      * Converts this feature to a OpenLayersFeature
      * @return The OpenLayerstype feature
@@ -617,7 +626,7 @@ Ext.define("viewer.viewercontroller.openlayers.OpenLayersVectorLayer",{
     /**
      * @see viewer.viewercontroller.openlayers.OpenLayersLayer#setVisible
      */
-    getVisible: function(){        
+    getVisible: function(){
        return this.mixins.openLayersLayer.getVisible.call(this);
     },
     /**

--- a/viewer/src/main/webapp/viewer-html/components/Drawing-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Drawing-config.js
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2012-2013 B3Partners B.V.
  *
  * This program is free software: you can redistribute it and/or modify
@@ -27,7 +27,7 @@ Ext.define("viewer.components.CustomConfiguration",{
         }
         configObject.showLabelconfig =true;
         viewer.components.CustomConfiguration.superclass.constructor.call(this, parentId, configObject, configPage);
-        this.form.add({ 
+        this.form.add({
                 xtype: 'colorfield',
                 fieldLabel: i18next.t('drawing_config_0'),
                 name: 'color',
@@ -52,8 +52,8 @@ Ext.define("viewer.components.CustomConfiguration",{
     getDefaultValues: function() {
         return {
             details: {
-                minWidth: 340,
-                minHeight: 500
+                minWidth: 250,
+                minHeight: 170
             }
         };
     }

--- a/viewer/src/main/webapp/viewer-html/components/components.json
+++ b/viewer/src/main/webapp/viewer-html/components/components.json
@@ -632,7 +632,7 @@
         "shortName": "Te",
         "sources": ["../common/ColorField.js","Drawing.js"],
         "configSource": ["ConfigObject.js","SelectionWindowConfig.js","Drawing-config.js"],
-        "restrictions": ["rightmargin_top", "leftmargin_top","left_menu"],
+        "restrictions": ["left_menu"],
         "type": "popup",
         "singleton": true,
         "showHelp": true


### PR DESCRIPTION
mantis-15935

Drawing tool was always active when in Simple drawing mode. Also fixed a couple of layout issues. Smaller windows sizes can now be set so you don't have a huge popup in simple drawing mode.

Removed left/right margins from layout options for Drawing component. Adding the drawing component there does not work very well, for example, the Close button is still visible and gives an error on clicking.