### PR TITLE
Upgrade GeoTools van 24.x naar 25.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw (and maybe jts) or you will end up in transitive dependency hell -->
-        <geotools.version>25-RC</geotools.version>
+        <geotools.version>25.0</geotools.version>
         <b3p-commons-csw.version>6.4.0-SNAPSHOT</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw (and maybe jts) or you will end up in transitive dependency hell -->
-        <geotools.version>24.2</geotools.version>
-        <b3p-commons-csw.version>6.3.2</b3p-commons-csw.version>
+        <geotools.version>25-RC</geotools.version>
+        <b3p-commons-csw.version>6.4.0-SNAPSHOT</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw (and maybe jts) or you will end up in transitive dependency hell -->
         <geotools.version>25.0</geotools.version>
-        <b3p-commons-csw.version>6.4.0-SNAPSHOT</b3p-commons-csw.version>
+        <b3p-commons-csw.version>6.4</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStore.java
+++ b/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStore.java
@@ -16,28 +16,26 @@
  */
 package nl.b3p.geotools.data.arcgis;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.*;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-//import org.codehaus.httpcache4j.cache.HTTPCache;
-import org.geotools.data.ows.HTTPClient;
-import org.geotools.data.ows.HTTPResponse;
-import org.geotools.data.ows.SimpleHttpClient;
 import org.geotools.data.store.ContentDataStore;
 import org.geotools.data.store.ContentEntry;
 import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.NameImpl;
+import org.geotools.http.HTTPClient;
+import org.geotools.http.HTTPResponse;
+import org.geotools.http.SimpleHttpClient;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.opengis.feature.type.Name;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.*;
 
 /**
  * DataStore for ArcGIS Server REST API for MapServer or FeatureServer

--- a/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStoreFactory.java
+++ b/viewer-commons/src/main/java/nl/b3p/geotools/data/arcgis/ArcGISDataStoreFactory.java
@@ -16,13 +16,12 @@
  */
 package nl.b3p.geotools.data.arcgis;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.net.URL;
-import java.util.Map;
 import org.geotools.data.DataStore;
 import org.geotools.data.DataStoreFactorySpi;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
 
 /**
  *
@@ -42,12 +41,12 @@ public class ArcGISDataStoreFactory implements DataStoreFactorySpi {
     // TODO: add CURRENT_VERSION param
     
     @Override
-    public DataStore createDataStore(Map<String, Serializable> params) throws IOException {
+    public DataStore createDataStore(Map<String, ?> params) throws IOException {
         return createNewDataStore(params);
     }
 
     @Override
-    public DataStore createNewDataStore(Map<String, Serializable> params) throws IOException {
+    public DataStore createNewDataStore(Map<String, ?> params) throws IOException {
         return new ArcGISDataStore(
                 (URL)params.get(URL.key), 
                 (String)params.get(USER.key),


### PR DESCRIPTION
- [x] Bump GeoTools van 24.2 naar 25-RC en b3p-commons-csw van 6.3.2 naar 6.4.0-SNAPSHOT
- [x] Bump GeoTools van 25-RC naar 25.0
- [x] Bump b3p-commons-csw van 6.4.0-SNAPSHOT naar 6.4

depends https://github.com/B3Partners/b3p-commons-csw/pull/73
see https://docs.geotools.org/latest/userguide/welcome/upgrade.html#geotools-25-x