### PR TITLE
15958: only disable save button when the first config is solr type

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/Search-config.js
+++ b/viewer/src/main/webapp/viewer-html/components/Search-config.js
@@ -36,7 +36,13 @@ Ext.define("viewer.components.SearchConfiguration",{
         if (configObject === null){
             configObject = {};
         }
-        configObject.willLoadLayers = true;
+        if(configObject.searchconfigs) {
+            if(configObject.searchconfigs.length > 0) {
+                if (configObject.searchconfigs[0].type === 'solr') {
+                    configObject.willLoadLayers = true;
+                }
+            }
+        }
         viewer.components.SearchConfiguration.superclass.constructor.call(this, parentId, configObject, configPage);
         if (!this.hideRemovePinConfig) {
             this.form.add({


### PR DESCRIPTION
[fixes-mantis-15958](https://mantis.b3p.nl/view.php?id=15985)

In relation with:
- https://mantis.b3p.nl/view.php?id=15294
- https://github.com/B3Partners/tailormap/issues/2013
