### PR TITLE
[mantis-16036] prevent NPE when a misconfigured simplefilter is present

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
+++ b/viewer/src/main/webapp/viewer-html/common/viewercontroller/ViewerController.js
@@ -1863,7 +1863,7 @@ Ext.define("viewer.viewercontroller.ViewerController", {
      * Get the attributes of the appLayer
      */
     getAttributesFromAppLayer: function (appLayer, featureTypeId, addJoinedAttributes){
-        if (appLayer.attributes == undefined){
+        if (appLayer == undefined || appLayer.attributes == undefined) {
             return undefined;
         }
         //if no featureTypeId given, get the one of the application layer.


### PR DESCRIPTION
when there is a simplefilter that is missing the appLayer this can cause an error here.

typical stack trace:
```
Uncaught TypeError: Cannot read property 'attributes' of undefined
    at constructor.getAttributesFromAppLayer (ViewerController.js:1751)
    at constructor.mustEscapeAttribute (SimpleFilterFilters.js?app=IBISGEMEENTE&version=:186)
    at constructor.getCQL (SimpleFilterFilters.js?app=IBISGEMEENTE&version=:1159)
    at constructor.applyFilter (SimpleFilterFilters.js?app=IBISGEMEENTE&version=:1154)
    at constructor.reset (SimpleFilterFilters.js?app=IBISGEMEENTE&version=:1179)
    at constructor.setVisible (SimpleFilterFilters.js?app=IBISGEMEENTE&version=:48)
    at constructor.layerVisibilityChanged (SimpleFilter.js?app=IBISGEMEENTE&version=:126)
    at constructor.layersInitialized (SimpleFilter.js?app=IBISGEMEENTE&version=:102)
    at constructor.fire (ext-all-debug.js:20731)
    at constructor.doFireEvent (ext-all-debug.js:21700)
```

will fix some of mantis-16036