### PR TITLE
Retrieve layer based on correct layername. Fixes TM-196

### DIFF
--- a/viewer-helpers/src/main/java/nl/viewer/helpers/services/WMSServiceHelper.java
+++ b/viewer-helpers/src/main/java/nl/viewer/helpers/services/WMSServiceHelper.java
@@ -664,13 +664,9 @@ public class WMSServiceHelper implements GeoServiceHelper {
                 } else {
                     // Find possibly already persistent updated layer
                     // (depth first) - if new already a pluckCopy()
-                    MutablePair<Layer, UpdateResult.Status> res = result.getLayerStatus().get(topLayerName);
-                    if(res == null){
-                        thisLayer = null;
-                    }else {
-                        thisLayer = res.getLeft();
-                        visitedLayerNames.add(layerName);
-                    }
+                    MutablePair<Layer, UpdateResult.Status> res = result.getLayerStatus().get(layerName);
+                    thisLayer = res.getLeft();
+                    visitedLayerNames.add(layerName);
                 }
             }
 


### PR DESCRIPTION
Wrong layername used, resulted in a NPE when updating a service with a toplayer with no name