### PR TITLE
TM-10 added checkboxes and date types for form-field

### DIFF
--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.css
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.css
@@ -21,5 +21,5 @@ mat-form-field {
 }
 
 .mat-checkbox {
-  padding: 16px 16px 0px 16px;
+  padding: 16px 16px 0 16px;
 }

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.css
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.css
@@ -19,3 +19,7 @@ mat-form-field {
 .select-field .label {
   padding-bottom: 5px;
 }
+
+.mat-checkbox {
+  padding: 16px 16px 0px 16px;
+}

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.html
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.html
@@ -3,6 +3,7 @@
   [value]="humanReadableValue$ | async"
   [label]="attribute.label"
   [fieldType]="attribute.type"
+  [valueTrue]="attribute.value === attribute.valueTrue"
 ></tailormap-label-field>
 
 <tailormap-input-field
@@ -28,4 +29,18 @@
       <mat-option *ngFor="let opt of attribute.options" [value]="opt.val" [hidden]="opt.disabled">{{opt.label}}</mat-option>
     </mat-select>
   </div>
+</div>
+
+<div [formGroup]="groep" class="form-field" *ngIf="editing && isCheckboxAttribute(attribute)">
+  <div class="label">{{attribute.label}}</div>
+  <mat-checkbox  [checked]="checkboxValue()" (change)="onCheckboxChange($event)"></mat-checkbox>
+</div>
+
+<div [formGroup]="groep" class="form-field" *ngIf="editing && isDateAttribute(attribute)">
+  <div class="label">{{attribute.label}}</div>
+  <mat-form-field>
+    <input matInput [matDatepicker]="picker" [value]="getDate()" (dateChange)="changeDate($event)" [placeholder]="getDate()">
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker [startAt]="getDate()" #picker></mat-datepicker>
+  </mat-form-field>
 </div>

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.html
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.html
@@ -36,11 +36,8 @@
   <mat-checkbox  [checked]="checkboxValue()" (change)="onCheckboxChange($event)"></mat-checkbox>
 </div>
 
-<div [formGroup]="groep" class="form-field" *ngIf="editing && isDateAttribute(attribute)">
-  <div class="label">{{attribute.label}}</div>
-  <mat-form-field>
-    <input matInput [matDatepicker]="picker" [value]="getDate()" (dateChange)="changeDate($event)" [placeholder]="getDate()">
-    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-    <mat-datepicker [startAt]="getDate()" #picker></mat-datepicker>
-  </mat-form-field>
-</div>
+<tailormap-datepicker-field
+  *ngIf="editing && isDateAttribute(attribute)"
+  [groep]="groep"
+  [attribute]="attribute"
+></tailormap-datepicker-field>

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, EventEmitter, Inject, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
 import { Attribute, FeatureAttribute, FormFieldType } from '../form/form-models';
 import { LinkedAttributeRegistryService } from '../linked-fields/registry/linked-attribute-registry.service';
@@ -11,7 +11,6 @@ import { selectCurrentFeature, selectFormConfigForFeature } from '../state/form.
 import { filter, map, take, takeUntil } from 'rxjs/operators';
 import { LayerUtils } from '../../shared/layer-utils/layer-utils.service';
 import { MatDatepickerInputEvent } from '@angular/material/datepicker';
-import { MAT_DATE_FORMATS } from '@angular/material/core';
 
 @Component({
   selector: 'tailormap-formfield',
@@ -47,14 +46,10 @@ export class FormfieldComponent implements AfterViewInit, OnDestroy, OnInit {
   constructor(
     private registry: LinkedAttributeRegistryService,
     private store$: Store<FormState>,
-    @Inject(MAT_DATE_FORMATS) private dateFormats,
   ) {
   }
 
   public ngOnInit(): void {
-    if(this.attribute.dateFormat) {
-      this.dateFormats.display.dateInput = this.attribute.dateFormat;
-    }
     this.humanReadableValue$ = combineLatest([
       this.store$.select(selectCurrentFeature),
       this.store$.select(selectFormConfigForFeature),
@@ -135,20 +130,6 @@ export class FormfieldComponent implements AfterViewInit, OnDestroy, OnInit {
         emitViewToModelChange: true,
       });
     }
-  }
-
-  public getDate(): Date {
-    return new Date(this.attribute.value.toString());
-  }
-
-  public changeDate(date: any) {
-    this.attribute.value = new Date(date.value._d).toString();
-    this.groep.get(this.attribute.key).setValue(new Date(date.value._d), {
-      emitEvent: true,
-      onlySelf: false,
-      emitModelToViewChange: true,
-      emitViewToModelChange: true,
-    });
   }
 
   public hasNonValidValue(): boolean {

--- a/tailormap-components/projects/core/src/lib/feature-form/form/form-models.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form/form-models.ts
@@ -27,6 +27,9 @@ export interface Attribute {
   label?: string;
   column: number;
   tab: number;
+  valueTrue?: string;
+  valueFalse?: string;
+  dateFormat?: string;
 }
 
 export interface FeatureAttribute extends Attribute {
@@ -41,6 +44,8 @@ export enum FormFieldType {
   HIDDEN = 'hidden',
   DOMAIN = 'domain',
   HYPERLINK = 'hyperlink',
+  CHECKBOX = 'checkbox',
+  DATE = 'date',
 }
 
 

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/base-field/base-field.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/base-field/base-field.component.ts
@@ -38,4 +38,7 @@ export class BaseFieldComponent implements OnInit {
     return this.fieldType === FormFieldType.HYPERLINK;
   }
 
+  public isCheckboxField() {
+    return this.fieldType === FormFieldType.CHECKBOX;
+  }
 }

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.html
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.html
@@ -1,0 +1,8 @@
+<div [formGroup]="groep" class="form-field">
+  <div class="label">{{attribute.label}}</div>
+  <mat-form-field>
+    <input matInput [matDatepicker]="picker" [value]="getDate()" (dateChange)="changeDate($event)" [placeholder]="getDate()">
+    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+    <mat-datepicker [startAt]="getDate()" #picker></mat-datepicker>
+  </mat-form-field>
+</div>

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DatepickerFieldComponent } from './datepicker-field.component';
+
+describe('DatepickerFieldComponent', () => {
+  let component: DatepickerFieldComponent;
+  let fixture: ComponentFixture<DatepickerFieldComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DatepickerFieldComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DatepickerFieldComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
@@ -8,7 +8,7 @@ describe('DatepickerFieldComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DatepickerFieldComponent ]
+      declarations: [ DatepickerFieldComponent ],
     })
     .compileComponents();
   });

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.spec.ts
@@ -1,25 +1,49 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { DatepickerFieldComponent } from './datepicker-field.component';
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+import { SharedModule } from '../../../shared/shared.module';
+import { MAT_DATE_FORMATS } from '@angular/material/core';
+import { FeatureAttribute, FormFieldType } from '../../../feature-form/form/form-models';
+import { FormControl, FormGroup } from '@angular/forms';
+
+const attribute: FeatureAttribute = {
+  dateFormat: 'YYYY-MM-DD',
+  value: '2021-06-16',
+  key: 'test',
+  label: 'test',
+  column: 1,
+  tab: 1,
+  type: FormFieldType.DATE,
+};
+
+const MY_FORMATS = {
+  parse: {
+    dateInput: 'LL',
+  },
+  display: {
+    dateInput: 'YYYY-MM-DD',
+    monthYearLabel: 'YYYY',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'YYYY',
+  },
+};
 
 describe('DatepickerFieldComponent', () => {
-  let component: DatepickerFieldComponent;
-  let fixture: ComponentFixture<DatepickerFieldComponent>;
+  let spectator: Spectator<DatepickerFieldComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ DatepickerFieldComponent ],
-    })
-    .compileComponents();
+  const createComponent = createComponentFactory({
+    component: DatepickerFieldComponent,
+    imports: [ SharedModule ],
+    providers: [{provide: MAT_DATE_FORMATS, useValue: MY_FORMATS } ],
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(DatepickerFieldComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+    spectator = createComponent({props: {
+        attribute,
+        groep: new FormGroup({ test: new FormControl('the value') })}});
+    spectator.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(spectator.component).toBeTruthy();
   });
 });

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.ts
@@ -1,0 +1,40 @@
+import { Component, EventEmitter, Inject, Input, OnInit, Output } from '@angular/core';
+import { BaseFieldComponent } from '../base-field/base-field.component';
+import { FeatureAttribute } from '../../../feature-form/form/form-models';
+import { MatDatepickerInputEvent } from '@angular/material/datepicker';
+import { MAT_DATE_FORMATS } from '@angular/material/core';
+
+@Component({
+  selector: 'tailormap-datepicker-field',
+  templateUrl: './datepicker-field.component.html',
+  styleUrls: ['./datepicker-field.component.css'],
+})
+export class DatepickerFieldComponent extends BaseFieldComponent implements OnInit {
+
+  @Input()
+  public attribute: FeatureAttribute;
+
+  @Output()
+  public dateChange: EventEmitter< MatDatepickerInputEvent< any>>;
+
+  constructor(@Inject(MAT_DATE_FORMATS) private dateFormats) {super(); }
+
+  public ngOnInit(): void {
+    this.dateFormats.display.dateInput = this.attribute.dateFormat;
+  }
+
+  public getDate(): Date {
+    return new Date(this.attribute.value.toString());
+  }
+
+  public changeDate(date: any) {
+    this.attribute.value = new Date(date.value._d).toString();
+    this.groep.get(this.attribute.key).setValue(new Date(date.value._d), {
+      emitEvent: true,
+      onlySelf: false,
+      emitModelToViewChange: true,
+      emitViewToModelChange: true,
+    });
+  }
+
+}

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/input-field/input-field.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/input-field/input-field.component.ts
@@ -18,7 +18,7 @@ export class InputFieldComponent extends BaseFieldComponent implements OnInit {
   }
 
   public getInputType() {
-    return this.fieldType === FormFieldType.HYPERLINK ? 'url' : 'text';
+    return this.fieldType === FormFieldType.HYPERLINK ? 'url' : this.fieldType === FormFieldType.CHECKBOX ? 'checkbox' : 'text';
   }
 
 }

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.css
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.css
@@ -1,5 +1,5 @@
 .form-field {
-  padding: 16px 16px 0px 16px;
+  padding: 16px 16px 0 16px;
 }
 
 .label {

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.css
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.css
@@ -1,5 +1,5 @@
 .form-field {
-  padding: 16px;
+  padding: 16px 16px 0px 16px;
 }
 
 .label {

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.html
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.html
@@ -1,7 +1,8 @@
 <div class="form-field">
   <div class="label"><mat-label>{{label}}</mat-label></div>
   <div class="value">
-    <div *ngIf="!isHyperlinkField()">{{value}}</div>
+    <div *ngIf="!isHyperlinkField() && !isCheckboxField()">{{value}}</div>
     <a href="{{value}}" target="_blank" rel="noopener" *ngIf="isHyperlinkField()">{{value}}</a>
+    <mat-checkbox *ngIf="isCheckboxField()" [checked]="valueTrue" [disabled]="true"></mat-checkbox>
   </div>
 </div>

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/label-field/label-field.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { BaseFieldComponent } from '../base-field/base-field.component';
 
 @Component({
@@ -7,7 +7,8 @@ import { BaseFieldComponent } from '../base-field/base-field.component';
   styleUrls: ['./label-field.component.css'],
 })
 export class LabelFieldComponent extends BaseFieldComponent implements OnInit {
-
+  @Input()
+  public valueTrue: string;
   constructor() {
     super();
   }

--- a/tailormap-components/projects/core/src/lib/user-interface/user-interface.module.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/user-interface.module.ts
@@ -15,6 +15,7 @@ import { InputFieldComponent } from './generic-components/input-field/input-fiel
 import { BaseFieldComponent } from './generic-components/base-field/base-field.component';
 import { LabelFieldComponent } from './generic-components/label-field/label-field.component';
 import { createCustomElement } from '@angular/elements';
+import { DatepickerFieldComponent } from './generic-components/datepicker-field/datepicker-field.component';
 
 @NgModule({
   declarations: [
@@ -26,18 +27,20 @@ import { createCustomElement } from '@angular/elements';
     InputFieldComponent,
     BaseFieldComponent,
     LabelFieldComponent,
+    DatepickerFieldComponent,
   ],
   imports: [
     CommonModule,
     SharedModule,
     AttributeListModule,
   ],
-  exports: [
-    EditBarComponent,
-    GeometryConfirmButtonsComponent,
-    InputFieldComponent,
-    LabelFieldComponent,
-  ],
+    exports: [
+        EditBarComponent,
+        GeometryConfirmButtonsComponent,
+        InputFieldComponent,
+        LabelFieldComponent,
+        DatepickerFieldComponent,
+    ],
   entryComponents: [],
   providers: [
     {


### PR DESCRIPTION
Added checkboxes and date types
TM-10

To configure a datepickerfield:
Set type to: date
and add dateFormat to the formconfig:
Example: {
    "key" : "inspectiedatum",
    "type" : "date",
    "column" : 1,
    "tab" : 2,
    "label" : "Inspectiedatum",
    "mandatory" : false,
    "linkedList" : 0,
    "dateFormat": "YYYY-MM-DD"
  }

To configure a checkbox:
Set type to: checkbox
Add the value for True and False as it is in the DB to the formconfig. For example if true = "Y" and false = "N".
Example:
{
    "key" : "m4_structurelewaarde",
    "type" : "checkbox",
    "column" : 2,
    "tab" : 3,
    "label" : "structurelewaarde",
    "mandatory" : false,
    "linkedList" : 0,
    "valueTrue" : "Y",
    "valueFalse": "N",
  }