### PR TITLE
Add restproxy.host init parameter for proxying to virtual host

### DIFF
--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyRESTActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ProxyRESTActionBean.java
@@ -110,8 +110,9 @@ public class ProxyRESTActionBean implements ActionBean, Auditable {
             parentId = "?parentId="+request.getParameter("parentId");
         }
         URL requestUrl = new URL(context.getRequest().getRequestURL().toString());
+        String host = context.getServletContext().getInitParameter("flamingo.restproxy.host");
         String port = context.getServletContext().getInitParameter("flamingo.restproxy.port");
-        String constructedURL = "http://localhost:" + (port != null ? port : "8084") + "/feature-api" + url + parentId;
+        String constructedURL = "http://" + (host != null ? host : "localhost") + ":" + (port != null ? port : "8084") + "/feature-api" + url + parentId;
         URL u = new URL(constructedURL);
         return u;
     }


### PR DESCRIPTION
The proxy to the feature-api webapp always used localhost as hostname, which does not work when feature-api is deployed under a virtual host. This fix adds a `flamingo.restproxy.host` init parameter to the viewer webapp configure the hostname to the feature-api webapp. Note that the feature-api itself does not perform any localhost security checks, the Tomcat HTTP connector must only be listening to localhost! In addition, the hostname must resolve to 127.0.0.1 on the server itself, not a public IP address. The hostname should be added to the hostfile on the server (`/etc/hosts`). The init-parameter can be configured in `viewer/META-INF/context.xml` as follows: 
```
  <Parameter name="flamingo.restproxy.host" override="false" value="[the hostname here]"/>  
  <Parameter name="flamingo.restproxy.port" override="false" value="8081"/>
```