### PR TITLE
Upgrade pl.project13.maven:git-commit-id-plugin:4.0.5 to io.github.git-commit-id:git-commit-id-maven-plugin:5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -714,9 +714,9 @@
                     <version>3.2.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.5</version>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>5.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -193,8 +193,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -582,8 +582,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
as the original relocated to new Maven coordinates.

Note: no backport as this only works with Java 11 and up