### PR TITLE
skip frontend-maven-plugin on LGTM

### DIFF
--- a/.lgtm/settings.xml
+++ b/.lgtm/settings.xml
@@ -3,6 +3,12 @@
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 https://maven.apache.org/xsd/settings-1.1.0.xsd">
     <profiles>
         <profile>
+            <id>lgtm</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+        <profile>
             <id>standard-with-extra-repos</id>
             <activation>
                 <activeByDefault>true</activeByDefault>

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -14,11 +14,12 @@ path_classifiers:
 extraction:
   javascript:
     index:
-      filters:
-        exclude: "**/ext-all*.js"
+      exclude:
+        - "**/ext-all*.js"
+        - "*/extjs/"
   java:
     after_prepare:
-      - "echo '-T1 -DskipTests -Dtest.skip.integrationtests=true -B -V -fae' > .mvn/maven.config"
+      - "echo '-T1 -DskipTests -Dtest.skip.integrationtests=true -B -V -fae -Plgtm' > .mvn/maven.config"
       - "cat .mvn/maven.config"
     index:
       maven:

--- a/solr-commons/src/main/java/nl/tailormap/viewer/solr/SolrUpdateJob.java
+++ b/solr-commons/src/main/java/nl/tailormap/viewer/solr/SolrUpdateJob.java
@@ -178,7 +178,7 @@ public class SolrUpdateJob implements Job {
                     q.setMaxFeatures(max);
                     
                     status.setCurrentAction("Bezig met verwerken features " + start + " - " + ( start + max) + " van de " + total);
-                    currentProgress += percentagePerBatch;
+                    currentProgress += (int)percentagePerBatch;
                     status.setProgress(currentProgress);
                     fc = fs.getFeatures(q);
                     processFeatures(fc.features(), indexAttributesConfig, resultAttributesConfig, config.getId(),solrServer, status, percentagePerBatch);

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -765,5 +765,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>lgtm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
LGTM doesn't need the build of npm packages so skip that during Java analysis