### PR TITLE
Bugfixes

### DIFF
--- a/tailormap-components/projects/core/src/lib/application/helpers/attribute-type.helper.ts
+++ b/tailormap-components/projects/core/src/lib/application/helpers/attribute-type.helper.ts
@@ -56,28 +56,32 @@ export class AttributeTypeHelper {
     if (!attribute) {
       return undefined;
     }
-    if (attribute.type === 'string') {
+    let type = attribute.type;
+    if (attribute.editValues && attribute.editValues.length > 0) {
+      type = attribute.editValues[0];
+    }
+    if (type === 'string') {
       return AttributeTypeEnum.STRING;
     }
-    if (attribute.type === 'double' || attribute.type === 'integer') {
+    if (type === 'double' || type === 'integer') {
       return AttributeTypeEnum.NUMBER;
     }
-    if (attribute.type === 'boolean') {
+    if (type === 'boolean') {
       return AttributeTypeEnum.BOOLEAN;
     }
-    if (attribute.type === 'date' || attribute.type === 'timestamp') {
+    if (type === 'date' || type === 'timestamp') {
       return AttributeTypeEnum.DATE;
     }
-    if (attribute.type === 'point' || attribute.type === 'multipoint') {
+    if (type === 'point' || type === 'multipoint') {
       return AttributeTypeEnum.GEOMETRY_POINT;
     }
-    if (attribute.type === 'linestring' || attribute.type === 'multilinestring') {
+    if (type === 'linestring' || type === 'multilinestring') {
       return AttributeTypeEnum.GEOMETRY_LINESTRING;
     }
-    if (attribute.type === 'polygon' || attribute.type === 'multipolygon') {
+    if (type === 'polygon' || type === 'multipolygon') {
       return AttributeTypeEnum.GEOMETRY_POLYGON;
     }
-    if (attribute.type === 'geometry') {
+    if (type === 'geometry') {
       return AttributeTypeEnum.GEOMETRY;
     }
     return undefined;

--- a/tailormap-components/projects/core/src/lib/application/state/application.selectors.ts
+++ b/tailormap-components/projects/core/src/lib/application/state/application.selectors.ts
@@ -150,7 +150,7 @@ export const selectFormConfigFeatureTypeNames = createSelector(
 export const selectVisibleLayersWithFormConfig = createSelector(
   selectFormConfigFeatureTypeNames,
   selectVisibleLayers,
-  (formConfigFeatureTypeNames, visibleLayers): string[] => {
+  (formConfigFeatureTypeNames, visibleLayers): TailormapAppLayer[] => {
     if (!visibleLayers || visibleLayers.length === 0) {
       return [];
     }
@@ -158,8 +158,7 @@ export const selectVisibleLayersWithFormConfig = createSelector(
     return visibleLayers
       .filter(layer => {
         return formFeatureTypeNamesSet.has(layer.featureTypeName);
-      })
-      .map(layer => (layer.alias || layer.layerName));
+      });
   },
 );
 

--- a/tailormap-components/projects/core/src/lib/feature-form/form-attribute-list-button/form-attribute-list-button.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-attribute-list-button/form-attribute-list-button.component.ts
@@ -74,12 +74,11 @@ export class FormAttributeListButtonComponent implements OnDestroy {
               }
               const feature = {} as Feature;
               const appLayer = this.tailorMapService.getApplayerById(+(layerId));
-              const className = appLayer.layerName;
               feature.children = [];
-              feature.layerName = className;
+              feature.layerName = appLayer.layerName;
               feature.fid = row.object_guid;
               feature.relatedFeatureTypes = row.related_featuretypes;
-              feature.tableName = className[0].toUpperCase() + className.substr(1);
+              feature.tableName = appLayer.featureTypeName;
               return ({ ...feature, ...rest });
             }),
           };

--- a/tailormap-components/projects/core/src/lib/shared/attribute-service/attribute-models.ts
+++ b/tailormap-components/projects/core/src/lib/shared/attribute-service/attribute-models.ts
@@ -66,6 +66,7 @@ export interface Attribute {
   editAlias: string;
   editHeight: string;
   editable: boolean;
+  editValues?: string[];
   featureType: number;
   filterable: boolean;
   folder_label: string;

--- a/tailormap-components/projects/core/src/lib/shared/feature-selection/feature-selection.service.ts
+++ b/tailormap-components/projects/core/src/lib/shared/feature-selection/feature-selection.service.ts
@@ -49,6 +49,9 @@ export class FeatureSelectionService implements OnDestroy {
           const filteredFeatureTypes = allowedFeatureTypes
             ? featureTypes.filter(f => allowedFeatureTypes.includes(f))
             : featureTypes;
+          if (filteredFeatureTypes.length === 0) {
+            return of([]);
+          }
           return this.featureControllerService.featuretypeOnPoint({
             application: this.applicationService.getApplicationId(),
             featureTypes: filteredFeatureTypes,

--- a/tailormap-components/projects/core/src/lib/shared/layer-utils/layer-utils.service.ts
+++ b/tailormap-components/projects/core/src/lib/shared/layer-utils/layer-utils.service.ts
@@ -15,19 +15,13 @@ export class LayerUtils {
     let allowedFeaturesTypes = [];
     const sl = this.tailorMap.selectedLayer;
     if (sl && useSelectedLayerFilter) {
-      allowedFeaturesTypes.push( this.getLayerName(sl));
+      allowedFeaturesTypes.push(this.getLayerName(sl));
     } else {
       allowedFeaturesTypes = allFeatureTypes;
     }
-    const visibleLayers = this.getVisibleLayers(false).map(layer => {
-      const idx = layer.indexOf(':');
-      if (idx !== -1) {
-        return layer.slice(idx + 1);
-      }
-      return layer;
-    });
+    const visibleLayers = this.getVisibleLayerFeatureTypes(false).map(LayerUtils.convertLayerToFeatureType);
     let newAr = allowedFeaturesTypes.filter(value => visibleLayers.includes(value));
-    const visibleUserLayers = this.getVisibleLayers(true);
+    const visibleUserLayers = this.getVisibleLayerFeatureTypes(true).map(LayerUtils.convertLayerToFeatureType);
 
     newAr = [...newAr, ...visibleUserLayers];
     return newAr;
@@ -44,7 +38,7 @@ export class LayerUtils {
   }
 
 
-  private getVisibleLayers(userLayers: boolean): string[] {
+  private getVisibleLayerFeatureTypes(userLayers: boolean): string[] {
     const visibleLayers = [];
 
     const appLayers = this.tailorMap.getViewerController().getVisibleLayers();
@@ -57,4 +51,13 @@ export class LayerUtils {
     });
     return visibleLayers;
   }
+
+  private static convertLayerToFeatureType(layer: string) {
+    const idx = layer.indexOf(':');
+    if (idx !== -1) {
+      return layer.slice(idx + 1);
+    }
+    return layer;
+  }
+
 }

--- a/tailormap-components/projects/core/src/lib/user-interface/edit-bar/add-feature-menu/add-feature-menu.component.html
+++ b/tailormap-components/projects/core/src/lib/user-interface/edit-bar/add-feature-menu/add-feature-menu.component.html
@@ -4,7 +4,7 @@
     <mat-form-field>
       <mat-label>Selecteer kaartlaag</mat-label>
       <mat-select [value]="this.layer" (selectionChange)="layerSelected($event)">
-        <mat-option *ngFor="let layer of layers" [value]="layer">{{layer}}</mat-option>
+        <mat-option *ngFor="let layer of layers" [value]="layer">{{ layer.alias || layer.layerName }}</mat-option>
       </mat-select>
     </mat-form-field>
   </div>

--- a/tailormap-components/projects/core/src/lib/user-interface/edit-bar/add-feature-menu/add-feature-menu.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/edit-bar/add-feature-menu/add-feature-menu.component.ts
@@ -10,6 +10,7 @@ import { WORKFLOW_ACTION } from '../../../workflow/state/workflow-models';
 import { WorkflowState } from '../../../workflow/state/workflow.state';
 import * as WorkflowActions from '../../../workflow/state/workflow.actions';
 import { selectFormConfigForFeatureTypeName, selectVisibleLayersWithFormConfig } from '../../../application/state/application.selectors';
+import { TailormapAppLayer } from '../../../application/models/tailormap-app-layer.model';
 
 @Component({
   selector: 'tailormap-add-feature-menu',
@@ -21,8 +22,8 @@ export class AddFeatureMenuComponent implements OnInit, OnDestroy {
   @Output()
   public closeMenu = new EventEmitter();
 
-  public layer = '-1';
-  public layers: string[];
+  public layer: TailormapAppLayer = null;
+  public layers: TailormapAppLayer[];
 
   private selectedConfig: FormConfiguration;
   private destroyed = new Subject();
@@ -47,7 +48,7 @@ export class AddFeatureMenuComponent implements OnInit, OnDestroy {
 
   public layerSelected(event: MatSelectChange): void {
     this.layer = event.value;
-    this.store$.select(selectFormConfigForFeatureTypeName, this.layer)
+    this.store$.select(selectFormConfigForFeatureTypeName, this.layer.featureTypeName)
       .pipe(take(1))
       .subscribe(formConfig => this.selectedConfig = formConfig);
   }
@@ -60,7 +61,7 @@ export class AddFeatureMenuComponent implements OnInit, OnDestroy {
     this.store$.dispatch(WorkflowActions.setTypes({
       action: WORKFLOW_ACTION.ADD_FEATURE,
       geometryType: type,
-      featureType: this.layer,
+      featureType: this.layer.featureTypeName,
     }));
     this.closeMenu.emit();
   }

--- a/tailormap-components/projects/core/src/lib/workflow/workflows/StandardFormWorkflow.ts
+++ b/tailormap-components/projects/core/src/lib/workflow/workflows/StandardFormWorkflow.ts
@@ -9,7 +9,7 @@ import * as FormActions from '../../feature-form/state/form.actions';
 import { selectFormClosed } from '../../feature-form/state/form.state-helpers';
 import { selectFormConfigForFeatureTypeName } from '../../application/state/application.selectors';
 import { selectFeatureType, selectGeometryType, selectWorkflowConfig } from '../state/workflow.selectors';
-import { combineLatest } from 'rxjs';
+import { combineLatest, of } from 'rxjs';
 
 
 export class StandardFormWorkflow extends Workflow {
@@ -104,10 +104,14 @@ export class StandardFormWorkflow extends Workflow {
       .pipe(
         take(1),
         concatMap(workFlowConfig => this.featureSelectionService.selectFeatureForClick$(data, workFlowConfig.useSelectedLayerFilter)),
+        concatMap(feature => combineLatest([
+          of(feature),
+          this.store$.select(selectFormConfigForFeatureTypeName, feature.tableName),
+        ])),
       )
-      .subscribe(feature => {
+      .subscribe(([ feature, formConfig ]) => {
         this.featureSelectionPopupOpen = false;
-        if (!feature) {
+        if (!feature || !formConfig) {
           return;
         }
         this.afterEditing();


### PR DESCRIPTION
TM-232: Fixes some edge cases where layernames are used for featuretype
TM-204: Don't load all features on point if there are no selected layers
TM-264: Fix drawing for layers with an alias
TM-265: Show styling for configured geometry type
TM-266: Don't show passport/edit form for features without Formconfiguration
 TM-268: Allow to edit features from attribute list again 