### PR TITLE
[TM-348] voeg commons-codec toe als expliciete dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <jakarta.mail.version>1.6.6</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <apache.commons-httpclient.version>3.1</apache.commons-httpclient.version>
+        <apache.commons-codec.version>1.15</apache.commons-codec.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.3</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
@@ -221,6 +222,11 @@
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.11.0</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${apache.commons-codec.version}</version>
             </dependency>
             <dependency>
                 <groupId>log4j</groupId>

--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -84,6 +84,10 @@
             <artifactId>web-commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.tailormap</groupId>
             <artifactId>form</artifactId>
         </dependency>

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -18,7 +18,6 @@
         <rest.api.outputdoc>${tailormap-components.source.dir}/projects/core/src/lib/shared/generated</rest.api.outputdoc>
     </properties>
     <dependencies>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -27,7 +26,6 @@
             <groupId>org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -119,6 +117,10 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
in plaats van te vertrouwen op een (verouderde) transitieve versie.

resolves TM-348