### PR TITLE
Fixup dependency management in viewer module

### DIFF
--- a/geotools-commons/pom.xml
+++ b/geotools-commons/pom.xml
@@ -42,5 +42,9 @@
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-wkt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-http</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <!-- when updating geotools also check b3p-commons-csw (and maybe jts) or you will end up in transitive dependency hell -->
         <geotools.version>26.0</geotools.version>
         <jts.version>1.18.2</jts.version>
-        <b3p-commons-csw.version>7.0</b3p-commons-csw.version>
+        <b3p-commons-csw.version>7.1</b3p-commons-csw.version>
         <hsqldb.version>2.6.0</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.2.24</postgresql.version>
@@ -68,6 +68,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <hibernate.version>5.6.0.Final</hibernate.version>
         <jackson2.version>2.12.5</jackson2.version>
+        <lucene.version>4.6.0</lucene.version>
         <test.junit-jupiter.version>5.8.1</test.junit-jupiter.version>
         <test.hamcrest.version>2.2</test.hamcrest.version>
         <!-- skip integration tests by default, override this property from commandline
@@ -94,6 +95,11 @@
                 <groupId>nl.opengeogroep</groupId>
                 <artifactId>safetymaps-api</artifactId>
                 <version>1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-dbutils</groupId>
+                <artifactId>commons-dbutils</artifactId>
+                <version>1.7</version>
             </dependency>
             <dependency>
                 <groupId>commons-fileupload</groupId>
@@ -218,6 +224,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.apache.xmlgraphics</groupId>
+                <artifactId>xmlgraphics-commons</artifactId>
+                <version>2.6</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.11.0</version>
@@ -321,7 +332,12 @@
             <dependency>
                 <groupId>org.apache.lucene</groupId>
                 <artifactId>lucene-core</artifactId>
-                <version>4.6.0</version>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>${lucene.version}</version>
             </dependency>
             <dependency>
                 <artifactId>solr-solrj</artifactId>
@@ -386,7 +402,17 @@
             </dependency>
             <dependency>
                 <groupId>org.geotools</groupId>
-                <artifactId>gt-wmts</artifactId>
+                <artifactId>gt-cql</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-xml</artifactId>
+                <version>${geotools.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-opengis</artifactId>
                 <version>${geotools.version}</version>
             </dependency>
             <dependency>
@@ -549,6 +575,11 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpmime</artifactId>
                 <version>${apache.httpcomponents.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.14</version>
             </dependency>
             <dependency>
                 <groupId>commons-httpclient</groupId>
@@ -841,6 +872,7 @@
                                     <excludes>
                                         <exclude>junit:junit</exclude>
                                         <exclude>org.hamcrest:hamcrest-core</exclude>
+                                        <exclude>commons-lang:commons-lang</exclude>
                                     </excludes>
                                 </bannedDependencies>
                             </rules>

--- a/viewer-admin/src/main/java/nl/tailormap/viewer/admin/stripes/ChooseApplicationActionBean.java
+++ b/viewer-admin/src/main/java/nl/tailormap/viewer/admin/stripes/ChooseApplicationActionBean.java
@@ -33,7 +33,7 @@ import nl.tailormap.viewer.config.app.ConfiguredComponent;
 import nl.tailormap.viewer.config.metadata.Metadata;
 import nl.tailormap.viewer.config.security.Group;
 import nl.tailormap.viewer.helpers.app.ApplicationHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;

--- a/viewer/pom.xml
+++ b/viewer/pom.xml
@@ -18,7 +18,6 @@
         <rest.api.outputdoc>${tailormap-components.source.dir}/projects/core/src/lib/shared/generated</rest.api.outputdoc>
     </properties>
     <dependencies>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -27,7 +26,6 @@
             <groupId>org.owasp.encoder</groupId>
             <artifactId>encoder</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -57,16 +55,8 @@
             <artifactId>gt-geojson</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-http</artifactId>
-        </dependency>
-        <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-wmts</artifactId>
         </dependency>
         <dependency>
             <groupId>eu.medsea.mimeutil</groupId>
@@ -75,6 +65,34 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-shapefile</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-opengis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-wfs-ng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-cql</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-metadata</artifactId>
         </dependency>
         <dependency>
             <groupId>org.geotools.xsd</groupId>
@@ -98,7 +116,15 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-dbutils</groupId>
+            <artifactId>commons-dbutils</artifactId>
         </dependency>
         <dependency>
             <groupId>org.tailormap</groupId>
@@ -110,11 +136,35 @@
         </dependency>
         <dependency>
             <groupId>org.tailormap</groupId>
+            <artifactId>viewer-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.tailormap</groupId>
+            <artifactId>web-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.tailormap</groupId>
+            <artifactId>geotools-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.tailormap</groupId>
+            <artifactId>viewer-audit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.tailormap</groupId>
             <artifactId>solr-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlgraphics</groupId>
+            <artifactId>xmlgraphics-commons</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -123,6 +173,14 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.b3p</groupId>
@@ -155,6 +213,10 @@
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
         </dependency>
         <dependency>
             <artifactId>solr-solrj</artifactId>
@@ -191,6 +253,14 @@
             <artifactId>xercesImpl</artifactId>
         </dependency>
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.tailormap</groupId>
             <artifactId>viewer-config-persistence</artifactId>
             <type>test-jar</type>
@@ -204,7 +274,7 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/viewer/src/main/java/nl/tailormap/viewer/features/ShapeDownloader.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/features/ShapeDownloader.java
@@ -19,7 +19,7 @@ package nl.tailormap.viewer.features;
 import nl.tailormap.viewer.config.app.ConfiguredAttribute;
 import nl.tailormap.viewer.config.services.AttributeDescriptor;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
@@ -44,7 +44,7 @@ import nl.tailormap.viewer.helpers.AuthorizationsHelper;
 import nl.tailormap.viewer.helpers.app.ApplicationHelper;
 import nl.tailormap.viewer.helpers.app.ComponentHelper;
 import nl.tailormap.viewer.util.SelectedContentCache;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.stripesstuff.stripersist.Stripersist;

--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/I18nActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/I18nActionBean.java
@@ -9,7 +9,7 @@ import net.sourceforge.stripes.action.UrlBinding;
 import net.sourceforge.stripes.validation.Validate;
 import nl.tailormap.i18n.ResourceBundleProvider;
 import nl.tailormap.i18n.ResourceBundleToJsProvider;
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 import java.io.StringReader;
 import java.util.Locale;

--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/LocalizableApplicationActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/LocalizableApplicationActionBean.java
@@ -7,7 +7,7 @@ import net.sourceforge.stripes.controller.LifecycleStage;
 import nl.tailormap.i18n.LocalizableActionBean;
 import nl.tailormap.i18n.ResourceBundleProvider;
 import nl.tailormap.viewer.config.app.Application;
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 import java.util.Locale;
 

--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/PrintActionBean.java
@@ -43,7 +43,7 @@ import nl.tailormap.viewer.print.PrintUtil;
 import nl.tailormap.viewer.util.FeaturePropertiesArrayHelper;
 import nl.tailormap.viewer.util.FeatureToJson;
 import nl.tailormap.viewer.util.TailormapCQL;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Logger;

--- a/viewer/src/main/java/nl/tailormap/viewer/util/TailormapCQL.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/util/TailormapCQL.java
@@ -23,7 +23,7 @@ import nl.tailormap.viewer.config.services.GeoService;
 import nl.tailormap.viewer.config.services.Layer;
 import nl.tailormap.viewer.config.services.SimpleFeatureType;
 import nl.tailormap.viewer.helpers.featuresources.FeatureSourceFactoryHelper;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geotools.data.FeatureSource;


### PR DESCRIPTION
After running `mvn org.apache.maven.plugins:maven-dependency-plugin:3.2.0:analyze-report -pl :viewer` which reposrt lots of undeclared dependencies

- Fixup dependency management in viewer
- forbid use of `commons-lang:commons-lang` (use `commons-lang3`)

note that #2933 adds `commons-codec`