### PR TITLE
fix LGTM viewer-admin build by skipping the frontend-maven-plugin execution

### DIFF
--- a/viewer-admin/pom.xml
+++ b/viewer-admin/pom.xml
@@ -467,5 +467,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>lgtm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
LGTM only checks Java code when running Maven anyways