### PR TITLE
[TM-349][v5.8.x] verwijder GBI componenten uit stable branch

### DIFF
--- a/viewer/src/main/webapp/viewer-html/components/components.json
+++ b/viewer/src/main/webapp/viewer-html/components/components.json
@@ -917,7 +917,6 @@
         "configSource": ["ConfigObject.js","SelectionWindowConfig.js", "Contactform-config.js"],
         "restrictions": ["rightmargin_top", "leftmargin_top","rightmargin_bottom", "leftmargin_bottom", "header","footer", "popupwindow"]
     },
-
     {
         "className": "viewer.components.Highlight",
         "name": "Highlight",
@@ -929,16 +928,6 @@
         "restrictions": ["content", "left_menu"]
     },
     {
-        "className": "viewer.components.GBI",
-        "name": "GBI",
-        "group": "Map",
-        "shortName": "GBI",
-        "sources": ["GBI.js"],
-        "singleton": true,
-        "configSource": ["ConfigObject.js","SelectionWindowConfig.js", "GBI-config.js"],
-        "restrictions": ["content", "left_menu"]
-    },
-    {
         "className": "viewer.components.NgAttributeList",
         "name": "NgAttributeList",
         "group": "Map",
@@ -947,16 +936,5 @@
         "singleton": true,
         "configSource": ["ConfigObject.js","SelectionWindowConfig.js","NgAttributeList-config.js"],
         "restrictions": ["left_menu"]
-    },
-    {
-        "className": "viewer.components.AnalysisLayerCreator",
-        "name": "GBI - Analyse / Laag maken",
-        "group": "Map",
-        "shortName": "GBI-A",
-        "sources": ["AnalysisLayerCreator.js"],
-        "type": "popup",
-        "singleton": true,
-        "configSource": ["ConfigObject.js","SelectionWindowConfig.js","AnalysisLayerCreator-config.js"],
-        "restrictions": ["content"]
     }
 ]

--- a/viewer/src/main/webapp/viewer-html/components/components.json
+++ b/viewer/src/main/webapp/viewer-html/components/components.json
@@ -926,15 +926,5 @@
         "singleton": true,
         "configSource": ["ConfigObject.js","SelectionWindowConfig.js", "Highlight-config.js"],
         "restrictions": ["content", "left_menu"]
-    },
-    {
-        "className": "viewer.components.NgAttributeList",
-        "name": "NgAttributeList",
-        "group": "Map",
-        "shortName": "NgAttrList",
-        "sources": ["NgAttributeList.js"],
-        "singleton": true,
-        "configSource": ["ConfigObject.js","SelectionWindowConfig.js","NgAttributeList-config.js"],
-        "restrictions": ["left_menu"]
     }
 ]


### PR DESCRIPTION
Verwijder GBI specifieke componenten ("GBI" en "GBI - Analyse / Laag maken" ) en ook de `NgAttributeList` uit stable/v5.8.x

zie ook TM-350 / #2942 

resolves TM-349