### PR TITLE
Bump GeoTools 25.2 -> 25.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.2.23</postgresql.version>
         <mssql.version>9.4.0.jre8</mssql.version>
-        <oracle.version>21.1.0.0</oracle.version>
+        <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.0.0</apache.poi.version>
         <jakarta.mail.version>1.6.6</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.2.23</postgresql.version>
+        <postgresql.version>42.3.0</postgresql.version>
         <mssql.version>9.4.0.jre8</mssql.version>
         <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.0.0</apache.poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>25.2</geotools.version>
-        <b3p-commons-csw.version>6.6</b3p-commons-csw.version>
+        <geotools.version>25.3</geotools.version>
+        <b3p-commons-csw.version>6.7-SNAPSHOT</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -661,7 +661,7 @@
                 <plugin>
                     <groupId>pl.project13.maven</groupId>
                     <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.0.5</version>
+                    <version>4.9.10</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -690,7 +690,7 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>6.3.1</version>
+                    <version>6.4.1</version>
                     <configuration>
                         <skipSystemScope>true</skipSystemScope>
                         <format>ALL</format>
@@ -822,7 +822,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.36.1</version>
+                    <version>0.37.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw or you will end up in transitive dependency hell -->
         <geotools.version>25.3</geotools.version>
-        <b3p-commons-csw.version>6.7-SNAPSHOT</b3p-commons-csw.version>
+        <b3p-commons-csw.version>6.7</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>


### PR DESCRIPTION
requires https://github.com/B3Partners/b3p-commons-csw/pull/96

while here update some other dependencies and maven plugins