### PR TITLE
GBIM-222: Fixes form validation (mandatory, readonly, domain validation) 

### DIFF
--- a/tailormap-components/projects/core/src/lib/feature-form/form-creator/form-creator.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-creator/form-creator.component.ts
@@ -54,6 +54,9 @@ export class FormCreatorComponent implements OnChanges, OnDestroy, AfterViewInit
   @Output()
   public formChanged = new EventEmitter<boolean>();
 
+  @Output()
+  public formValidChanged = new EventEmitter<boolean>();
+
   @Input()
   public formTabs: TabbedField[] = [];
 
@@ -97,7 +100,6 @@ export class FormCreatorComponent implements OnChanges, OnDestroy, AfterViewInit
     for (const attr of attrs) {
       const featureAttribute = this.indexedAttributes.attrs.get(attr.key);
       let value: string | number | boolean = !this.isBulk && featureAttribute ? featureAttribute.value : null;
-
       if (attr.type === FormFieldType.DOMAIN) {
         this.registry.registerDomainField(attr.linkedList, featureAttribute);
         if (!this.isBulk && featureAttribute.value && featureAttribute.value !== '') {
@@ -119,6 +121,7 @@ export class FormCreatorComponent implements OnChanges, OnDestroy, AfterViewInit
     this.formgroep.markAllAsTouched();
     this.formgroep.valueChanges.subscribe(() => {
       this.formChanged.emit(true);
+      this.formValidChanged.emit(this.formgroep.valid);
     });
   }
 

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/form-field-helpers.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/form-field-helpers.ts
@@ -13,16 +13,18 @@ export class FormFieldHelpers {
 
   public static nonExistingValueValidator(attribute: FeatureAttribute): ValidatorFn {
     return (control: AbstractControl): {[key: string]: any} | null => {
-      return FormFieldHelpers.hasNonValidValue(attribute) ? {invalidValue: {value: control.value}} : null;
+      return FormFieldHelpers.hasNonValidValue({ ...attribute, value: control.value }, true)
+        ? { nonExistingValue: { value: control.value }}
+        : null;
     };
   }
 
-  public static hasNonValidValue(attribute: FeatureAttribute): boolean {
+  public static hasNonValidValue(attribute: FeatureAttribute, allowValueFormEmptyOptions?: boolean): boolean {
     if (attribute.type !== FormFieldType.DOMAIN && attribute.type !== FormFieldType.SELECT) {
       return false;
     }
     if (attribute.value && (!attribute.options || attribute.options.length === 0)) {
-      return true;
+      return allowValueFormEmptyOptions ? false : true;
     }
     if (attribute.options && attribute.options?.length !== 0) {
       return !FormFieldHelpers.findSelectedOption(attribute.options, attribute.value);

--- a/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form-field/formfield.component.ts
@@ -1,5 +1,5 @@
-import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
-import { AbstractControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
 import { Attribute, FeatureAttribute, FormFieldType } from '../form/form-models';
 import { FormFieldHelpers } from './form-field-helpers';
 import { FormTreeHelpers } from '../form-tree/form-tree-helpers';
@@ -14,7 +14,7 @@ import { filter, map } from 'rxjs/operators';
   templateUrl: './formfield.component.html',
   styleUrls: ['./formfield.component.css'],
 })
-export class FormfieldComponent implements AfterViewInit, OnInit {
+export class FormfieldComponent implements OnInit {
 
   public humanReadableValue$: Observable<string>;
 
@@ -52,36 +52,22 @@ export class FormfieldComponent implements AfterViewInit, OnInit {
         map(([feature, config]) => {
           return FormTreeHelpers.getFeatureValueForField(feature, config, this.attribute.key);
         }));
-    }
+    this.updateFieldValue();
+  }
 
-  public ngAfterViewInit(): void {
+  private updateFieldValue(): void {
     this.control = this.groep.controls[this.attribute.key];
-    if (this.attribute.isReadOnly && this.control.enabled) {
-      this.control.disable({ emitEvent: false });
-    }
-    if (!this.attribute.isReadOnly && this.control.disabled) {
-      this.control.enable({ emitEvent: false });
-    }
-    const validators: ValidatorFn[] = [];
     if (!this.isBulk) {
-      if (FormFieldHelpers.hasNonValidValue(this.attribute)) {
-        validators.push(FormFieldHelpers.nonExistingValueValidator(this.attribute));
-      } else {
-        const comparableValue = FormFieldHelpers.findSelectedOption(this.attribute.options, this.attribute.value);
-        const value = comparableValue ? comparableValue.val : this.attribute.value;
-        if (value) {
-          this.control.setValue(value, {
-            emitEvent: false,
-            onlySelf: false,
-            emitModelToViewChange: false,
-            emitViewToModelChange: false,
-          });
-        }
+      const comparableValue = FormFieldHelpers.findSelectedOption(this.attribute.options, this.attribute.value);
+      const value = comparableValue ? comparableValue.val : this.attribute.value;
+      if (value) {
+        this.control.setValue(value, {
+          emitEvent: false,
+          onlySelf: false,
+          emitModelToViewChange: false,
+          emitViewToModelChange: false,
+        });
       }
-      if (this.attribute.mandatory) {
-        validators.push(Validators.required);
-      }
-      this.control.setValidators(validators);
     }
   }
 

--- a/tailormap-components/projects/core/src/lib/feature-form/form/form.component.html
+++ b/tailormap-components/projects/core/src/lib/feature-form/form/form.component.html
@@ -17,6 +17,7 @@
                               [formConfig]="formConfig"
                               [isBulk]="isBulk"
                               [parentId]="currentParentFeature"
+                              (formValidChanged)="formValidChanged($event)"
                               (formChanged)="formChanged($event)"></tailormap-form-creator>
     </div>
   </div>
@@ -52,7 +53,7 @@
     </button>
 
     <button *ngIf="formCreator.editing$ | async"
-            [disabled]="!formDirty && !closeAfterSave"
+            [disabled]="!isSaveAllowed()"
             mat-flat-button
             color="primary"
             (click)="formCreator.beforeSave();">

--- a/tailormap-components/projects/core/src/lib/feature-form/form/form.component.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/form/form.component.ts
@@ -41,6 +41,7 @@ export class FormComponent implements OnDestroy, OnInit {
   public isBulk: boolean;
   public formsForNew: FormConfiguration[] = [];
   public formDirty: boolean;
+  public formValid: boolean;
 
   private destroyed = new Subject();
   public closeAfterSave = false;
@@ -170,6 +171,10 @@ export class FormComponent implements OnDestroy, OnInit {
 
   public formChanged(result: boolean) {
     this.formDirty = result;
+  }
+
+  public formValidChanged(result: boolean) {
+    this.formValid = result;
   }
 
   public isCreatingNew() {
@@ -307,6 +312,10 @@ export class FormComponent implements OnDestroy, OnInit {
         filter(remove => remove),
       )
       .subscribe(() => callback());
+  }
+
+  public isSaveAllowed() {
+    return this.formDirty && this.formValid;
   }
 
 }

--- a/tailormap-components/projects/core/src/lib/feature-form/linked-fields/domain-repository/domain-repository.service.ts
+++ b/tailormap-components/projects/core/src/lib/feature-form/linked-fields/domain-repository/domain-repository.service.ts
@@ -60,6 +60,7 @@ export class DomainRepositoryService implements OnDestroy {
                     id: domeinwaarde.id,
                   });
                 }
+                options.sort((opt1, opt2) => opt1.label === opt2.label ? 0 : (opt1.label > opt2.label ? 1 : -1));
                 field.options = options;
               }
             });

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/checkbox-field/checkbox-field.component.html
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/checkbox-field/checkbox-field.component.html
@@ -1,5 +1,6 @@
 <div [formGroup]="groep" class="form-field">
   <label class="label">{{attribute.label}}</label>
   <mat-checkbox [checked]="checkboxValue()"
+                [disabled]="attribute.isReadOnly"
                 (change)="onCheckboxChange($event)"></mat-checkbox>
 </div>

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.css
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.css
@@ -1,0 +1,3 @@
+.datepicker-form-field {
+  width: 100%;
+}

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.html
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.html
@@ -1,7 +1,7 @@
 <div [formGroup]="groep" class="form-field">
   <label class="label">{{attribute.label}}</label>
-  <mat-form-field>
-    <input matInput [matDatepicker]="picker" [value]="getDate()" (dateChange)="changeDate($event)" [placeholder]="getDate()">
+  <mat-form-field class="datepicker-form-field">
+    <input matInput [disabled]="isDisabled()" [matDatepicker]="picker" [value]="getDate()" (dateChange)="changeDate($event)" [placeholder]="getDate()">
     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
     <mat-datepicker [startAt]="getDate()" #picker></mat-datepicker>
   </mat-form-field>

--- a/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.ts
+++ b/tailormap-components/projects/core/src/lib/user-interface/generic-components/datepicker-field/datepicker-field.component.ts
@@ -49,4 +49,8 @@ export class DatepickerFieldComponent implements OnInit {
     return this.attribute.dateFormat || 'YYYY-MM-DD';
   }
 
+  public isDisabled() {
+    return this.attribute.isReadOnly;
+  }
+
 }


### PR DESCRIPTION
GBIM-222: Properly apply mandatory and isReadOnly validation. Fixed the domain values validation in case of value withouth options.
GBIM-224: Sort domain options

One thing to note, with this PR having a valid form is required. So if some domain field for example is marked as mandatory but there are no options because of misconfigured domain list then validation will always fail. You are unable to create a new object since you are required to pick an option but there are no options.