### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <hsqldb.version>2.6.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.3.1</postgresql.version>
-        <mssql.version>9.4.0.jre11</mssql.version>
+        <mssql.version>9.4.1.jre11</mssql.version>
         <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.1.0</apache.poi.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <apache.commons-httpclient.version>3.1</apache.commons-httpclient.version>
         <apache.commons-codec.version>1.15</apache.commons-codec.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
-        <jaxb.impl.version>2.3.3</jaxb.impl.version>
+        <jaxb.impl.version>2.3.5</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
         <slf4j.version>1.7.32</slf4j.version>
         <hibernate.version>5.6.2.Final</hibernate.version>


### PR DESCRIPTION
- Bump `org.glassfish.jaxb:jaxb-runtime` 2.3.3 -> 2.3.5
- Bump `com.microsoft.sqlserver:mssql-jdbc` 9.4.0.jre11 -> 9.4.1.jre11