### PR TITLE
Dependency updates v5.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>com.github.blutorange</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.3.0</postgresql.version>
+        <postgresql.version>42.3.1</postgresql.version>
         <mssql.version>9.4.1.jre8</mssql.version>
         <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.1.0</apache.poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <jakarta.mail.version>1.6.6</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
-        <jaxb.impl.version>2.3.3</jaxb.impl.version>
+        <jaxb.impl.version>2.3.5</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
         <slf4j.version>1.7.32</slf4j.version>
         <jackson2.version>2.12.5</jackson2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <mssql.version>9.4.1.jre8</mssql.version>
         <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.1.0</apache.poi.version>
-        <jakarta.mail.version>1.6.6</jakarta.mail.version>
+        <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.5</jaxb.impl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.3.0</postgresql.version>
-        <mssql.version>9.4.0.jre8</mssql.version>
+        <mssql.version>9.4.1.jre8</mssql.version>
         <oracle.version>21.3.0.0</oracle.version>
         <apache.poi.version>5.1.0</apache.poi.version>
         <jakarta.mail.version>1.6.6</jakarta.mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>com.github.blutorange</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### dependencies

- Bump `org.postgresql:postgresql` 42.3.0 -> 42.3.1
- Bump `org.glassfish.jaxb:jaxb-runtime` 2.3.3 -> 2.3.5
- Bump `com.microsoft.sqlserver:mssql-jdbc` 9.4.0.jre8 -> 9.4.1.jre8
- Bump `jakarta.mail.version` 1.6.6 -> 1.6.7

### plugins
- ~Bump `com.github.blutorange:closure-compiler-maven-plugin`  2.21.0 -> 2.22.0~ requires Java 11