### PR TITLE
[TM-353] Bump GeoTools from 25.3 to 25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>com.github.blutorange</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>2.21.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.3.1</postgresql.version>
         <mssql.version>9.4.1.jre8</mssql.version>
-        <oracle.version>21.3.0.0</oracle.version>
+        <oracle.version>21.4.0.0.1</oracle.version>
         <apache.poi.version>5.1.0</apache.poi.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>25.3</geotools.version>
-        <b3p-commons-csw.version>6.7</b3p-commons-csw.version>
+        <geotools.version>25.4</geotools.version>
+        <b3p-commons-csw.version>6.8</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>

--- a/pom.xml
+++ b/pom.xml
@@ -666,7 +666,7 @@
                 <plugin>
                     <groupId>com.github.blutorange</groupId>
                     <artifactId>closure-compiler-maven-plugin</artifactId>
-                    <version>2.21.0</version>
+                    <version>2.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ChooseApplicationActionBean.java
+++ b/viewer-admin/src/main/java/nl/b3p/viewer/admin/stripes/ChooseApplicationActionBean.java
@@ -32,7 +32,7 @@ import nl.b3p.viewer.config.app.ConfiguredComponent;
 import nl.b3p.viewer.config.metadata.Metadata;
 import nl.b3p.viewer.config.security.Group;
 import nl.b3p.viewer.util.SelectedContentCache;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.*;

--- a/viewer/src/main/java/nl/b3p/viewer/features/ShapeDownloader.java
+++ b/viewer/src/main/java/nl/b3p/viewer/features/ShapeDownloader.java
@@ -30,7 +30,7 @@ import javax.xml.transform.TransformerException;
 import nl.b3p.viewer.config.app.ConfiguredAttribute;
 import nl.b3p.viewer.config.services.AttributeDescriptor;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/ApplicationActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/ApplicationActionBean.java
@@ -32,7 +32,7 @@ import nl.b3p.viewer.config.metadata.Metadata;
 import nl.b3p.viewer.config.security.Authorizations;
 import nl.b3p.viewer.config.security.User;
 import nl.b3p.viewer.util.SelectedContentCache;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.stripesstuff.stripersist.Stripersist;

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/I18nActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/I18nActionBean.java
@@ -4,7 +4,7 @@ import net.sourceforge.stripes.action.*;
 import net.sourceforge.stripes.validation.Validate;
 import nl.b3p.i18n.ResourceBundleToJsProvider;
 import nl.b3p.i18n.ResourceBundleProvider;
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 import java.io.StringReader;
 import java.util.Locale;

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/LocalizableApplicationActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/LocalizableApplicationActionBean.java
@@ -8,7 +8,7 @@ import net.sourceforge.stripes.action.After;
 import net.sourceforge.stripes.controller.LifecycleStage;
 import nl.b3p.viewer.config.app.Application;
 import nl.b3p.i18n.ResourceBundleProvider;
-import org.apache.commons.lang.LocaleUtils;
+import org.apache.commons.lang3.LocaleUtils;
 
 /**
  * Abstract ActionBean which can be implemented by ActionBeans

--- a/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
+++ b/viewer/src/main/java/nl/b3p/viewer/stripes/PrintActionBean.java
@@ -31,7 +31,7 @@ import nl.b3p.viewer.print.*;
 import nl.b3p.viewer.util.FeaturePropertiesArrayHelper;
 import nl.b3p.viewer.util.FeatureToJson;
 import nl.b3p.viewer.util.FlamingoCQL;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.Logger;

--- a/viewer/src/main/java/nl/b3p/viewer/util/FlamingoCQL.java
+++ b/viewer/src/main/java/nl/b3p/viewer/util/FlamingoCQL.java
@@ -17,7 +17,7 @@
 package nl.b3p.viewer.util;
 
 import nl.b3p.viewer.config.services.*;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.geotools.factory.CommonFactoryFinder;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;


### PR DESCRIPTION
also bump b3p-commons-csw to 6.8, remove remnants of commons-lang (and use commons-lang3), update oracle driver

depends on https://github.com/B3Partners/b3p-commons-csw/pull/102 / https://github.com/B3Partners/b3p-commons-csw/releases/tag/b3p-commons-csw-6.8


resolves TM-353