### PR TITLE
[5.8.x] Bump postgresql and oracle drivers (security fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.5.2</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.3.1</postgresql.version>
+        <postgresql.version>42.3.2</postgresql.version>
         <mssql.version>9.4.1.jre8</mssql.version>
         <oracle.version>21.4.0.0.1</oracle.version>
         <apache.poi.version>5.2.0</apache.poi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.3.2</postgresql.version>
         <mssql.version>9.4.1.jre8</mssql.version>
-        <oracle.version>21.4.0.0.1</oracle.version>
+        <oracle.version>21.5.0.0</oracle.version>
         <apache.poi.version>5.2.0</apache.poi.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>


### PR DESCRIPTION
- [x] Bump postgresql from 42.3.1 to 42.3.2 (security update)
- [x] Bump oracle.version from 21.4.0.0.1 to 21.5.0.0

backports #3076 
backports #3077 