### PR TITLE
[5.6.x] Bump postgresql and oracle drivers (security fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.2.25</postgresql.version>
         <mssql.version>9.2.1.jre8</mssql.version>
-        <oracle.version>21.1.0.0</oracle.version>
+        <oracle.version>21.5.0.0</oracle.version>
         <apache.poi.version>4.1.2</apache.poi.version>
         <jakarta.mail.version>1.6.5</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <powermock.version>2.0.7</powermock.version>
         <hsqldb.version>2.5.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.2.23</postgresql.version>
+        <postgresql.version>42.2.25</postgresql.version>
         <mssql.version>9.2.1.jre8</mssql.version>
         <oracle.version>21.1.0.0</oracle.version>
         <apache.poi.version>4.1.2</apache.poi.version>


### PR DESCRIPTION
- [x] Bump postgresql from 42.2.23 to 42.2.23 (security update)
- [x] Bump oracle.version from 21.1.0.0 to 21.5.0.0

backports #3076 
backports #3077 