### PR TITLE
GBIM-238: don't add the line that has been drawn for using to split as a new line

### DIFF
--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/SplitFeatureActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/SplitFeatureActionBean.java
@@ -368,6 +368,10 @@ public class SplitFeatureActionBean extends LocalizableApplicationActionBean imp
         for (int i = 0; i < lines.getNumGeometries(); i++) {
             LineString l = (LineString) lines.getGeometryN(i);
             if (bufferedToSplit.contains(l)) {
+                if (l.getCoordinates()[0].compareTo(line.getCoordinates()[0]) == 0 ||
+                        l.getCoordinates()[l.getCoordinates().length-1].compareTo(line.getCoordinates()[line.getCoordinates().length-1]) == 0) {
+                    continue;
+                }
                 output.add(l);
             }
         }


### PR DESCRIPTION
Als de lijn heel kort is getekend voor het splitsen van een lijn komt deze in de bufferedTosplit lijn terecht waardoor de getekende lijn ook als nieuwe lijn wordt opgeslagen.

Check toegevoegd van de nieuwe lijnen, als de x en y van het eerste coordinaat of laatste coordinaat hetzelfde is als de getekende lijn die gebruikt wordt  voor het splitsen mag die niet worden toegevoegd.