### PR TITLE
GBIM-201: Build a correct URI from the HttpServletRequest

### DIFF
--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
@@ -411,9 +411,14 @@ public class ApplicationActionBean extends LocalizableApplicationActionBean impl
         }
 
         buildComponentSourceHTML(em);
-
+        HttpServletRequest req  = context.getRequest();
+        URIBuilder builder = new URIBuilder()
+                .setScheme(req.getScheme())
+                .setHost(req.getServerName())
+                .setPath(req.getContextPath())
+                .setPort(req.getServerPort());
         appConfigJSON = ApplicationHelper.toJSON( application,  AuthorizationsHelper.getRoles(context.getRequest(), em),
-                URI.create(context.getRequest().getRequestURI()),
+                URI.create(builder.toString()),
                 context.getRequest().getServletContext().getInitParameter("proxy"),  false,  false,  false,  false,
                 em,  true,  false).toString();
 

--- a/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
+++ b/viewer/src/main/java/nl/tailormap/viewer/stripes/ApplicationActionBean.java
@@ -45,6 +45,7 @@ import nl.tailormap.viewer.helpers.app.ApplicationHelper;
 import nl.tailormap.viewer.helpers.app.ComponentHelper;
 import nl.tailormap.viewer.util.SelectedContentCache;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.stripesstuff.stripersist.Stripersist;
@@ -325,10 +326,16 @@ public class ApplicationActionBean extends LocalizableApplicationActionBean impl
         EntityManager em = Stripersist.getEntityManager();
         JSONObject response = new JSONObject();
         response.put("success", false);
+        HttpServletRequest req  = context.getRequest();
+        URIBuilder builder = new URIBuilder()
+                .setScheme(req.getScheme())
+                .setHost(req.getServerName())
+                .setPath(req.getContextPath())
+                .setPort(req.getServerPort());
         JSONObject obj = ApplicationHelper.toJSON(
                 application,
                 AuthorizationsHelper.getRoles(context.getRequest(), em),
-                URI.create(context.getRequest().getRequestURI()),
+                URI.create(builder.toString()),
                 context.getRequest().getServletContext().getInitParameter("proxy"),
                 false,
                 false,


### PR DESCRIPTION
De URI die gemaakt werd van de HttpServletRequest miste alle eigenschappen.

Die worden weer gebruikt in SelectedContentCache.java van regel 193 t/m 196.
Deze stonden allemaal op null waardoor er geen correcte proxy URL opgebouwd werd wanneer de service gebruik moet maken van de proxy.

Mis gegaan vanaf V5.9.9(zo ver ik kan terug zien).