### PR TITLE
Bump oracle.version from 21.6.0.0.1 to 21.7.0.0 (#3349)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
         <postgresql.version>42.5.0</postgresql.version>
         <mssql.version>9.4.1.jre8</mssql.version>
-        <oracle.version>21.6.0.0.1</oracle.version>
+        <oracle.version>21.7.0.0</oracle.version>
         <apache.poi.version>5.2.2</apache.poi.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>


### PR DESCRIPTION
(cherry picked from commit bef68df30b389a3008a83bb4e34b3a703ee3fa35)