### PR TITLE
[Backport v5.8.x] Bump jackson libraries from 2.13.3 -> 2.13.4 to resolve CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <jaxb.api.version>2.3.3</jaxb.api.version>
         <jaxb.impl.version>2.3.6</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <jackson2.version>2.12.7</jackson2.version>
+        <slf4j.version>2.0.3</slf4j.version>
+        <jackson2.version>2.13.4</jackson2.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'gh-action' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>


### PR DESCRIPTION
backports #3384 