### PR TITLE
[Backport v5.8.x] Bump closure-compiler from v20220601 to v20221004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
             <dependency>
                 <groupId>com.google.javascript</groupId>
                 <artifactId>closure-compiler</artifactId>
-                <version>v20220601</version>
+                <version>v20221004</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
backports https://github.com/B3Partners/tailormap/pull/3386