### PR TITLE
Bump jackson2.version from 2.13.4 to 2.14.0-rc2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <jaxb.impl.version>2.3.6</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
         <slf4j.version>2.0.3</slf4j.version>
-        <jackson2.version>2.13.4</jackson2.version>
+        <jackson2.version>2.14.0-rc2</jackson2.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'gh-action' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>


### PR DESCRIPTION
Jackson resolved some security issues:
- CVE-2022-42003
- CVE-2022-42004