### PR TITLE
downgrade closure-compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
             <dependency>
                 <groupId>com.google.javascript</groupId>
                 <artifactId>closure-compiler</artifactId>
-                <version>v20220601</version>
+                <version>v20220502</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>


### PR DESCRIPTION
closure-compiler v20220601 is using a java 11 method [see](https://github.com/google/closure-compiler/blob/40f690720a5f01907c79378b01063bfa74599cc1/src/com/google/javascript/jscomp/SourceFile.java#L713)


