### PR TITLE
Decode bookmark values

### DIFF
--- a/viewer/src/main/webapp/viewer-html/common/ajax/Bookmark.js
+++ b/viewer/src/main/webapp/viewer-html/common/ajax/Bookmark.js
@@ -66,7 +66,10 @@ Ext.define("viewer.Bookmark", {
                 var response = Ext.JSON.decode(result.responseText);
                 
                 if(response.success) {
-                    successFunction(response.params);
+                    // decode bookmark URL
+                    // https://github.com/B3Partners/tailormap/pull/2391/files
+                    // Na dit PR worden tekeningen decoded opgeslagen maar niet op de juiste manier terugggeven.
+                    successFunction(response.params.replaceAll(new RegExp('&#34;', 'g'), '\\"'));
                 } else {
                     if(failureFunction != undefined) {
                         failureFunction(response.error);


### PR DESCRIPTION
Bookmark URLS worden nu gesanitized opgeslagen door een fix van Meine vorig jaar.

Zie: https://github.com/B3Partners/tailormap/pull/2391/files

De viewer kan hier niet mee omgaan.

(Jira issue)[https://b3partners.atlassian.net/browse/SUPPORT-13400]