### PR TITLE
Bump various dependencies, resolves CVE-2023-25158, CVE-2023-24998

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,22 +47,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- when updating geotools also check b3p-commons-csw or you will end up in transitive dependency hell -->
-        <geotools.version>25.6</geotools.version>
+        <geotools.version>25.7</geotools.version>
         <b3p-commons-csw.version>6.8</b3p-commons-csw.version>
         <powermock.version>2.0.9</powermock.version>
         <hsqldb.version>2.7.1</hsqldb.version>
         <test.persistence.unit>viewer-config-hsqldb</test.persistence.unit>
-        <postgresql.version>42.5.1</postgresql.version>
-        <mssql.version>11.2.1.jre8</mssql.version>
-        <oracle.version>21.7.0.0</oracle.version>
+        <postgresql.version>42.5.4</postgresql.version>
+        <mssql.version>11.2.3.jre8</mssql.version>
+        <oracle.version>21.9.0.0</oracle.version>
         <apache.poi.version>5.2.3</apache.poi.version>
         <jakarta.mail.version>1.6.7</jakarta.mail.version>
-        <apache.httpcomponents.version>4.5.13</apache.httpcomponents.version>
+        <apache.httpcomponents.version>4.5.14</apache.httpcomponents.version>
         <jaxb.api.version>2.3.3</jaxb.api.version>
-        <jaxb.impl.version>2.3.6</jaxb.impl.version>
+        <jaxb.impl.version>2.3.8</jaxb.impl.version>
         <activation.api.version>1.2.2</activation.api.version>
-        <slf4j.version>2.0.5</slf4j.version>
-        <jackson2.version>2.14.0</jackson2.version>
+        <slf4j.version>2.0.6</slf4j.version>
+        <jackson2.version>2.14.2</jackson2.version>
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'gh-action' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
@@ -97,7 +97,7 @@
             <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
-                <version>1.4</version>
+                <version>1.5</version>
             </dependency>
             <dependency>
                 <groupId>org.jdom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <!-- skip integration tests by default, override this property from commandline
         or as part of a profile, see eg. 'gh-action' profile in viewer -->
         <test.skip.integrationtests>false</test.skip.integrationtests>
-        <maven-surefire-plugin.version>3.0.0-M8</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
         <tomcat.version>7.0.109</tomcat.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <tomcat7-maven-plugin.version>2.2</tomcat7-maven-plugin.version>
@@ -583,7 +583,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.14.2</version>
+                    <version>2.15.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -602,7 +602,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                     <configuration>
                         <quiet>true</quiet>
                     </configuration>
@@ -680,7 +680,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -689,12 +689,12 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>4.0.0-M4</version>
+                    <version>4.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>7.4.4</version>
+                    <version>8.1.0</version>
                     <configuration>
                         <skipSystemScope>true</skipSystemScope>
                         <format>ALL</format>
@@ -812,7 +812,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -826,7 +826,7 @@
                 <plugin>
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
-                    <version>0.40.3</version>
+                    <version>0.41.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- geotools.version: 25.6 ⇨ 25.7 (resolves CVE-2023-25158)
- postgresql.version: 42.5.1 ⇨ 42.5.4
- mssql.version: 11.2.1.jre8 ⇨ 11.2.3.jre8 
- oracle.version: 21.7.0.0 ⇨ 21.9.0.0
- apache.httpcomponents.version: 4.5.13 ⇨ 4.5.14
- slf4j.version: 2.0.5 ⇨ 2.0.5
- jackson2.version: 2.14.0 ⇨ 2.0.5
- commons-fileupload: 1.4 ⇨ 1.6 (CVE-2023-24998)

Also update the Maven plugins